### PR TITLE
Adding static asserts to hard-coded offsets used by debugger

### DIFF
--- a/debugger/pythonExtension/gdb_sgx_plugin.py
+++ b/debugger/pythonExtension/gdb_sgx_plugin.py
@@ -22,12 +22,12 @@ OE_ENCLAVE_MAGIC_VALUE = 0x20dc98463a5ad8b8
 OE_ENCLAVE_FLAGS_OFFSET = 0x598
 OE_ENCLAVE_FLAGS_LENGTH = 2
 OE_ENCLAVE_FLAGS_FORMAT = 'BB'
-OE_ENCLAVE_THREAD_DATA_OFFSET = 0x28
+OE_ENCLAVE_THREAD_BINDING_OFFSET = 0x28
 
-# These constant definitions must align with ThreadData structure defined in host\enclave.h
-THREAD_DATA_SIZE = 0x28
-THREAD_DATA_HEADER_LENGTH = 0X8
-THREAD_DATA_HEADER_FORMAT = 'Q'
+# These constant definitions must align with ThreadBinding structure defined in host\enclave.h
+THREAD_BINDING_SIZE = 0x28
+THREAD_BINDING_HEADER_LENGTH = 0X8
+THREAD_BINDING_HEADER_FORMAT = 'Q'
 
 # This constant definition must align with the OE enclave layout.
 TD_OFFSET_FROM_TCS =  0X4000
@@ -157,16 +157,16 @@ def enable_oeenclave_debug(oe_enclave_addr, enclave_path):
     if load_enclave_symbol(enclave_path, enclave_tuple[OE_ENCLAVE_ADDR_FIELD]) != 1:
         return False
     # Set debug flag for each TCS in this enclave.
-    thread_data_addr = oe_enclave_addr + OE_ENCLAVE_THREAD_DATA_OFFSET
-    thread_data_blob = read_from_memory(thread_data_addr, THREAD_DATA_HEADER_LENGTH)
-    thread_data_tuple = struct.unpack(THREAD_DATA_HEADER_FORMAT, thread_data_blob)
-    while thread_data_tuple[0] > 0 :
-        # print ("tcs address {0:#x}" .format(thread_data_tuple[0]))
-        set_tcs_debug_flag(thread_data_tuple[0])
+    thread_binding_addr = oe_enclave_addr + OE_ENCLAVE_THREAD_BINDING_OFFSET
+    thread_binding_blob = read_from_memory(thread_binding_addr, THREAD_BINDING_HEADER_LENGTH)
+    thread_binding_tuple = struct.unpack(THREAD_BINDING_HEADER_FORMAT, thread_binding_blob)
+    while thread_binding_tuple[0] > 0 :
+        # print ("tcs address {0:#x}" .format(thread_binding_tuple[0]))
+        set_tcs_debug_flag(thread_binding_tuple[0])
         # Iterate the array
-        thread_data_addr = thread_data_addr + THREAD_DATA_SIZE
-        thread_data_blob = read_from_memory(thread_data_addr, THREAD_DATA_HEADER_LENGTH);
-        thread_data_tuple = struct.unpack(THREAD_DATA_HEADER_FORMAT, thread_data_blob)
+        thread_binding_addr = thread_binding_addr + THREAD_BINDING_SIZE
+        thread_binding_blob = read_from_memory(thread_binding_addr, THREAD_BINDING_HEADER_LENGTH);
+        thread_binding_tuple = struct.unpack(THREAD_BINDING_HEADER_FORMAT, thread_binding_blob)
     return True
 
 def update_untrusted_ocall_frame(frame_pointer, ocallcontext_tuple):

--- a/debugger/pythonExtension/gdb_sgx_plugin.py
+++ b/debugger/pythonExtension/gdb_sgx_plugin.py
@@ -17,8 +17,8 @@ OE_ENCLAVE_HEADER_LENGTH = 0X28
 OE_ENCLAVE_HEADER_FORMAT = 'QQQQQ'
 OE_ENCLAVE_MAGIC_VALUE = 0x20dc98463a5ad8b8
 
-# The following is the offset of the 'debug' and
-# 'simulate' fields which must lie one after the other.
+# The following are the offset of the 'debug' and
+# 'simulate' flag fields which must lie one after the other.
 OE_ENCLAVE_FLAGS_OFFSET = 0x598
 OE_ENCLAVE_FLAGS_LENGTH = 2
 OE_ENCLAVE_FLAGS_FORMAT = 'BB'

--- a/enclave/core/td.c
+++ b/enclave/core/td.c
@@ -28,10 +28,12 @@ OE_STATIC_ASSERT(OE_OFFSETOF(td_t, simulate) == td_simulate);
 
 // Static asserts for consistency with
 // debugger/pythonExtension/gdb_sgx_plugin.py
+#if defined(__linux__)
 OE_STATIC_ASSERT(td_callsites == 0xf0);
 OE_STATIC_ASSERT(OE_OFFSETOF(Callsite, ocall_context) == 0x40);
 OE_STATIC_ASSERT(TD_FROM_TCS == 0x4000);
 OE_STATIC_ASSERT(sizeof(oe_ocall_context_t) == 2 * 8);
