### PR TITLE
Fix missing dependency on oeedger8r.

### DIFF
--- a/cmake/oeedl_file.cmake
+++ b/cmake/oeedl_file.cmake
@@ -37,7 +37,13 @@ function(oeedl_file EDL_FILE TYPE OUT_FILES_VAR)
 
 	add_custom_command(
 		OUTPUT ${h_file} ${c_file}
-		DEPENDS ${EDL_FILE} oeedger8r
+		# Temorary workaround:
+		# Add explict dependency to oeedger8r binary.
+		# oeedger8r custom target cannot declare its output binary.
+		# Without the explicity dependecy to the binary below, running make on a test
+		# will rebuild the edger8r if it is out of date, but will not invoke the newly build edger8r
+		# on the edl file.
+		DEPENDS ${EDL_FILE} oeedger8r ${OE_BINDIR}/oeedger8r
 		COMMAND ${OE_BINDIR}/oeedger8r ${type_opt} ${dir_opt} ${CMAKE_CURRENT_BINARY_DIR} ${EDL_FILE}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		)

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -11,8 +11,14 @@ add_custom_command(
             --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl
             --trusted
 
-    # Regenerate if any edl file changes
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../edl/*.edl
+    # Regenerate if any edl file changes or oeedger8r changes
+    # Temorary workaround:
+    # Add explict dependency to oeedger8r binary.
+    # oeedger8r custom target cannot declare its output binary.
+    # Without the explicity dependecy to the binary below, running make on a test
+    # will rebuild the edger8r if it is out of date, but will not invoke the newly build edger8r
+    # on the edl file.
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../edl/*.edl oeedger8r ${OE_BINDIR}/oeedger8r
 )
 
 # Copy generated c file to cpp file.

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -11,8 +11,14 @@ add_custom_command(
             --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl
             --untrusted
 
-    # Regenerate if any edl file changes
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../edl/*.edl
+    # Regenerate if any edl file changes or oeedger8r changes
+    # Temorary workaround:
+    # Add explict dependency to oeedger8r binary.
+    # oeedger8r custom target cannot declare its output binary.
+    # Without the explicity dependecy to the binary below, running make on a test
+    # will rebuild the edger8r if it is out of date, but will not invoke the newly build edger8r
+    # on the edl file.    
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../edl/*.edl oeedger8r ${OE_BINDIR}/oeedger8r
 )
 
 add_executable(edl_host 


### PR DESCRIPTION
Use temporary workaround to ensure that if edger8r source changes,
build tests that depend on it.
The oeedger8r target depends on the edger8r binary, tests depend on
the orrdger8r target.
When building a test, the oeedger8r target is built if
the edger8r source has changed.
However the newly built edger8r is not run on the test's edl file.
This is because the oeedger8r target does no (and has no way) to declare
that its output is the edger8r binary.

This changelist incorporates a workaround to fix the above issue.
Tests also depend on the oeedger8r binary explicitly.