### PR TITLE
OE_TRACE_LEVEL cmake parameter.

### DIFF
--- a/common/revocation.c
+++ b/common/revocation.c
@@ -159,6 +159,7 @@ oe_result_t oe_enforce_revocation(
     oe_cert_chain_t* pck_cert_chain)
 {
     oe_result_t result = OE_FAILURE;
+    oe_result_t r = OE_FAILURE;
     ParsedExtensionInfo parsed_extension_info = {{0}};
     oe_get_revocation_info_args_t revocation_args = {0};
     oe_cert_chain_t tcb_issuer_chain = {0};
@@ -236,9 +237,14 @@ oe_result_t oe_enforce_revocation(
     // constraint. If the crl_issuer_chain was different from the certificate
     // chain, then verification would fail because the CRLs will not be found
     // for certificates in the chain.
-    OE_CHECK(
-        oe_cert_verify(
-            leaf_cert, &crl_issuer_chain[0], crl_ptrs, 2, &cert_verify_error));
+    r = oe_cert_verify(
+        leaf_cert, &crl_issuer_chain[0], crl_ptrs, 2, &cert_verify_error);
+    if (r != OE_OK)
+    {
+        OE_TRACE_INFO(
+            "oe_cer_verify failed with error = %s\n", cert_verify_error.buf);
+        OE_RAISE(r);
+    }
 
     for (uint32_t i = 0; i < OE_COUNTOF(platform_tcb_level.sgx_tcb_comp_svn);
          ++i)

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -64,6 +64,10 @@ if(USE_LIBSGX)
     add_target_compile_defs(oecore PUBLIC "C;CXX" OE_USE_LIBSGX)
 endif()
 
+if(OE_TRACE_LEVEL)
+    target_compile_definitions(oecore PUBLIC "OE_TRACE_LEVEL=${OE_TRACE_LEVEL}")
+endif()
+
 if(USE_DEBUG_MALLOC)
     add_target_compile_defs(oecore PRIVATE "C;CXX" OE_USE_DEBUG_MALLOC)
     message("USE_DEBUG_MALLOC is set, building oecore with memory leak detection.")

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -107,6 +107,10 @@ target_link_libraries(oehost PUBLIC ${LIBSGX_COMMON} ${LIBSGX_QE} ${LIBSGX_URTS}
 target_compile_definitions(oehost PRIVATE OE_USE_LIBSGX)
 endif()
 
+if(OE_TRACE_LEVEL)
+    target_compile_definitions(oehost PUBLIC "OE_TRACE_LEVEL=${OE_TRACE_LEVEL}")
+endif()
+
 if(USE_DEBUG_MALLOC)
 target_compile_definitions(oehost PRIVATE OE_USE_DEBUG_MALLOC)
 endif()

--- a/host/files.c
+++ b/host/files.c
@@ -100,14 +100,14 @@ oe_result_t __oe_load_pages(const char* path, oe_page_t** pages, size_t* npages)
 
     /* Reject invalid parameters */
     if (!path || !pages || !npages)
-        OE_THROW(OE_INVALID_PARAMETER);
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Load the file into memory with zero extra bytes */
-    OE_TRY(__oe_load_file(path, 0, &data, &size));
+    OE_CHECK(__oe_load_file(path, 0, &data, &size));
 
     /* Fail if file size is not a multiple of the page size */
     if (size % OE_PAGE_SIZE)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     /* Set the output parameters */
     *pages = ((oe_page_t*)data);
@@ -115,7 +115,7 @@ oe_result_t __oe_load_pages(const char* path, oe_page_t** pages, size_t* npages)
 
     result = OE_OK;
 
-OE_CATCH:
+done:
 
     if (result != OE_OK)
         free(data);

--- a/host/linux/aesm.c
+++ b/host/linux/aesm.c
@@ -174,20 +174,20 @@ static oe_result_t _pack_bytes(
     uint8_t tag;
 
     if (_make_tag(field_num, WIRETYPE_LENGTH_DELIMITED, &tag) != 0)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     if (mem_cat(buf, &tag, sizeof(tag)) != 0)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     if (_pack_variant_uint32(buf, size) != 0)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     if (mem_cat(buf, data, size) != 0)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     result = OE_OK;
 
-OE_CATCH:
+done:
     return result;
 }
 
@@ -196,14 +196,14 @@ static int _pack_var_int(mem_t* buf, uint8_t field_num, uint64_t value)
     oe_result_t result = OE_UNEXPECTED;
 
     if (_pack_tag(buf, field_num, WIRETYPE_VARINT) != 0)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     if (_pack_variant_uint32(buf, value) != 0)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     result = OE_OK;
 
-OE_CATCH:
+done:
     return result;
 }
 
@@ -218,20 +218,20 @@ static oe_result_t _unpack_var_int(
     uint8_t tmp_tag;
 
     if ((*pos = _unpack_tag(buf, *pos, &tag)) == -1)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     if (_make_tag(field_num, WIRETYPE_VARINT, &tmp_tag) != 0)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     if (tag != tmp_tag)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     if ((*pos = _unpack_variant_uint32(buf, *pos, value)) == -1)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     result = OE_OK;
 
-OE_CATCH:
+done:
     return result;
 }
 
@@ -306,7 +306,7 @@ static oe_result_t _write_request(
 #endif
 
     /* Wrap message in envelope */
-    OE_TRY(
+    OE_CHECK(
         _pack_bytes(
             &envelope, message_type, mem_ptr(message), mem_size(message)));
 
@@ -316,16 +316,16 @@ static oe_result_t _write_request(
 
         /* Send message size */
         if (_write(aesm->sock, &size, sizeof(uint32_t)) != 0)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
 
         /* Send message data */
         if (_write(aesm->sock, mem_ptr(&envelope), mem_size(&envelope)) != 0)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
     }
 
     result = OE_OK;
 
-OE_CATCH:
+done:
 
     mem_free(&envelope);
 
@@ -347,15 +347,15 @@ static oe_result_t _read_response(
     {
         /* Read the envelope size */
         if (_read(aesm->sock, &size, sizeof(uint32_t)) != 0)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
 
         /* Expand the buffer */
         if (mem_resize(&envelope, size) != 0)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
 
         /* Read the message */
         if (_read(aesm->sock, mem_mutable_ptr(&envelope), size) != 0)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
     }
 
     /* Copy envelope contents into MESSAGE */
@@ -367,21 +367,21 @@ static oe_result_t _read_response(
 
         /* Get the tag of this payload */
         if ((pos = _unpack_tag(&envelope, pos, &tag)) == (size_t)-1)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
 
         if (_make_tag(message_type, WIRETYPE_LENGTH_DELIMITED, &tmp_tag) != 0)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
 
         if (tag != tmp_tag)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
 
         /* Get the size of this payload */
         if ((pos = _unpack_variant_uint32(&envelope, pos, &size)) == (size_t)-1)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
 
         /* Check the size (must equal unread bytes in envelope) */
         if (size != mem_size(&envelope) - pos)
-            OE_THROW(OE_FAILURE);
+            OE_RAISE(OE_FAILURE);
 
         /* Read the message from the envelope */
         mem_cat(message, mem_ptr(&envelope) + pos, size);
@@ -394,7 +394,7 @@ static oe_result_t _read_response(
 
     result = OE_OK;
 
-OE_CATCH:
+done:
 
     mem_free(&envelope);
 

--- a/host/linux/sgxsign.c
+++ b/host/linux/sgxsign.c
@@ -39,12 +39,12 @@ static oe_result_t _get_date(unsigned int* date)
     size_t i;
 
     if (!date)
-        OE_THROW(OE_INVALID_PARAMETER);
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     t = time(NULL);
 
     if (localtime_r(&t, &tm) == NULL)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     {
         char s[9];
@@ -67,7 +67,7 @@ static oe_result_t _get_date(unsigned int* date)
 
     result = OE_OK;
 
-OE_CATCH:
+done:
     return result;
 }
 
@@ -77,16 +77,16 @@ static oe_result_t _get_modulus(RSA* rsa, uint8_t modulus[OE_KEY_SIZE])
     uint8_t buf[OE_KEY_SIZE];
 
     if (!rsa || !modulus)
-        OE_THROW(OE_INVALID_PARAMETER);
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     if (!BN_bn2bin(rsa->n, buf))
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     _mem_reverse(modulus, buf, OE_KEY_SIZE);
 
     result = OE_OK;
 
-OE_CATCH:
+done:
     return result;
 }
 
@@ -96,10 +96,10 @@ static oe_result_t _get_exponent(RSA* rsa, uint8_t exponent[OE_EXPONENT_SIZE])
     // uint8_t buf[OE_EXPONENT_SIZE];
 
     if (!rsa || !exponent)
-        OE_THROW(OE_INVALID_PARAMETER);
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     if (rsa->e->top != 1)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     {
         uint64_t x = rsa->e->d[0];
@@ -111,7 +111,7 @@ static oe_result_t _get_exponent(RSA* rsa, uint8_t exponent[OE_EXPONENT_SIZE])
 
     result = OE_OK;
 
-OE_CATCH:
+done:
     return result;
 }
 
@@ -402,18 +402,18 @@ static oe_result_t _load_rsa_private_key(
 
     /* Check parameters */
     if (!pem_data || pem_size == 0 || !key)
-        OE_THROW(OE_INVALID_PARAMETER);
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Initialize OpenSSL */
     oe_initialize_openssl();
 
     /* Create a BIO object for loading the PEM data */
     if (!(bio = BIO_new_mem_buf(pem_data, pem_size)))
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     /* Read the RSA structure from the PEM data */
     if (!(rsa = PEM_read_bio_RSAPrivateKey(bio, &rsa, NULL, NULL)))
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     /* Set the output key parameter */
     *key = rsa;
@@ -421,7 +421,7 @@ static oe_result_t _load_rsa_private_key(
 
     result = OE_OK;
 
-OE_CATCH:
+done:
 
     if (rsa)
         RSA_free(rsa);

--- a/host/load.c
+++ b/host/load.c
@@ -49,7 +49,7 @@ oe_result_t __oe_load_segments(
 /* Fail if not a dynamic object */
 #if 0
     if (eh->e_type != ET_DYN)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 #endif
 
     /* Fail if not Intel X86 64-bit */
@@ -224,7 +224,7 @@ oe_result_t __oe_calculate_segments_size(
 
     /* Reject bad parameters */
     if (!segments || nsegments == 0 || !size)
-        OE_THROW(OE_INVALID_PARAMETER);
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Calculate boundaries (LO and HI) of the image */
     for (i = 0; i < nsegments; i++)
@@ -240,18 +240,18 @@ oe_result_t __oe_calculate_segments_size(
 
     /* Fail if LO not found */
     if (lo != 0)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     /* Fail if HI not found */
     if (hi == 0)
-        OE_THROW(OE_FAILURE);
+        OE_RAISE(OE_FAILURE);
 
     /* Calculate the full size of the image (rounded up to the page size) */
     *size = __oe_round_up_to_page_size(hi - lo);
 
     result = OE_OK;
 
-OE_CATCH:
+done:
 
     return result;
 }

--- a/include/openenclave/internal/raise.h
+++ b/include/openenclave/internal/raise.h
@@ -63,6 +63,7 @@
 
 #include <openenclave/bits/defs.h>
 #include <openenclave/bits/result.h>
+#include <openenclave/internal/trace.h>
 
 OE_EXTERNC_BEGIN
 
@@ -87,13 +88,30 @@ OE_EXTERNC_BEGIN
             OE_RAISE(_result_);              \
     } while (0)
 
+#if !defined(OE_RAISE_TRACE)
+
+#if defined(OE_TRACE_LEVEL) && (OE_TRACE_LEVEL == 2)
+
+// With TRACE_LEVEL_INFO, OE_CHECK failures are logged by default.
+#define OE_RAISE_TRACE(RESULT)                                \
+    OE_TRACE_INFO(                                            \
+        "OE_CHECK failed with %s in function %s at %s:%d \n", \
+        oe_result_str(RESULT),                                \
+        __FUNCTION__,                                         \
+        __FILE__,                                             \
+        __LINE__)
+
+#else
+
 // This macro is used to trace the OE_RAISE macro. It is empty by default but
 // may be defined prior to including this header file.
-#if !defined(OE_RAISE_TRACE)
 #define OE_RAISE_TRACE(RESULT) \
     do                         \
     {                          \
     } while (0)
+
+#endif
+
 #endif
 
 OE_EXTERNC_END

--- a/include/openenclave/internal/raise.h
+++ b/include/openenclave/internal/raise.h
@@ -92,7 +92,7 @@ OE_EXTERNC_BEGIN
 
 #if defined(OE_TRACE_LEVEL)
 
-// With TRACE_LEVEL_INFO, OE_CHECK failures are logged by default.
+// OE_CHECK failures are logged at OE_TRACE_LEVEL_ERROR.
 #define OE_RAISE_TRACE(RESULT)                                \
     OE_TRACE_ERROR(                                           \
         "OE_CHECK failed with %s in function %s at %s:%d \n", \

--- a/include/openenclave/internal/raise.h
+++ b/include/openenclave/internal/raise.h
@@ -90,11 +90,11 @@ OE_EXTERNC_BEGIN
 
 #if !defined(OE_RAISE_TRACE)
 
-#if defined(OE_TRACE_LEVEL) && (OE_TRACE_LEVEL == 2)
+#if defined(OE_TRACE_LEVEL)
 
 // With TRACE_LEVEL_INFO, OE_CHECK failures are logged by default.
 #define OE_RAISE_TRACE(RESULT)                                \
-    OE_TRACE_INFO(                                            \
+    OE_TRACE_ERROR(                                           \
         "OE_CHECK failed with %s in function %s at %s:%d \n", \
         oe_result_str(RESULT),                                \
         __FUNCTION__,                                         \

--- a/include/openenclave/internal/trace.h
+++ b/include/openenclave/internal/trace.h
@@ -9,6 +9,7 @@
 
 #ifdef OE_BUILD_ENCLAVE
 #include <openenclave/enclave.h>
+#include <openenclave/internal/print.h>
 #define OE_PRINTF oe_host_printf
 #else
 #include <stdio.h>

--- a/include/openenclave/internal/trace.h
+++ b/include/openenclave/internal/trace.h
@@ -22,59 +22,11 @@
 
 OE_EXTERNC_BEGIN
 
-OE_INLINE void __oe_trace_result(
-    const char* op,
-    oe_result_t result,
-    const char* file,
-    unsigned int line,
-    const char* expr)
-{
-    if (result == OE_OK)
-    {
-#if (OE_TRACE_LEVEL >= OE_TRACE_LEVEL_INFO)
-        OE_PRINTF(
-            "\nok: %s: %s(%u): result=%u: %s\n", op, file, line, result, expr);
-#endif
-    }
-    else
-    {
-#if (OE_TRACE_LEVEL >= OE_TRACE_LEVEL_ERROR)
-        OE_PRINTF(
-            "\nfail: %s: %s(%u): result=%u: %s\n",
-            op,
-            file,
-            line,
-            result,
-            expr);
-#endif
-    }
-}
-
 #ifdef __cplusplus
 #define OE_CATCH _catch
 #else
 #define OE_CATCH catch
 #endif
-
-#define OE_THROW(RESULT)                                                 \
-    do                                                                   \
-    {                                                                    \
-        result = (RESULT);                                               \
-        __oe_trace_result("throw", result, __FILE__, __LINE__, #RESULT); \
-        goto OE_CATCH;                                                   \
-    } while (0)
-
-#define OE_TRY(EXPR)                                                   \
-    do                                                                 \
-    {                                                                  \
-        oe_result_t _result_ = (EXPR);                                 \
-        __oe_trace_result("try", _result_, __FILE__, __LINE__, #EXPR); \
-        if (_result_ != OE_OK)                                         \
-        {                                                              \
-            result = _result_;                                         \
-            goto OE_CATCH;                                             \
-        }                                                              \
-    } while (0)
 
 #if (OE_TRACE_LEVEL >= OE_TRACE_LEVEL_ERROR)
 #define OE_TRACE_ERROR(...)     \

--- a/tests/ecall_ocall/enc/enc.cpp
+++ b/tests/ecall_ocall/enc/enc.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <stdio.h>
+#undef OE_TRACE_LEVEL
 #define OE_TRACE_LEVEL 1
 
 #include <openenclave/enclave.h>

--- a/tests/ecall_ocall/enc/enc.cpp
+++ b/tests/ecall_ocall/enc/enc.cpp
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <stdio.h>
-#undef OE_TRACE_LEVEL
-#define OE_TRACE_LEVEL 1
-
 #include <openenclave/enclave.h>
 #include <openenclave/internal/globals.h> // for __oe_get_enclave_base()
 #include <openenclave/internal/tests.h>
 #include <openenclave/internal/thread.h>
 #include <openenclave/internal/trace.h>
+#include <stdio.h>
 #include <mutex>
 #include <system_error>
 #include "../args.h"

--- a/tests/ecall_ocall/host/host.cpp
+++ b/tests/ecall_ocall/host/host.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+#undef OE_TRACE_LEVEL
 #define OE_TRACE_LEVEL 1
 
 #include <openenclave/host.h>

--- a/tests/ecall_ocall/host/host.cpp
+++ b/tests/ecall_ocall/host/host.cpp
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#undef OE_TRACE_LEVEL
-#define OE_TRACE_LEVEL 1
-
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/tests.h>

--- a/tests/ocall-alloc/enc/enc.cpp
+++ b/tests/ocall-alloc/enc/enc.cpp
@@ -6,7 +6,7 @@
    - Regular nesting / un-nesting
    - Whitebox-tests w/ tracking of allocation/de-allocation
  */
-
+#undef OE_TRACE_LEVEL
 #define OE_TRACE_LEVEL 1
 
 #include <openenclave/enclave.h>

--- a/tests/ocall-alloc/enc/enc.cpp
+++ b/tests/ocall-alloc/enc/enc.cpp
@@ -6,9 +6,6 @@
    - Regular nesting / un-nesting
    - Whitebox-tests w/ tracking of allocation/de-allocation
  */
-#undef OE_TRACE_LEVEL
-#define OE_TRACE_LEVEL 1
-
 #include <openenclave/enclave.h>
 #include <openenclave/internal/hostalloc.h>
 #include <openenclave/internal/print.h>


### PR DESCRIPTION
1. OE_TRACE_LEVEL value can be specified to cmake and it is propagated
to compiler definitions.

2. If OE_TRACE_LEVEL is info, any OE_CHECK failure is logged.
This allows quickly identifying the root cause of an attestation failure,
and other kinds of failures where the OE_CHECK output may not be readily
available/printed at the top-level.

3. If cert verification failed, with tracing enabled, print the error message
reported by the crypto library.

4. Make some tests robust to the OE_TRACE_LEVEL specification by undef-ing incoming define.

Note OE_TRACE_LEVEL=0 is equivalent to not defining it. Use OE_TRACE_LEVEL=2 for maximum information.
If tracing is enables, few tests that rely on the printed out strings fail. This is expected since
tracing changes the printout.