### PR TITLE
Making single implementation for random functionality at common/rand.c,for both oecore and oelibcoelibc.

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -32,10 +32,13 @@
 #else
 
 #include <openenclave/host.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #endif
+
+uint64_t _rdrand(void);
 
 #endif // _OE_COMMON_COMMON_H

--- a/common/rand.S
+++ b/common/rand.S
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.text
+.globl  _rdrand
+
+_rdrand:
+    pushq   %rbp
+    movq    %rsp, %rbp
+
+_rdrand_retry:
+    rdrand %rax
+    jnc _rdrand_retry
+
+    leave
+    ret
+

--- a/common/rand.asm
+++ b/common/rand.asm
@@ -1,0 +1,25 @@
+;; Copyright (c) Microsoft Corporation. All rights reserved.
+;; Licensed under the MIT License.
+.CODE
+
+PUBLIC _rdrand
+_rdrand PROC
+;; Subroutine Prologue
+	push rbp     ;; Save the old base pointer value.
+	mov rbp, rsp ;; Set the new base pointer value.
+	sub rsp, 4   ;; Make room for one 4-byte local variable.
+
+;; Subroutine Body
+_rdrand_retry:
+	rdrand rax
+	jnc _rdrand_retry
+
+;; Subroutine Epilogue
+	mov rsp, rbp ;; Deallocate local variables
+	pop rbp      ;; Restore the caller's base pointer value
+
+	ret
+
+_rdrand ENDP
+
+END

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -3,10 +3,12 @@
 
 if (UNIX)
 set(PLATFORM_SRC
+    ../../common/rand.S
     linux/reloc.c
     )
 elseif (WIN32)
 set(PLATFORM_SRC
+    ../../common/rand.asm
     windows/reloc.c
     )
 endif()

--- a/enclave/core/entropy.c
+++ b/enclave/core/entropy.c
@@ -4,14 +4,7 @@
 #include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/enclavelibc.h>
-
-uint64_t _rdrand(void)
-{
-    uint64_t r;
-    __asm__ volatile("rdrand %0\n\t" : "=r"(r));
-
-    return r;
-}
+#include "../../common/common.h"
 
 /*
  * MBEDTLS links this function definition when MBEDTLS_ENTROPY_HARDWARE_ALT

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -29,6 +29,17 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(oelibasm PRIVATE -Wno-error=unused-command-line-argument)
 endif ()
 
+if (UNIX)
+set(PLATFORM_SRC
+    ../common/rand.S
+)
+elseif (WIN32)
+set(PLATFORM_SRC
+    ../common/rand.asm
+)
+endif()
+
+
 add_library(oelibc STATIC
     arc4random.c
     atexit.c
@@ -653,7 +664,8 @@ add_library(oelibc STATIC
     ${MUSLSRC}/time/__year_to_secs.c
     ${MUSLSRC}/unistd/close.c
     ${MUSLSRC}/unistd/dup.c
-    ${MUSLSRC}/unistd/dup3.c)
+    ${MUSLSRC}/unistd/dup3.c
+    ${PLATFORM_SRC})
 
 set_property(TARGET oelibc PROPERTY C_STANDARD 99)
 

--- a/libc/arc4random.c
+++ b/libc/arc4random.c
@@ -4,6 +4,7 @@
 /* Ignore unused-variable warning in system header */
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #include <stdlib.h>
+#include "../common/common.h"
 /*
  * Random implementation needed by libcxx as alternative to device oriented
  * randomness (/dev/rand)
@@ -12,8 +13,6 @@
 unsigned int arc4random(void)
 {
     unsigned int r;
-
-    while (!__builtin_ia32_rdrand32_step(&r))
-        ;
+    r = (unsigned int)_rdrand();
     return r;
 }

--- a/tests/crypto/enclave/enc/CMakeLists.txt
+++ b/tests/crypto/enclave/enc/CMakeLists.txt
@@ -7,12 +7,14 @@ oeedl_file(../crypto.edl enclave gen)
 
 add_executable(cryptoenc
     enc.c
+    ../../../../common/rand.S
     ../../read_file.c
     ../../asn1_tests.c
     ../../crl_tests.c
     ../../ec_tests.c
     ../../hash.c
     ../../random_tests.c
+    ../../rdrand_test.c
     ../../rsa_tests.c
     ../../sha_tests.c
     ../../tests.c

--- a/tests/crypto/host/CMakeLists.txt
+++ b/tests/crypto/host/CMakeLists.txt
@@ -1,14 +1,17 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 set(DATA_DIR "../data")
 add_executable(hostcrypto 
     main.c
+    ../../../common/rand.S
     ../read_file.c
     ../asn1_tests.c
     ../crl_tests.c
     ../ec_tests.c
     ../hash.c
     ../random_tests.c
+    ../rdrand_test.c
     ../rsa_tests.c
     ../sha_tests.c
     ../tests.c)
@@ -109,5 +112,4 @@ COMMAND openssl dgst -sha256 -sign ${DATA_DIR}/Leaf.key.pem -out ${DATA_DIR}/tes
 
 )
 target_link_libraries(hostcrypto oehost)
-
 add_test(tests/crypto/host hostcrypto)

--- a/tests/crypto/rdrand_test.c
+++ b/tests/crypto/rdrand_test.c
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define MAX_LOOP_SIZE 100000000
+#include <openenclave/internal/tests.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "../../common/common.h"
+
+// TestRdrand is trying to ensure that _rdrand function incoperates blocking
+// wait  to retry if the RDRAND instruction is out of entropy
+void TestRdrand()
+{
+    uint64_t rand_num = 0;
+    printf("=== begin %s()\n", __FUNCTION__);
+    for (uint64_t i = 0; i < MAX_LOOP_SIZE; i++)
+    {
+        rand_num = _rdrand();
+        if (rand_num == 0)
+        {
+            rand_num = _rdrand();
+            OE_TEST(rand_num != 0);
+        }
+    }
+    printf("=== passed %s()\n", __FUNCTION__);
+}

--- a/tests/crypto/tests.c
+++ b/tests/crypto/tests.c
@@ -9,6 +9,7 @@ void TestAll()
     TestCRL();
     TestEC();
     TestRandom();
+    TestRdrand();
     TestRSA();
     TestSHA();
 }

--- a/tests/crypto/tests.h
+++ b/tests/crypto/tests.h
@@ -8,6 +8,7 @@ void TestASN1(void);
 void TestCRL(void);
 void TestEC(void);
 void TestRandom(void);
+void TestRdrand(void);
 void TestRSA(void);
 void TestSHA(void);
 


### PR DESCRIPTION
The random generator function _rdrand in enclave/core/entropy.c is moved to common/rand.c
In  arc4random  used _rdrand  instead of _rdrand32_step 
Made  common/rand.c implementation available for both oecore and oelibc  