### PR TITLE
Fix issue with building oeedger8r on windows

### DIFF
--- a/tools/oeedger8r/CMakeLists.txt
+++ b/tools/oeedger8r/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 if (WIN32)
     set(BINARY ${OE_BINDIR}/oeedger8r.exe)
-    set(BUILD_COMMAND ocaml-env exec -- cmd.exe /c make)
+    set(BUILD_COMMAND ocamlbuild -I intel -no-links -libs str,unix main.native )
 else()
     set(BINARY ${OE_BINDIR}/oeedger8r)
     set(BUILD_COMMAND make)


### PR DESCRIPTION
This will allow the edger8r to build using the deployment on acc VM and ocaml with Visual C