### PR TITLE
Fix #823: libcxx test failures with RelWithDebInfo and clang

### DIFF
--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -19,5 +19,13 @@ endif()
 
 foreach(testcase ${alltests})
     get_testcase_name(${testcase} name "../../3rdparty/libcxx/libcxx/test/")
-	add_enclave_test(tests/libcxxtest-${name} ./host libcxx_host ./enc libcxxtest-${name}_enc)
+
+# the allocations are entirely optimized out by Clang in these tests and are excluded from Clang release builds
+    if ("${name}" MATCHES "cons_default_throws_bad_alloc.pass" OR "${name}" MATCHES "allocator_allocator.members_construct.pass")
+        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_BUILD_TYPE MATCHES "Rel")
+                continue()
+        endif()
+    endif()
+
+    add_enclave_test(tests/libcxxtest-${name} ./host libcxx_host ./enc libcxxtest-${name}_enc)
 endforeach(testcase)

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -61,5 +61,13 @@ else()
 endif()
 foreach(testcase ${alltests})
     get_testcase_name(${testcase} name "../../3rdparty/libcxx/libcxx/test/")
+
+# the allocations are entirely optimized out by Clang in these tests and are excluded from Clang release builds
+    if ("${name}" MATCHES "cons_default_throws_bad_alloc.pass" OR "${name}" MATCHES "allocator_allocator.members_construct.pass")
+	if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_BUILD_TYPE MATCHES "Rel")
+		continue()
+	endif()
+    endif()
+
     add_libcxx_test_enc("${name}" "${testcase}")
 endforeach(testcase)

--- a/tests/libcxx/tests.broken
+++ b/tests/libcxx/tests.broken
@@ -14,6 +14,3 @@
 ../../3rdparty/libcxx/libcxx/test/std/utilities/meta/meta.rel/is_invocable.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/meta/meta.rel/is_nothrow_invocable.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.pass.cpp
-#Broken with clang RelWithDebInfo 
-../../3rdparty/libcxx/libcxx/test/libcxx/experimental/containers/sequences/dynarray/dynarray.cons/default_throws_bad_alloc.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/utilities/memory/default.allocator/allocator.members/construct.pass.cpp

--- a/tests/libcxx/tests.supported
+++ b/tests/libcxx/tests.supported
@@ -89,6 +89,7 @@
 ../../3rdparty/libcxx/libcxx/test/libcxx/experimental/any/version.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/experimental/containers/sequences/dynarray/dynarray.cons/alloc.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/experimental/containers/sequences/dynarray/dynarray.cons/default.pass.cpp
+../../3rdparty/libcxx/libcxx/test/libcxx/experimental/containers/sequences/dynarray/dynarray.cons/default_throws_bad_alloc.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/experimental/containers/sequences/dynarray/dynarray.data/default.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/experimental/containers/sequences/dynarray/dynarray.mutate/default.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/experimental/containers/sequences/dynarray/dynarray.overview/at.pass.cpp
@@ -4278,6 +4279,7 @@
 ../../3rdparty/libcxx/libcxx/test/std/utilities/memory/default.allocator/allocator.members/address.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/memory/default.allocator/allocator.members/allocate.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/memory/default.allocator/allocator.members/allocate.size.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/utilities/memory/default.allocator/allocator.members/construct.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/memory/default.allocator/allocator.members/max_size.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/memory/default.allocator/allocator_pointers.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/memory/default.allocator/allocator_types.pass.cpp


### PR DESCRIPTION
Two libcxx tests where failing as a result of clang optimization. Modified CMakeLists to skip these tests in clang with optimization.