### PR TITLE
Add a "defaults" stage to CI

### DIFF
--- a/.jenkins/Dockerfile.scripts
+++ b/.jenkins/Dockerfile.scripts
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+FROM ubuntu:16.04
+
+COPY scripts/install-prereqs /bin
+RUN \
+  apt-get update \
+  && apt-get install --no-install-recommends -y \
+  lsb-release \
+  wget ca-certificates \
+  && install-prereqs

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -14,6 +14,35 @@ pipeline {
     }
     stage('Build and Test') {
       parallel {
+        stage('Simulation default compiler') {
+          // This particular test asserts that everything (at least
+          // for simulation) can be built after using our
+          // install-prereqs script to bootstrap a machine.
+          agent {
+            dockerfile {
+              filename '.jenkins/Dockerfile.scripts'
+            }
+          }
+          steps {
+            // This is run to test that it works with the dependencies
+            // installed by our install-prereqs script.
+            sh './scripts/check-precommit-reqs'
+
+            // We actually expect `ctest` to fail because it is an
+            // older version that emits a failure if any tests are
+            // skipped. In other stages, we explicitly install an
+            // updated version of CMake.
+            dir('build') {
+              sh '''
+                cmake ..
+                make
+                OE_SIMULATION=1 ctest --verbose --output-on-failure || true
+              '''
+              // Note that `make package` is not expected to work
+              // without extra configuration.
+            }
+          }
+        }
         stage('Simulation clang-7 SGX1 Debug') {
           agent {
             docker {

--- a/scripts/install-prereqs
+++ b/scripts/install-prereqs
@@ -10,8 +10,11 @@
 # and add it to the list.
 #
 
-# Needed for Open Enclave build and scripts
-PACKAGES=('clang-format-3.8' 'cmake' 'make' 'shellcheck')
+# Needed for Open Enclave build
+PACKAGES=('cmake' 'make' 'pkg-config')
+
+# Needed for Open Enclave scripts
+PACKAGES+=('clang-format-3.8' 'shellcheck')
 
 # Needed for using oedbg
 PACKAGES+=('gdb')


### PR DESCRIPTION
This resolves #739 by adding a stage which explicitly tests the (simulation) build and tests with an environment bootstrapped only by our `install-prereqs` script.

This also resolves #882 which was found during testing, and should help avoid issues like #865 and #703.