### PR TITLE
Fix tests/libcxx test exclusion

### DIFF
--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -22,8 +22,9 @@ foreach(testcase ${alltests})
 
 # the allocations are entirely optimized out by Clang in these tests and are excluded from Clang release builds
     if ("${name}" MATCHES "cons_default_throws_bad_alloc.pass" OR "${name}" MATCHES "allocator_allocator.members_construct.pass")
-        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_BUILD_TYPE MATCHES "Rel")
-                continue()
+        string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+        if (CMAKE_CXX_COMPILER_ID MATCHES Clang AND BUILD_TYPE_UPPER MATCHES REL)
+            continue()
         endif()
     endif()
 

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -64,8 +64,9 @@ foreach(testcase ${alltests})
 
 # the allocations are entirely optimized out by Clang in these tests and are excluded from Clang release builds
     if ("${name}" MATCHES "cons_default_throws_bad_alloc.pass" OR "${name}" MATCHES "allocator_allocator.members_construct.pass")
-	if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_BUILD_TYPE MATCHES "Rel")
-		continue()
+        string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+        if (CMAKE_CXX_COMPILER_ID MATCHES Clang AND BUILD_TYPE_UPPER MATCHES REL)
+            continue()
 	endif()
     endif()
 


### PR DESCRIPTION
PR #889 reintroduced 2 libcxx tests that fail on Clang release builds,
with changes to CMakeLists.txt to exclude them from those configurations.
The check for build type was not case insensitive and so fails to exclude
the tests during CI tests. This PR fixes that by forcing upper case
comparisons of the build type.