### PR TITLE
Fix #580: libcxx test failures with debug build.

### DIFF
--- a/tests/libcxx/enc/enc.cpp
+++ b/tests/libcxx/enc/enc.cpp
@@ -64,11 +64,11 @@ OE_ECALL void Test(Args* args)
 }
 
 OE_SET_ENCLAVE_SGX(
-    1,    /* ProductID */
-    1,    /* SecurityVersion */
-    true, /* AllowDebug */
-    8192, /* HeapPageCount */
-    1024, /* StackPageCount */
-    2);   /* TCSCount */
+    1,     /* ProductID */
+    1,     /* SecurityVersion */
+    true,  /* AllowDebug */
+    12288, /* HeapPageCount */
+    1024,  /* StackPageCount */
+    2);    /* TCSCount */
 
 OE_DEFINE_EMPTY_ECALL_TABLE();

--- a/tests/libcxx/tests.broken
+++ b/tests/libcxx/tests.broken
@@ -8,8 +8,6 @@
 ../../3rdparty/libcxx/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/wchar_t_encoding.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/wchar_t_max_length.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/numerics/rand/rand.device/ctor.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.match/exponential.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.search/exponential.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.traits/lookup_classname.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/meta/meta.rel/is_invocable.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/meta/meta.rel/is_nothrow_invocable.pass.cpp

--- a/tests/libcxx/tests.supported
+++ b/tests/libcxx/tests.supported
@@ -3497,6 +3497,7 @@
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/nothing_to_do.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.match/awk.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.match/egrep.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.match/exponential.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.match/grep.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.match/lookahead_capture.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.match/parse_curly_brackets.pass.cpp
@@ -3508,6 +3509,7 @@
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.replace/test6.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.search/backup.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.search/egrep.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.search/exponential.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.search/grep.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.search/invert_neg_word_search.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/re/re.alg/re.alg.search/lookahead.pass.cpp


### PR DESCRIPTION
  The HeapPageCount of libcxx tests should be increased to a
  minimum of 11696 for these tests to pass.