### PR TITLE
Remove ocamlbuild from the build do to many quasi-linux dependencies

### DIFF
--- a/tools/oeedger8r/CMakeLists.txt
+++ b/tools/oeedger8r/CMakeLists.txt
@@ -3,7 +3,6 @@
 
 if (WIN32)
     set(BINARY ${OE_BINDIR}/oeedger8r.exe)
-    set(BUILD_COMMAND ocamlbuild -I intel -no-links -libs str,unix main.native )
 else()
     set(BINARY ${OE_BINDIR}/oeedger8r)
     set(BUILD_COMMAND make)
@@ -37,13 +36,23 @@ add_custom_command(
     DEPENDS ${OEEDGER8R_SRC}
 )
 
+if (WIN32)
 add_custom_command(
     OUTPUT ${BINARY}
-    COMMAND ${BUILD_COMMAND}
+    COMMAND C:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell -command ${CMAKE_CURRENT_SOURCE_DIR}/build.ps1 ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} 
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/src/_build/main.native ${BINARY}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/src
 )
+else()
+ add_custom_command(
+     OUTPUT ${BINARY}
+     COMMAND ${BUILD_COMMAND}
+     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/src/_build/main.native ${BINARY}
+     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
+     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/src
+ )
+endif()
 
 add_custom_target(oeedger8r ALL
     DEPENDS ${BINARY}

--- a/tools/oeedger8r/build.ps1
+++ b/tools/oeedger8r/build.ps1
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. 
+
+[CmdletBinding(DefaultParameterSetName="Standard")]
+Param(
+    [string]
+    [ValidateNotNullOrEmpty()]
+    $srcdir,
+    [string]
+    [ValidateNotNullOrEmpty()]
+    $dstdir
+)
+$source_files = @( "Ast", 
+        "Util", 
+        "Parser", 
+        "Lexer", 
+        "Plugin", 
+        "Preprocessor", 
+        "SimpleStack", 
+        "CodeGen", 
+        "Edger8r" )
+
+try {
+    New-Item -Path "$dstdir" -Name "src" -ItemType "directory"
+    New-Item -Path "$dstdir/src" -Name "_build" -ItemType "directory"
+}
+catch {
+    Write-Output "error $_"
+    Write-Host "error $_"
+}
+
+copy-item -recurse -Path "$srcdir/intel/*.ml*" -Destination "$dstdir/src/_build"
+pushd $dstdir/src/_build
+
+ocamllex.opt -q Lexer.mll
+ocamlyacc Parser.mly
+
+foreach ($i in @("Lexer", "Util", "Plugin", "Preprocessor","SimpleStack", "Ast", "CodeGen", "Edger8r")) {
+    ocamldep.opt -modules "$i.ml" > "$i.ml.depends"
+}
+ocamldep.opt -modules Parser.mli > Parser.mli.depends
+
+ocamlc.opt -c -o Ast.cmo Ast.ml
+ocamlc.opt -c -o Parser.cmi Parser.mli
+
+foreach ($i in @("Lexer", "Util", "Plugin", "Preprocessor","SimpleStack", "CodeGen", "Edger8r")) {
+    ocamlc.opt -c -o "$i.cmo" "$i.ml"
+}
+ocamldep.opt -modules Parser.ml > Parser.ml.depends
+
+foreach ($i in $source_files) {
+    ocamlopt.opt -c -o "$i.cmx" "$i.ml"
+}
+ocamlopt.opt str.cmxa unix.cmxa Ast.cmx Util.cmx Parser.cmx Lexer.cmx Plugin.cmx Preprocessor.cmx SimpleStack.cmx CodeGen.cmx Edger8r.cmx -o main.native
+popd


### PR DESCRIPTION
Replaces oacmlbuild with a dedicated build script. Required for build without cygwin64 or mingw64