+#endif
 
 /*
 **==============================================================================

--- a/enclave/core/td.c
+++ b/enclave/core/td.c
@@ -12,6 +12,8 @@
 #include <openenclave/internal/utils.h>
 #include "asmdefs.h"
 
+#define TD_FROM_TCS 4 * OE_PAGE_SIZE
+
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, magic) == td_magic);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, depth) == td_depth);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, host_rcx) == td_host_rcx);
@@ -23,6 +25,13 @@ OE_STATIC_ASSERT(OE_OFFSETOF(td_t, oret_func) == td_oret_func);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, oret_arg) == td_oret_arg);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, callsites) == td_callsites);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, simulate) == td_simulate);
+
+// Static asserts for consistency with
+// debugger/pythonExtension/gdb_sgx_plugin.py
+OE_STATIC_ASSERT(td_callsites == 0xf0);
+OE_STATIC_ASSERT(OE_OFFSETOF(Callsite, ocall_context)  == 0x40);
+OE_STATIC_ASSERT(TD_FROM_TCS == 0x4000);
+OE_STATIC_ASSERT(sizeof(oe_ocall_context_t) == 2 * 8);
 
 /*
 **==============================================================================
@@ -123,7 +132,7 @@ void td_pop_callsite(td_t* td)
 
 td_t* td_from_tcs(void* tcs)
 {
-    return (td_t*)((uint8_t*)tcs + (4 * OE_PAGE_SIZE));
+    return (td_t*)((uint8_t*)tcs + TD_FROM_TCS);
 }
 
 /*

--- a/enclave/core/td.c
+++ b/enclave/core/td.c
@@ -29,7 +29,7 @@ OE_STATIC_ASSERT(OE_OFFSETOF(td_t, simulate) == td_simulate);
 // Static asserts for consistency with
 // debugger/pythonExtension/gdb_sgx_plugin.py
 OE_STATIC_ASSERT(td_callsites == 0xf0);
-OE_STATIC_ASSERT(OE_OFFSETOF(Callsite, ocall_context)  == 0x40);
+OE_STATIC_ASSERT(OE_OFFSETOF(Callsite, ocall_context) == 0x40);
 OE_STATIC_ASSERT(TD_FROM_TCS == 0x4000);
 OE_STATIC_ASSERT(sizeof(oe_ocall_context_t) == 2 * 8);
 

--- a/enclave/core/td.c
+++ b/enclave/core/td.c
@@ -12,7 +12,7 @@
 #include <openenclave/internal/utils.h>
 #include "asmdefs.h"
 
-#define TD_FROM_TCS 4 * OE_PAGE_SIZE
+#define TD_FROM_TCS (4 * OE_PAGE_SIZE)
 
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, magic) == td_magic);
 OE_STATIC_ASSERT(OE_OFFSETOF(td_t, depth) == td_depth);
@@ -32,7 +32,7 @@ OE_STATIC_ASSERT(OE_OFFSETOF(td_t, simulate) == td_simulate);
 OE_STATIC_ASSERT(td_callsites == 0xf0);
 OE_STATIC_ASSERT(OE_OFFSETOF(Callsite, ocall_context) == 0x40);
 OE_STATIC_ASSERT(TD_FROM_TCS == 0x4000);
-OE_STATIC_ASSERT(sizeof(oe_ocall_context_t) == 2 * 8);
+OE_STATIC_ASSERT(sizeof(oe_ocall_context_t) == (2 * sizeof(uintptr_t)));
 #endif
 
 /*

--- a/enclave/core/td.h
+++ b/enclave/core/td.h
@@ -47,7 +47,7 @@ struct _callsite
     /* Enclave callsite stored here when exiting to make an OCALL */
     oe_jmpbuf_t jmpbuf;
 
-    /* Pointer ot the ocall context */
+    /* Pointer to the ocall context */
     oe_ocall_context_t* ocall_context;
 
     /* Pointer to next ECALL context */

--- a/host/enclave.h
+++ b/host/enclave.h
@@ -137,7 +137,7 @@ struct _oe_enclave
 // debugger/pythonExtension/gdb_sgx_plugin.py
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_enclave_t, magic) == 0);
 
-// Python plugin seems to code this as just 2.
+// Python plugin only needs the field number which is 2
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_enclave_t, addr) == 2 * sizeof(void*));
 
 // The fields up to binding correspond to 'ENCLAVE_HEADER'

--- a/host/enclave.h
+++ b/host/enclave.h
@@ -135,6 +135,7 @@ struct _oe_enclave
 
 // Static asserts for consistency with
 // debugger/pythonExtension/gdb_sgx_plugin.py
+#if defined(__linux__)
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_enclave_t, magic) == 0);
 
 // Python plugin only needs the field number which is 2
@@ -147,6 +148,7 @@ OE_STATIC_ASSERT(OE_OFFSETOF(oe_enclave_t, debug) == 0x598);
 OE_STATIC_ASSERT(
     OE_OFFSETOF(oe_enclave_t, debug) + 1 ==
     OE_OFFSETOF(oe_enclave_t, simulate));
+#endif
 
 /* Get the event for the given TCS */
 EnclaveEvent* GetEnclaveEvent(oe_enclave_t* enclave, uint64_t tcs);


### PR DESCRIPTION
Added static asserts to hard-coded offsets used by the oe-gdb debugger.
Fixed build break on Windows using conditional compilation for Linux as oe-gdb works only on Linux.
Renamed all references of ThreadData to ThreadBinding, the new/current name in in the python plugin.