### PR TITLE
Radhikaj/deploydocs packaging

### DIFF
--- a/.jenkins/Packaging.Jenkinsfile
+++ b/.jenkins/Packaging.Jenkinsfile
@@ -66,6 +66,9 @@ pipeline {
             sh 'bash ./scripts/test-build-config -p SGX1 -b Release --build_package'
             azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Release/SGX1/', containerName: 'oejenkins')
             azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Release/SGX1/', containerName: 'oejenkins')
+            withCredentials([usernamePassword(credentialsId: 'https_gh_pages_push', passwordVariable: 'SERVICE_PRINCIPAL_PASSWORD', usernameVariable: 'SERVICE_PRINCIPAL_ID')]) {
+                sh 'bash ./scripts/deploy-docs build https $SERVICE_PRINCIPAL_ID $SERVICE_PRINCIPAL_PASSWORD'
+            }
           }
         }
         stage('SGX1 Package RelWithDebInfo') {

--- a/.jenkins/Packaging.Jenkinsfile
+++ b/.jenkins/Packaging.Jenkinsfile
@@ -27,6 +27,9 @@ pipeline {
             sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --build_package'
             azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Release/SGX1FLC/', containerName: 'oejenkins')
             azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Release/SGX1FLC/', containerName: 'oejenkins')
+            withCredentials([usernamePassword(credentialsId: 'https_gh_pages_push', passwordVariable: 'GHUSER_PASSWORD', usernameVariable: 'GHUSER_ID')]) {
+                sh 'bash ./scripts/deploy-docs build https $GHUSER_ID $GHUSER_PASSWORD'
+            }
           }
         }
         stage('SGX1FLC Package RelWithDebInfo') {
@@ -66,9 +69,6 @@ pipeline {
             sh 'bash ./scripts/test-build-config -p SGX1 -b Release --build_package'
             azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Release/SGX1/', containerName: 'oejenkins')
             azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Release/SGX1/', containerName: 'oejenkins')
-            withCredentials([usernamePassword(credentialsId: 'https_gh_pages_push', passwordVariable: 'SERVICE_PRINCIPAL_PASSWORD', usernameVariable: 'SERVICE_PRINCIPAL_ID')]) {
-                sh 'bash ./scripts/deploy-docs build https $SERVICE_PRINCIPAL_ID $SERVICE_PRINCIPAL_PASSWORD'
-            }
           }
         }
         stage('SGX1 Package RelWithDebInfo') {

--- a/scripts/deploy-docs
+++ b/scripts/deploy-docs
@@ -4,7 +4,6 @@
 # Licensed under the MIT License.
 
 ##==============================================================================
-set -x
 
 function trap_handler()
 {
@@ -66,9 +65,7 @@ case $mode in
         git push -f git@github.com:Microsoft/openenclave.git $branch:$branch
     ;; 
     https)
-        echo "
-        git  push -f https://${username}:${password}@github.com/Microsoft/openenclave.git $branch:$branch"
-       git push  -f "https://${username}:${password}@github.com/Microsoft/openenclave.git" $branch:$branch
+        git push  -f "https://${username}:${password}@github.com/Microsoft/openenclave.git" $branch:$branch
     ;;
     *)
         echo " Unexpected"

--- a/scripts/deploy-docs
+++ b/scripts/deploy-docs
@@ -4,6 +4,7 @@
 # Licensed under the MIT License.
 
 ##==============================================================================
+set -x
 
 function trap_handler()
 {
@@ -22,16 +23,17 @@ case $mode in
     ;;
     
     https)
-        echo "Pushing gh-pages via https, will prompt for username and personal access token"
+        echo "Pushing gh-pages via https"
+        username=$3
+        password=$4
     ;;
-    
     *)
-        echo "Usage: $0 builddir [ ssh | https ]";
+        echo "Usage: $0 builddir [ ssh | https username pat ]";
         echo "  builddir:  Build directory for OpenEnclave repo"
         echo "  ssh:   Pushes doxygen generated docs to OpenEnclave's gh-pages"
         echo "         via ssh, requires ssh keys to be set up"
         echo "  https: Pushes doxygen generated docs to OpenEnclave's gh-pages"
-        echo "         via https, prompts user for username and personal access token"
+        echo "         specify username and personal access token on cmd line"
         exit 1;
     ;;
 esac 
@@ -64,7 +66,9 @@ case $mode in
         git push -f git@github.com:Microsoft/openenclave.git $branch:$branch
     ;; 
     https)
-        git push -f https://github.com/Microsoft/openenclave.git $branch:$branch
+        echo "
+        git  push -f https://${username}:${password}@github.com/Microsoft/openenclave.git $branch:$branch"
+       git push  -f "https://${username}:${password}@github.com/Microsoft/openenclave.git" $branch:$branch
     ;;
     *)
         echo " Unexpected"


### PR DESCRIPTION
Have the nightly packagebuild deploy doxygen html docs to gh-pages. This keeps the doxygen pages in sync with current API set.