### PR TITLE
Install oeedger8r specific headers in SDK

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(oe_includes INTERFACE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
 install(DIRECTORY openenclave/bits DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
+install(DIRECTORY openenclave/edger8r DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(FILES openenclave/enclave.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(FILES openenclave/host.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(TARGETS oe_includes EXPORT openenclave-targets)


### PR DESCRIPTION
Were missing the whole edger8r include directory.