### PR TITLE
Disable Kabylake builds in CI until further notice.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -109,39 +109,6 @@ pipeline {
             sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo --compiler=clang-7'
           }
         }
-        stage('Kabylake clang-7 SGX1 Debug') {
-          agent {
-            node {
-              label 'SGX'
-            }
-
-          }
-          steps {
-            sh './scripts/test-build-config -p SGX1 -b Debug -d --compiler=clang-7'
-          }
-        }
-        stage('Kabylake clang-7 SGX1 Release') {
-          agent {
-            node {
-              label 'SGX'
-            }
-
-          }
-          steps {
-            sh './scripts/test-build-config -p SGX1 -b Release -d --compiler=clang-7'
-          }
-        }
-        stage('Kabylake clang-7 SGX1 RelWithDebInfo') {
-          agent {
-            node {
-              label 'SGX'
-            }
-
-          }
-          steps {
-            sh './scripts/test-build-config -p SGX1 -b RelWithDebInfo -d --compiler=clang-7'
-          }
-        }
         stage('Coffeelake clang-7 SGX1-FLC Debug') {
           agent {
             node {


### PR DESCRIPTION
This will be re-enabled at a point in the future if both: 1) we can acquire a Kabylake system in Azure that supports SGX1, and 2) we decide that it should be a tested scenario going forward