### PR TITLE
Removed references to libcxxthrd in doc

### DIFF
--- a/docs/GettingStartedDocs/AdvancedTestInfo.md
+++ b/docs/GettingStartedDocs/AdvancedTestInfo.md
@@ -4,7 +4,7 @@ Advanced test information
 * If tests fail, `ctest -V` provides verbose information.
 * Executing `ctest` from the build subfolder of a test executes only the contained test.
 
-Only a small subset of libc/libcxx/libcxxthrd tests are enabled by default due to their huge
+Only a small subset of libc/libcxx tests are enabled by default due to their huge
 cost on building (a couple hours). Enable the full set by setting the corresponding cmake
 `ENABLE_FULL_LIBC_TESTS` or `ENABLE_FULL_LIBCXX_TESTS` variables before building.
 For example, run the following from your build subfolder:

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,9 +20,9 @@ build/tests/echo$ make
 ```
 
 
-This builds and runs all the tests. For libcxx & libcxxthrd a small subset is
-the default, the complete one is very slow to build and run. To enable the full
-set, set the ENABLE_FULL_LIBCXX_TESTS cmake variable as follows:
+This builds and runs all the tests. For libcxx a small subset is the default,
+the complete one is very slow to build and run. To enable the full set,
+set the ENABLE_FULL_LIBCXX_TESTS cmake variable as follows:
 
 ```
 build$ cmake .. -DENABLE_FULL_LIBCXX_TESTS=1


### PR DESCRIPTION
Since tests/libcxxthrd has been merged with tests/libcxx, references to libcxxthrd in doc need to be removed.