### PR TITLE
Make OE_DEPRECATED macro be compiler agnostic

### DIFF
--- a/include/openenclave/bits/defs.h
+++ b/include/openenclave/bits/defs.h
@@ -132,4 +132,13 @@
 /* The maxiumum value for a four-byte enum tag */
 #define OE_ENUM_MAX 0xffffffff
 
+/* OE_DEPRECATED */
+#if defined(__GNUC__)
+#define OE_DEPRECATED(FUNC, MSG) FUNC __attribute__((deprecated(MSG)))
+#elif defined(_MSC_VER)
+#define OE_DEPRECATED(FUNC, MSG) __declspec(deprecated(MSG)) FUNC
+#else
+#define OE_DEPRECATED(FUNC, MSG) FUNC
+#endif
+
 #endif /* _OE_BITS_DEFS_H */

--- a/include/openenclave/internal/defs.h
+++ b/include/openenclave/internal/defs.h
@@ -18,9 +18,6 @@
 #define OE_ZERO_SIZED_ARRAY /* empty */
 #endif
 
-/* OE_DEPRECATED */
-#define OE_DEPRECATED(MSG) __attribute__((deprecated(MSG)))
-
 /*
  * Define packed types, such as:
  *     OE_PACK_BEGIN


### PR DESCRIPTION
Addresses Issue #869

This PR is identical to #877 but from an updated repository

Signed-off-by: Dave Thaler <dthaler@microsoft.com>