### PR TITLE
oeedger8r calling convention warn, not error

### DIFF
--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -627,7 +627,8 @@ let validate_oe_support (ec: enclave_content) (ep: edger8r_params) =
   ) ec.tfunc_decls;
   List.iter (fun f -> 
     (if f.Ast.uf_fattr.fa_convention <> Ast.CC_NONE then
-        failwithf "Function '%s': Calling conventions for ocalls are not supported by oeedger8r." f.Ast.uf_fdecl.fname);
+        let cconv_str = Ast.get_call_conv_str f.Ast.uf_fattr.Ast.fa_convention in
+        printf "Warning: Function '%s': Calling convention '%s' for ocalls is not supported by oeedger8r.\n" f.Ast.uf_fdecl.fname cconv_str);
     (if f.Ast.uf_fattr.fa_dllimport then
         failwithf "Function '%s': dllimport is not supported by oeedger8r." f.Ast.uf_fdecl.fname);
     (if f.Ast.uf_allow_list != [] then


### PR DESCRIPTION
importing intel sgx edl files have calling conventions specified and our
edger8r is erroring out on these.
Emitting a warning instead of an error now

Fixes #952: have oeedger8r warn instead of error when a calling convention is specified

Example output after this change:
```bash
$ oeedger8r  --trusted-dir enc --untrusted-dir host ./secure_file.edl --search-path ~/sgxsdk/include/
Generating edge routines for the Open Enclave SDK.
Warning: Function 'sgx_oc_cpuidex': Calling convention 'CDECL' for ocalls is not supported by oeedger8r.
Warning: Function 'sgx_thread_wait_untrusted_event_ocall': Calling convention 'CDECL' for ocalls is not supported by oeedger8r.
Warning: Function 'sgx_thread_set_untrusted_event_ocall': Calling convention 'CDECL' for ocalls is not supported by oeedger8r.
Warning: Function 'sgx_thread_setwait_untrusted_events_ocall': Calling convention 'CDECL' for ocalls is not supported by oeedger8r.
Warning: Function 'sgx_thread_set_multiple_untrusted_events_ocall': Calling convention 'CDECL' for ocalls is not supported by oeedger8r.
Success.
```