### PR TITLE
Improvements to edger8r

### DIFF
--- a/tests/memory/enc/basic.c
+++ b/tests/memory/enc/basic.c
@@ -22,7 +22,7 @@ static void _check_buffer(int* buf, size_t start, size_t end)
         OE_TEST(buf[i] == i);
 }
 
-OE_ECALL void test_malloc(void* args_)
+void test_malloc(void)
 {
     /* malloc(0) is implementation defined, but we can always free it. */
     int* ptr = (int*)malloc(0);
@@ -40,7 +40,7 @@ OE_ECALL void test_malloc(void* args_)
     OE_TEST(ptr == NULL);
 }
 
-OE_ECALL void test_calloc(void* args_)
+void test_calloc(void)
 {
     /* calloc with 0 is implementation defined, but we can always free it. */
     int* ptr = (int*)calloc(0, 0);
@@ -58,7 +58,7 @@ OE_ECALL void test_calloc(void* args_)
     OE_TEST(ptr == NULL);
 }
 
-OE_ECALL void test_realloc(void* args_)
+void test_realloc(void)
 {
     /* Realloc with null pointer works like malloc. */
     int* ptr = (int*)realloc(NULL, 256 * sizeof(int));
@@ -101,7 +101,7 @@ OE_ECALL void test_realloc(void* args_)
     free(ptr);
 }
 
-OE_ECALL void test_memalign(void* args_)
+void test_memalign(void)
 {
     /* Get an aligned pointer below malloc's alignment. */
     int* ptr = (int*)memalign(8, 256 * sizeof(int));
@@ -127,7 +127,7 @@ OE_ECALL void test_memalign(void* args_)
     OE_TEST(memalign(max, 64) == NULL);
 }
 
-OE_ECALL void test_posix_memalign(void* args_)
+void test_posix_memalign(void)
 {
     void* ptr = NULL;
 

--- a/tests/oeedger8r/edl/basic.edl
+++ b/tests/oeedger8r/edl/basic.edl
@@ -47,6 +47,8 @@ enclave  {
         public uint64_t ecall_ret_uint64_t();   
         public long long ecall_ret_long_long();
         public long double ecall_ret_long_double();
+        public void ecall_ret_void();
+
 
         public void test_basic_edl_ocalls();             
     };
@@ -94,6 +96,8 @@ enclave  {
         uint32_t ocall_ret_uint32_t();
         uint64_t ocall_ret_uint64_t();     
         long long ocall_ret_long_long();
-        long double ocall_ret_long_double();             
+        long double ocall_ret_long_double();     
+        
+        void ocall_ret_void();        
     }; 
 };

--- a/tests/oeedger8r/enc/testbasic.cpp
+++ b/tests/oeedger8r/enc/testbasic.cpp
@@ -145,6 +145,11 @@ void test_basic_edl_ocalls()
         OE_TEST(ocall_ret_long_double(&ret) == OE_OK);
         OE_TEST(ret == 0.191919);
     }
+
+    {
+        OE_TEST(ocall_ret_void() == OE_OK);
+    }
+
     printf("=== test_basic_edl_ocalls passed\n");
 }
 
@@ -324,4 +329,8 @@ long double ecall_ret_long_double()
 {
     check_return_type<ecall_ret_long_double_args_t, long double>();
     return 0.191919;
+}
+
+void ecall_ret_void()
+{
 }

--- a/tests/oeedger8r/host/testbasic.cpp
+++ b/tests/oeedger8r/host/testbasic.cpp
@@ -147,6 +147,10 @@ void test_basic_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(ret == 0.191919);
     }
 
+    {
+        OE_TEST(ecall_ret_void(enclave) == OE_OK);
+    }
+
     printf("=== test_basic_edl_ecalls passed\n");
 }
 
@@ -328,4 +332,8 @@ long double ocall_ret_long_double()
 {
     check_return_type<ocall_ret_long_double_args_t, long double>();
     return 0.191919;
+}
+
+void ocall_ret_void()
+{
 }


### PR DESCRIPTION
1. Emit warnings for use of wchar_t, long, and long double.
2. Declare functions with no parameters as (void) instead of
    just (). In C, without the explict (void), the function
   behaves as if it was (...).
   Update test that was using wrong signature. Detected
   due to the updated signature.