### PR TITLE
Refactored prereqs makefiles to use apt repos.

### DIFF
--- a/docs/GettingStartedDocs/SGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/SGX1FLCGettingStarted.md
@@ -27,7 +27,6 @@ sudo ./scripts/install-prereqs
 If you are running in an Azure Confidential Compute VM and would like to use the attestation features, you should also run the following command from the root of the source tree:
 
 ```bash
-sudo make -C prereqs/az-dcap-client
 sudo make -C prereqs/az-dcap-client install
 ```
 

--- a/prereqs/az-dcap-client/Makefile
+++ b/prereqs/az-dcap-client/Makefile
@@ -1,16 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-all: setuprepo
+all: 
 
-setuprepo:
+/etc/apt/sources.list.d/msprod.list:
 	echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/prod xenial main" | tee /etc/apt/sources.list.d/msprod.list
 	wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 	apt-get update
 
 clean:
 
-install:
+install: /etc/apt/sources.list.d/msprod.list
 	apt-get install -y az-dcap-client
 
 uninstall:

--- a/prereqs/az-dcap-client/Makefile
+++ b/prereqs/az-dcap-client/Makefile
@@ -1,38 +1,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-AZ_DCAP_PKG=az-dcap-client_1.0_amd64.deb
+all: setuprepo
 
-all: getdist
-
-getdist:
-	$(MAKE) -s distclean
-	$(MAKE) get-quote-provider
-
-distclean:
-	- rm -f $(AZ_DCAP_PKG)
-
-build:
+setuprepo:
+	echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/prod xenial main" | tee /etc/apt/sources.list.d/msprod.list
+	wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+	apt-get update
 
 clean:
 
 install:
-	$(MAKE) -s uninstall
-	dpkg -i $(AZ_DCAP_PKG)
+	apt-get install -y az-dcap-client
 
 uninstall:
-	- dpkg -P az-dcap-client
+	apt-get --purge remove az-dcap-client
 
-##==============================================================================
-##
-## Helper subroutines
-##
-##==============================================================================
-
-get-quote-provider:
-ifdef USE_PKGS_IN
-	cp $(USE_PKGS_IN)/$(AZ_DCAP_PKG) .
-else
-	@ apt-get -y install wget
-	@ wget https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod/pool/main/a/az-dcap-client/$(AZ_DCAP_PKG)
-endif

--- a/prereqs/dcap/Makefile
+++ b/prereqs/dcap/Makefile
@@ -1,16 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-all: setuprepo
+all:
 
-setuprepo:
+/etc/apt/sources.list.d/intel-sgx.list:
 	echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu xenial main' | tee /etc/apt/sources.list.d/intel-sgx.list
 	wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
 	apt-get update
 
 clean:
 
-install:
+install: /etc/apt/sources.list.d/intel-sgx.list
 	apt-get -y install libsgx-enclave-common libsgx-enclave-common-dev libsgx-dcap-ql libsgx-dcap-ql-dev
 
 uninstall:

--- a/prereqs/dcap/Makefile
+++ b/prereqs/dcap/Makefile
@@ -1,86 +1,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-PACKAGE_NAMES=\
-	libsgx-enclave-common\
-	libsgx-enclave-common-dev\
-	libsgx-dcap-ql\
-	libsgx-dcap-ql-dev\
+all: setuprepo
 
-PACKAGES=\
-	libsgx-enclave-common_2.3.100.46354-1_amd64.deb\
-	libsgx-enclave-common-dev_2.3.100.0-1_amd64.deb\
-	libsgx-dcap-ql_1.0.100.46460-1.0_amd64.deb\
-	libsgx-dcap-ql-dev_1.0.100.46460-1.0_amd64.deb\
-
-PACKAGE_URLS=\
-	https://download.01.org/intel-sgx/dcap-1.0/SGX_installers/ubuntu16.04/libsgx-enclave-common_2.3.100.46354-1_amd64.deb\
-	https://download.01.org/intel-sgx/sgx_repo/ubuntu/pool/main/libs/libsgx-enclave-common-dev/libsgx-enclave-common-dev_2.3.100.0-1_amd64.deb\
-	https://download.01.org/intel-sgx/dcap-1.0/DCAP_installers/ubuntu16.04/libsgx-dcap-ql_1.0.100.46460-1.0_amd64.deb\
-	https://download.01.org/intel-sgx/dcap-1.0/DCAP_installers/ubuntu16.04/libsgx-dcap-ql-dev_1.0.100.46460-1.0_amd64.deb\
-
-UNINSTALL_NAMES=$(call reverse-list,$(PACKAGE_NAMES))
-
-all: getdist
-
-getdist:
-	$(MAKE) -s distclean
-	$(MAKE) get-package
-
-distclean:
-	-@ for PKG in $(PACKAGES); do \
-		rm -f $$PKG; \
-	done
-
-build:
+setuprepo:
+	echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu xenial main' | tee /etc/apt/sources.list.d/intel-sgx.list
+	wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
+	apt-get update
 
 clean:
 
 install:
-	@ for PKG in $(PACKAGES); do \
-		dpkg -i $$PKG; \
-	done
-	$(MAKE) check-installed
+	apt-get -y install libsgx-enclave-common libsgx-enclave-common-dev libsgx-dcap-ql libsgx-dcap-ql-dev
 
 uninstall:
-	@ for PKG in $(UNINSTALL_NAMES); do \
-		dpkg -P $$PKG 2>/dev/null; \
-	done
+	apt-get --purge remove libsgx-enclave-common libsgx-enclave-common-dev libsgx-dcap-ql libsgx-dcap-ql-dev
 
-##==============================================================================
-##
-## Helper subroutines
-##
-##==============================================================================
-
-is-pkg-installed = $(shell dpkg-query -s $(1) 2>/dev/null | grep "Status: .* installed")
-reverse-list = $(if $(wordlist 2,2,$(1)),\
-	$(call reverse-list,$(wordlist 2,$(words $(1)),$(1))) $(firstword $(1)),$(1))
-
-PACKAGES_INSTALLED=\
-	$(foreach PKG,$(PACKAGE_NAMES),\
-		$(if $(call is-pkg-installed,$(PKG)),\
-			"Verified: $(PKG) package installed",\
-			"*** Failed to install $(PKG) package"))
-
-# Workaround until these packages are available via apt-get directly
-get-package:
-	apt-get -y install wget dpkg-dev libprotobuf9v5
-ifdef USE_PKGS_IN
-	@ for PKG in $(PACKAGES); do \
-		cp $(USE_PKGS_IN)/$$PKG .; \
-	done
-else
-	@ for PKG_URL in $(PACKAGE_URLS); do \
-		wget $$PKG_URL; \
-	done
-endif
-
-check-installed:
-	@ for PKG in $(PACKAGES_INSTALLED); do \
-		echo $$PKG; \
-	done
-
-ifneq ($(findstring Failed,$(PACKAGES_INSTALLED)),)
-	@ exit 1
-endif


### PR DESCRIPTION
Not sure if we want two different targets anymore ("make" and then "make install", according to the docs).  We could probably combine these targets now, at least for SGX1+FLC configurations