### PR TITLE
Set CI timeouts

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
   agent any
+  options {
+    timeout(time: 30, unit: 'MINUTES')
+  }
   stages {
     stage('Precommit-checking') {
       agent {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,8 +1,5 @@
 pipeline {
   agent any
-  options {
-    timeout(time: 30, unit: 'MINUTES')
-  }
   stages {
     stage('Precommit-checking') {
       agent {
@@ -12,7 +9,9 @@ pipeline {
 
       }
       steps {
-        sh './scripts/check-precommit-reqs'
+        timeout(2) {
+          sh './scripts/check-precommit-reqs'
+        }
       }
     }
     stage('Build and Test') {
@@ -27,22 +26,24 @@ pipeline {
             }
           }
           steps {
-            // This is run to test that it works with the dependencies
-            // installed by our install-prereqs script.
-            sh './scripts/check-precommit-reqs'
+            timeout(15) {
+              // This is run to test that it works with the dependencies
+              // installed by our install-prereqs script.
+              sh './scripts/check-precommit-reqs'
 
-            // We actually expect `ctest` to fail because it is an
-            // older version that emits a failure if any tests are
-            // skipped. In other stages, we explicitly install an
-            // updated version of CMake.
-            dir('build') {
-              sh '''
+              // We actually expect `ctest` to fail because it is an
+              // older version that emits a failure if any tests are
+              // skipped. In other stages, we explicitly install an
+              // updated version of CMake.
+              dir('build') {
+                sh '''
                 cmake ..
                 make
                 OE_SIMULATION=1 ctest --verbose --output-on-failure || true
               '''
-              // Note that `make package` is not expected to work
-              // without extra configuration.
+                // Note that `make package` is not expected to work
+                // without extra configuration.
+              }
             }
           }
         }
@@ -54,7 +55,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -b Debug --compiler=clang-7'
+            timeout(15) {
+              sh './scripts/test-build-config -b Debug --compiler=clang-7'
+            }
           }
         }
         stage('Simulation clang-7 SGX1 Release') {
@@ -65,7 +68,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1 -b Release --compiler=clang-7'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1 -b Release --compiler=clang-7'
+            }
           }
         }
         stage('Simulation clang-7 SGX1 RelWithDebInfo') {
@@ -76,7 +81,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1 -b RelWithDebInfo --compiler=clang-7'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1 -b RelWithDebInfo --compiler=clang-7'
+            }
           }
         }
         stage('Simulation clang-7 SGX1-FLC Debug') {
@@ -87,7 +94,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1FLC -b Debug --compiler=clang-7'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1FLC -b Debug --compiler=clang-7'
+            }
           }
         }
         stage('Simulation clang-7 SGX1-FLC Release') {
@@ -98,7 +107,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1FLC -b Release --compiler=clang-7'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1FLC -b Release --compiler=clang-7'
+            }
           }
         }
         stage('Simulation clang-7 SGX1-FLC RelWithDebInfo') {
@@ -109,7 +120,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo --compiler=clang-7'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo --compiler=clang-7'
+            }
           }
         }
         stage('Coffeelake clang-7 SGX1-FLC Debug') {
@@ -120,7 +133,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1FLC -b Debug -d --compiler=clang-7'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1FLC -b Debug -d --compiler=clang-7'
+            }
           }
         }
         stage('Coffeelake clang-7 SGX1-FLC Release') {
@@ -131,7 +146,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1FLC -b Release -d --compiler=clang-7'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1FLC -b Release -d --compiler=clang-7'
+            }
           }
         }
         stage('Coffeelake clang-7 SGX1-FLC RelWithDebInfo') {
@@ -142,7 +159,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --compiler=clang-7'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --compiler=clang-7'
+            }
           }
         }
         stage('Coffeelake gcc SGX1-FLC Debug') {
@@ -153,7 +172,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1FLC -b Debug -d --compiler=gcc'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1FLC -b Debug -d --compiler=gcc'
+            }
           }
         }
         stage('Coffeelake gcc SGX1-FLC Release') {
@@ -164,7 +185,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1FLC -b Release -d --compiler=gcc'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1FLC -b Release -d --compiler=gcc'
+            }
           }
         }
         stage('Coffeelake gcc SGX1-FLC RelWithDebInfo') {
@@ -175,7 +198,9 @@ pipeline {
 
           }
           steps {
-            sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --compiler=gcc'
+            timeout(15) {
+              sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --compiler=gcc'
+            }
           }
         }
       }

--- a/.jenkins/Packaging.Jenkinsfile
+++ b/.jenkins/Packaging.Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
   agent any
+  options {
+    timeout(time: 30, unit: 'MINUTES')
+  }
   stages {
     stage('Build, Test, and Package') {
       parallel {

--- a/.jenkins/Packaging.Jenkinsfile
+++ b/.jenkins/Packaging.Jenkinsfile
@@ -1,8 +1,5 @@
 pipeline {
   agent any
-  options {
-    timeout(time: 30, unit: 'MINUTES')
-  }
   stages {
     stage('Build, Test, and Package') {
       parallel {
@@ -14,9 +11,11 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --build_package'
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Debug/SGX1FLC/', containerName: 'oejenkins')
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Debug/SGX1FLC/', containerName: 'oejenkins')
+            timeout(10) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --build_package'
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Debug/SGX1FLC/', containerName: 'oejenkins')
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Debug/SGX1FLC/', containerName: 'oejenkins')
+            }
           }
         }
         stage('SGX1FLC Package Release') {
@@ -27,11 +26,13 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --build_package'
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Release/SGX1FLC/', containerName: 'oejenkins')
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Release/SGX1FLC/', containerName: 'oejenkins')
-            withCredentials([usernamePassword(credentialsId: 'https_gh_pages_push', passwordVariable: 'GHUSER_PASSWORD', usernameVariable: 'GHUSER_ID')]) {
+            timeout(10) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --build_package'
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Release/SGX1FLC/', containerName: 'oejenkins')
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Release/SGX1FLC/', containerName: 'oejenkins')
+              withCredentials([usernamePassword(credentialsId: 'https_gh_pages_push', passwordVariable: 'GHUSER_PASSWORD', usernameVariable: 'GHUSER_ID')]) {
                 sh 'bash ./scripts/deploy-docs build https $GHUSER_ID $GHUSER_PASSWORD'
+              }
             }
           }
         }
@@ -43,9 +44,11 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --build_package'
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/RelWithDebInfo/SGX1FLC/', containerName: 'oejenkins')
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/RelWithDebInfo/SGX1FLC/', containerName: 'oejenkins')
+            timeout(10) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --build_package'
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/RelWithDebInfo/SGX1FLC/', containerName: 'oejenkins')
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/RelWithDebInfo/SGX1FLC/', containerName: 'oejenkins')
+            }
           }
         }
         stage('SGX1 Package Debug') {
@@ -56,9 +59,11 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1 -b Debug --build_package'
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Debug/SGX1/', containerName: 'oejenkins')
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Debug/SGX1/', containerName: 'oejenkins')
+            timeout(10) {
+              sh 'bash ./scripts/test-build-config -p SGX1 -b Debug --build_package'
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Debug/SGX1/', containerName: 'oejenkins')
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Debug/SGX1/', containerName: 'oejenkins')
+            }
           }
         }
         stage('SGX1 Package Release') {
@@ -69,9 +74,11 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1 -b Release --build_package'
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Release/SGX1/', containerName: 'oejenkins')
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Release/SGX1/', containerName: 'oejenkins')
+            timeout(10) {
+              sh 'bash ./scripts/test-build-config -p SGX1 -b Release --build_package'
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/Release/SGX1/', containerName: 'oejenkins')
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/Release/SGX1/', containerName: 'oejenkins')
+            }
           }
         }
         stage('SGX1 Package RelWithDebInfo') {
@@ -82,9 +89,11 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1 -b RelWithDebInfo --build_package'
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/RelWithDebInfo/SGX1/', containerName: 'oejenkins')
-            azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/RelWithDebInfo/SGX1/', containerName: 'oejenkins')
+            timeout(10) {
+              sh 'bash ./scripts/test-build-config -p SGX1 -b RelWithDebInfo --build_package'
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/${BUILD_NUMBER}/RelWithDebInfo/SGX1/', containerName: 'oejenkins')
+              azureUpload(storageCredentialId: 'oejenkinsciartifacts_storageaccount', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: 'master/latest/RelWithDebInfo/SGX1/', containerName: 'oejenkins')
+            }
           }
         }
       }

--- a/.jenkins/libc_tests.Jenkinsfile
+++ b/.jenkins/libc_tests.Jenkinsfile
@@ -1,8 +1,5 @@
 pipeline {
   agent any
-  options {
-    timeout(time: 30, unit: 'MINUTES')
-  }
   stages {
     stage('Build and Run libc Tests') {
       parallel {
@@ -14,7 +11,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libc_tests --compiler=clang-7'
+            timeout(15) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libc_tests --compiler=clang-7'
+            }
           }
         }
         stage('libc clang-7 Release') {
@@ -25,7 +24,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libc_tests --compiler=clang-7'
+            timeout(15) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libc_tests --compiler=clang-7'
+            }
           }
         }
         stage('libc clang-7 RelWithDebInfo') {
@@ -36,7 +37,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libc_tests --compiler=clang-7'
+            timeout(15) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libc_tests --compiler=clang-7'
+            }
           }
         }
         stage('libc gcc Debug') {
@@ -47,7 +50,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libc_tests --compiler=gcc'
+            timeout(15) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libc_tests --compiler=gcc'
+            }
           }
         }
         stage('libc gcc Release') {
@@ -58,7 +63,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libc_tests --compiler=gcc'
+            timeout(15) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libc_tests --compiler=gcc'
+            }
           }
         }
         stage('libc gcc RelWithDebInfo') {
@@ -69,7 +76,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libc_tests --compiler=gcc'
+            timeout(15) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libc_tests --compiler=gcc'
+            }
           }
         }
       }

--- a/.jenkins/libc_tests.Jenkinsfile
+++ b/.jenkins/libc_tests.Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
   agent any
+  options {
+    timeout(time: 30, unit: 'MINUTES')
+  }
   stages {
     stage('Build and Run libc Tests') {
       parallel {

--- a/.jenkins/libcxx_tests.Jenkinsfile
+++ b/.jenkins/libcxx_tests.Jenkinsfile
@@ -1,8 +1,5 @@
 pipeline {
   agent any
-  options {
-    timeout(time: 3, unit: 'HOURS')
-  }
   stages {
     stage('Build and Run libcxx Tests') {
       parallel {
@@ -14,7 +11,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libcxx_tests --compiler=clang-7'
+            timeout(3) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libcxx_tests --compiler=clang-7'
+            }
           }
         }
         stage('libcxx clang-7 Release') {
@@ -25,7 +24,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libcxx_tests --compiler=clang-7'
+            timeout(3) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libcxx_tests --compiler=clang-7'
+            }
           }
         }
         stage('libcxx clang-7 RelWithDebInfo') {
@@ -36,7 +37,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libcxx_tests --compiler=clang-7'
+            timeout(3) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libcxx_tests --compiler=clang-7'
+            }
           }
         }
         stage('libcxx gcc Debug') {
@@ -47,7 +50,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libcxx_tests --compiler=gcc'
+            timeout(3) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libcxx_tests --compiler=gcc'
+            }
           }
         }
         stage('libcxx gcc Release') {
@@ -58,7 +63,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libcxx_tests --compiler=gcc'
+            timeout(3) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libcxx_tests --compiler=gcc'
+            }
           }
         }
         stage('libcxx gcc RelWithDebInfo') {
@@ -69,7 +76,9 @@ pipeline {
 
           }
           steps {
-            sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libcxx_tests --compiler=gcc'
+            timeout(3) {
+              sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libcxx_tests --compiler=gcc'
+            }
           }
         }
       }

--- a/.jenkins/libcxx_tests.Jenkinsfile
+++ b/.jenkins/libcxx_tests.Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
   agent any
+  options {
+    timeout(time: 3, unit: 'HOURS')
+  }
   stages {
     stage('Build and Run libcxx Tests') {
       parallel {

--- a/bors.toml
+++ b/bors.toml
@@ -2,6 +2,7 @@ status = [ "continuous-integration/jenkins/branch" ]
 pr_status = [ "license/cla" ]
 required_approvals = 1
 delete_merged_branches = true
+timeout_sec = 7200 # two hours
 
 [committer]
 name = "oe-bors[bot]"


### PR DESCRIPTION
The Bors timeout has been upped to 2 hours because it includes the time
for a build to start, which with our bogged CI system can be a while.

The Jenkins timeouts have been set by analyzing the `buildTimeTrend`
report for each build, such that if the timeout is hit, the build was
anomalous. For most builds that means 30 minutes, with the exception of
the slow full C++ tests which is 3 hours. Note that occasionally that
build will "successfully" complete in 4-6 hours, but this should be
considered a failure because it means something hung for a while.