### PR TITLE
Win oeedgr8r

### DIFF
--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -31,11 +31,12 @@ The json will look like
     },
     "windowsProfile": {
       "adminUsername": "*your username here*",
-      "adminPassword": "*your password here"
+      "adminPassword": "*your password here*"
     }
   }
 }
 ```
+The json allows a number of different options which are outside of this discussion.  
 
 Prerequisites
 -------------

--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -14,6 +14,29 @@ then enclave binaries. That information, along with a step-by-step tutorial
 on building an enclave application, is covered in [Getting Started with
 Open Enclave](GettingStarted.md) document.
 
+Using an ACC VM via oe-engine
+------------------------------
+
+The quickest way to begin development would be to use a pre-deployed acc VM. This will install and configure the environment. 
+In order to do so, you need to find a binary or build oe-engine, which is located [here](https://github.com/Microsoft/oe-engine).
+
+oe-engine will generate an azure resource manager template suitable for deployment by azure from a json file.
+The json will look like
+'''
+{
+  "properties": {
+    "masterProfile": {
+      "vmSize": "Standard_DC2s",
+      "VMName": "*your hostname here*"
+    },
+    "windowsProfile": {
+      "adminUsername": "*your username here*",
+      "adminPassword": "*your password here"
+    }
+  }
+}
+'''
+
 Prerequisites
 -------------
 

--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -22,7 +22,7 @@ In order to do so, you need to find a binary or build oe-engine, which is locate
 
 oe-engine will generate an azure resource manager template suitable for deployment by azure from a json file.
 The json will look like
-'''
+```
 {
   "properties": {
     "masterProfile": {
@@ -35,7 +35,7 @@ The json will look like
     }
   }
 }
-'''
+```
 
 Prerequisites
 -------------

--- a/tools/oeedger8r/CMakeLists.txt
+++ b/tools/oeedger8r/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 if (WIN32)
     set(BINARY ${OE_BINDIR}/oeedger8r.exe)
-    set(BUILD_COMMAND ocaml-env exec -- cmd.exe /c make)
+    set(BUILD_COMMAND ocamlbuild -I intel -no-links -libs str,unix main.native )
 else()
     set(BINARY ${OE_BINDIR}/oeedger8r)
     set(BUILD_COMMAND make)


### PR DESCRIPTION
Allows windows to compile oeedgr8r without requiring cygwin. mingw64 or other auxilliary issues. 