### PR TITLE
Special internal functions for ocall buffer allocation.

### DIFF
--- a/enclave/core/hostcalls.c
+++ b/enclave/core/hostcalls.c
@@ -3,6 +3,7 @@
 
 #include <openenclave/bits/safecrt.h>
 #include <openenclave/bits/safemath.h>
+#include <openenclave/edger8r/enclave.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/calls.h>
 #include <openenclave/internal/enclavelibc.h>
@@ -194,4 +195,16 @@ int oe_host_fprintf(int device, const char* fmt, ...)
     oe_va_end(ap);
 
     return n;
+}
+
+// Function used by oeedger8r for allocating ocall buffers.
+void* oe_allocate_ocall_buffer(size_t size)
+{
+    return oe_host_malloc(size);
+}
+
+// Function used by oeedger8r for freeing ocall buffers.
+void oe_free_ocall_buffer(void* buffer)
+{
+    oe_host_free(buffer);
 }

--- a/include/openenclave/edger8r/enclave.h
+++ b/include/openenclave/edger8r/enclave.h
@@ -28,7 +28,7 @@ OE_EXTERNC_BEGIN
  * The type of a function in ecall function table
  */
 typedef void (*oe_ecall_func_t)(
-    uint8_t* input_buffer,
+    const uint8_t* input_buffer,
     size_t input_buffer_size,
     uint8_t* output_buffer,
     size_t output_buffer_size,
@@ -40,7 +40,11 @@ typedef void (*oe_ecall_func_t)(
  * Call the host function whose matching the given function_id.
  * The host function is expected to have the following signature:
  *
- *     void (*)(void* args);
+ *     void (const uint8_t* input_buffer,
+ *           size_t input_buffer_size,
+ *           uint8_t* output_buffer,
+ *           size_t output_buffer_size,
+ *           size_t* output_bytes_written);
  *
  * Note that the return value of this function only indicates the success of
  * the call and not of the underlying function. The OCALL implementation must
@@ -68,6 +72,25 @@ oe_result_t oe_call_host_function(
     void* output_buffer,
     size_t output_buffer_size,
     size_t* output_bytes_written);
+
+/**
+ * Allocate a buffer of given size for doing an ocall.
+ *
+ * The buffer may or may not be allocated in host memory.
+ * The buffer should be treated as untrusted.
+ *
+ * @param size The size in bytes of the buffer.
+ * @returns pointer to the allocated buffer.
+ * @return NULL if allocation failed.
+ */
+void* oe_allocate_ocall_buffer(size_t size);
+
+/**
+ * Free the buffer allocated for ocalls.
+ *
+ * @param buffer The buffer allocated via oe_allocate_ocall_buffer.
+ */
+void oe_free_ocall_buffer(void* buffer);
 
 /**
  * For hand-written enclaves, that use the older calling mechanism, define empty

--- a/include/openenclave/edger8r/host.h
+++ b/include/openenclave/edger8r/host.h
@@ -31,7 +31,11 @@ OE_EXTERNC_BEGIN
  * Call the enclave function that matches the given function-id.
  * The enclave function is expected to have the following signature:
  *
- *     void (*)(void* args);
+ *     void (const uint8_t* input_buffer,
+ *           size_t input_buffer_size,
+ *           uint8_t* output_buffer,
+ *           size_t output_buffer_size,
+ *           size_t* output_bytes_written);
  *
  * Note that the return value of this function only indicates the success of
  * the call and not of the underlying function. The ECALL implementation must

--- a/include/openenclave/host.h
+++ b/include/openenclave/host.h
@@ -57,7 +57,7 @@ OE_EXTERNC_BEGIN
  * Type of each function in an ocall-table.
  */
 typedef void (*oe_ocall_func_t)(
-    uint8_t* input_buffer,
+    const uint8_t* input_buffer,
     size_t input_buffer_size,
     uint8_t* output_buffer,
     size_t output_buffer_size,

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -698,8 +698,8 @@ let oe_gen_ocall_enclave_wrapper (os:out_channel) (fd:Ast.func_decl) =
   fprintf os "    /* Fill marshaling struct */\n";
   fprintf os "    memset(&_args, 0, sizeof(_args));\n";
   gen_fill_marshal_struct os fd "_args";
-  oe_prepare_input_buffer os fd "oe_host_malloc";
-  fprintf os "    /* Call enclave function */\n";
+  oe_prepare_input_buffer os fd "oe_allocate_ocall_buffer";
+  fprintf os "    /* Call host function */\n";
   fprintf os "    if((_result = oe_call_host_function(\n";
   fprintf os "                        %s,\n" (get_function_id fd);
   fprintf os "                        _input_buffer, _input_buffer_size,\n";
@@ -710,7 +710,7 @@ let oe_gen_ocall_enclave_wrapper (os:out_channel) (fd:Ast.func_decl) =
   fprintf os "    _result = OE_OK;\n";
   fprintf os "done:    \n";
   fprintf os "    if (_buffer)\n";
-  fprintf os "        oe_host_free(_buffer);\n";
+  fprintf os "        oe_free_ocall_buffer(_buffer);\n";
   fprintf os "    return _result;\n";
   fprintf os "}\n\n"
 

--- a/tools/oeedger8r/intel/CodeGen.ml
+++ b/tools/oeedger8r/intel/CodeGen.ml
@@ -823,7 +823,7 @@ let gen_ptr_size (ty: Ast.atype) (pattr: Ast.ptr_attr) (name: string) (get_parm:
           Ast.Ptr ty  -> 
             sprintf "sizeof(%s)" (Ast.get_tystr ty)
         | _ -> 
-          if pattr.pa_isptr then
+          if pattr.Ast.pa_isptr then
             sprintf "sizeof(*%s)" parm_name
           else
             sprintf "sizeof(%s)"  (Ast.get_tystr ty)


### PR DESCRIPTION
1. oe_allocate_ocall_buffer and oe_free_ocall_buffer functions.
2. Edger8r generates calls to these functions.

Additional stuff:
3. constness qualifier added to input_buffer parameter.
4. Comment cleanup.
5. Prevent warning in CodeGen.ml but qualifying with module name  (Ast).