### PR TITLE
Libcxx build fix to remove duplicate entries in tests.supported

### DIFF
--- a/tests/libcxxthrd/tests.supported
+++ b/tests/libcxxthrd/tests.supported
@@ -49,6 +49,3 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.assign/move2.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.assign/move.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.member/joinable.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.member/swap.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.unique/thread.lock.unique.locking/lock.pass.cpp

--- a/tests/libcxxthrd/tests.supported.default
+++ b/tests/libcxxthrd/tests.supported.default
@@ -20,7 +20,6 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.promise/set_rvalue_at_thread_exit.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.promise/set_value_at_thread_exit_const.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.promise/set_value_at_thread_exit_void.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.shared_future/get.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.task/futures.task.members/make_ready_at_thread_exit.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.task/futures.task.members/operator.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/futures/futures.unique_future/get.pass.cpp


### PR DESCRIPTION
Removed 3 duplicate files from tests/libcxxthrd/tests.supported which was a merge issue and broke libcxx ENABLE_FULL_LIBCXX_TESTS Jenkins server run.
Also removed one timing sensitive test.