### PR TITLE
CPUID emulation bugfix.

### DIFF
--- a/enclave/core/cpuid.c
+++ b/enclave/core/cpuid.c
@@ -78,7 +78,8 @@ int oe_emulate_cpuid(uint64_t* rax, uint64_t* rbx, uint64_t* rcx, uint64_t* rdx)
     uint32_t cpuid_leaf = (*rax) & 0xFFFFFFFF;
     uint32_t cpuid_sub_leaf = (*rcx) & 0xFFFFFFFF;
 
-    if (cpuid_leaf < OE_CPUID_LEAF_COUNT)
+    if (cpuid_leaf < OE_CPUID_LEAF_COUNT &&
+        oe_is_emulated_cpuid_leaf(cpuid_leaf))
     {
         // For leaf 4 of cpuid, only subleaf of 0 is emulated
         if ((cpuid_leaf == 4) && (cpuid_sub_leaf != 0))

--- a/include/openenclave/internal/cpuid.h
+++ b/include/openenclave/internal/cpuid.h
@@ -4,6 +4,8 @@
 #ifndef _OE_CPUID_H
 #define _OE_CPUID_H
 
+#include <openenclave/bits/defs.h>
+
 #define OE_CPUID_OPCODE 0xA20F
 #define OE_CPUID_LEAF_COUNT 8
 #define OE_CPUID_EXTENDED_CPUID_LEAF 0x80000000
@@ -15,5 +17,18 @@
 #define OE_CPUID_REG_COUNT 4
 
 #define OE_CPUID_AESNI_FEATURE 0x02000000u
+
+/**
+ * The list of cpuid leafs that are emulated.
+ * Currently 0, 1, 4, 7 leafs are emulated, consistent with Intel SDK.
+ * Note: leaf 1 is used by mbedtls to determine aesni support.
+ * The higher 8 bits of ebx for leaf 1 is the current processor id (initial APIC
+ * id). Since CPUID emulation returns cached values, this higher 8 bits of ebx
+ * should not be relied upon for leaf 1.
+ */
+OE_INLINE bool oe_is_emulated_cpuid_leaf(uint32_t leaf)
+{
+    return (leaf == 0) || (leaf == 1) || (leaf == 4) || (leaf == 7);
+}
 
 #endif /* _OE_CPUID_H */

--- a/tests/VectorException/enc/sigill_handling.c
+++ b/tests/VectorException/enc/sigill_handling.c
@@ -173,21 +173,15 @@ OE_ECALL void TestSigillHandling(void* args_)
     // Return enclave-cached CPUID leaves to host for further validation
     for (int i = 0; i < OE_CPUID_LEAF_COUNT; i++)
     {
-        oe_get_cpuid(
-            i,
-            0,
-            &args->cpuid_table[i][OE_CPUID_RAX],
-            &args->cpuid_table[i][OE_CPUID_RBX],
-            &args->cpuid_table[i][OE_CPUID_RCX],
-            &args->cpuid_table[i][OE_CPUID_RDX]);
-
-        // Do something with the out param to prevent call from getting
-        // optimized out
-        if (args->cpuid_table[i][OE_CPUID_RAX] != 0)
+        if (oe_is_emulated_cpuid_leaf(i))
         {
-            oe_host_printf(
-                "The value of cpuidRAX is now: %d\n.",
-                args->cpuid_table[i][OE_CPUID_RAX]);
+            oe_get_cpuid(
+                i,
+                0,
+                &args->cpuid_table[i][OE_CPUID_RAX],
+                &args->cpuid_table[i][OE_CPUID_RBX],
+                &args->cpuid_table[i][OE_CPUID_RCX],
+                &args->cpuid_table[i][OE_CPUID_RDX]);
         }
     }
 


### PR DESCRIPTION
1. Support only the leafs 0, 1, 4, 7 based on Intel SDK.
2. Update the test. cpuid.1.ebx highest 8 bits indicate current processor and
two successive calls are not guaranteed to return same value since the thread could
be scheduled to different processor for different cpuid calls.
Additionally, emulated cpuid always returns the same cached value.