### PR TITLE
Adding enclave tests to Windows CI

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -203,16 +203,69 @@ pipeline {
             }
           }
         }
-        stage('Windows Debug') {
-           agent {
-             node {
-               label 'SGXFLC-Windows'
-             }
+        stage('Windows Debug Crossplat') {
+          stages {
+            stage('Linux SGX1 Debug') {
+              agent {
+                docker {
+                  image 'oetools-azure:1.6'
+                }
 
-           }
-           steps {
-             bat '''mkdir build && cd build && cmake -G "Visual Studio 15 2017 Win64" .. && pushd . && "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\Common7\\Tools\\LaunchDevCmd.bat" && popd && cmake --build . --config Debug && ctest -C Debug'''
-           }
+              }
+              steps {
+                timeout(15) {
+                  sh './scripts/test-build-config -p SGX1FLC -b Debug --compiler=clang-7'
+                  stash includes: 'build/tests/**', name: 'linuxdebug'
+                }
+              }
+            }
+
+            stage('Windows Debug') {
+              agent {
+                node {
+                  label 'SGXFLC-Windows'
+                }
+              }
+
+              steps {
+                unstash 'linuxdebug'
+                bat 'move build linuxbin'
+                bat 'mkdir build && cd build && cmake -G "Visual Studio 15 2017 Win64" -DADD_WINDOWS_ENCLAVE_TESTS=1 -DLINUX_BIN_DIR=%cd%\\linuxbin\\tests .. && pushd . && "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\Common7\\Tools\\LaunchDevCmd.bat" && popd && cmake --build . --config Debug && ctest -V -C Debug'
+              }
+            }
+          }
+        }
+        stage('Windows Release Crossplat') {
+          stages {
+            stage('Linux SGX1 Release') {
+              agent {
+                docker {
+                  image 'oetools-azure:1.6'
+                }
+
+              }
+              steps {
+                timeout(15) {
+                  sh './scripts/test-build-config -p SGX1FLC -b Release --compiler=clang-7'
+                  stash includes: 'build/tests/**', name: 'linuxrelease'
+                }
+              }
+            }
+
+            stage('Windows Release') {
+              agent {
+                node {
+                  label 'SGXFLC-Windows'
+                }
+              }
+
+              steps {
+                unstash 'linuxrelease'
+                bat 'move build linuxbin'
+                bat 'mkdir build && cd build && cmake -G "Visual Studio 15 2017 Win64" -DADD_WINDOWS_ENCLAVE_TESTS=1 -DLINUX_BIN_DIR=%cd%\\linuxbin\\tests .. && pushd . && "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\Common7\\Tools\\LaunchDevCmd.bat" && popd && cmake --build . --config Release && ctest -V -C Release'
+              }
+            }
+          }
         }
       }
     }

--- a/tests/props/enc/props.c
+++ b/tests/props/enc/props.c
@@ -7,6 +7,6 @@ OE_SET_ENCLAVE_SGX(
     1234, /* ProductID */
     5678, /* SecurityVersion */
     true, /* AllowDebug */
-    1024, /* HeapPageCount */
+    512,  /* HeapPageCount */
     512,  /* StackPageCount */
     4);   /* TCSCount */

--- a/tests/props/enc/sign.conf
+++ b/tests/props/enc/sign.conf
@@ -3,8 +3,8 @@
 
 # Enclave settings:
 Debug=1
-NumHeapPages=2048
-NumStackPages=1024
-NumTCS=8
+NumHeapPages=512
+NumStackPages=512
+NumTCS=4
 ProductID=1111
 SecurityVersion=2222

--- a/tests/props/host/host.c
+++ b/tests/props/host/host.c
@@ -136,9 +136,9 @@ int main(int argc, const char* argv[])
             1111,                                        /* product_id */
             2222,                                        /* security_version */
             OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT, /* attributes */
-            2048,                                        /* num_heap_pages  */
-            1024,                                        /* num_stack_pages */
-            8);                                          /* num_tcs */
+            512,                                         /* num_heap_pages  */
+            512,                                         /* num_stack_pages */
+            4);                                          /* num_tcs */
     }
     else
     {
@@ -148,7 +148,7 @@ int main(int argc, const char* argv[])
             1234,                                        /* product_id */
             5678,                                        /* security_version */
             OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT, /* attributes */
-            1024,                                        /* num_heap_pages  */
+            512,                                         /* num_heap_pages  */
             512,                                         /* num_stack_pages */
             4);                                          /* num_tcs */
     }


### PR DESCRIPTION
This enables the building of the OE tests on Linux, copying them to a Windows system, and then running the Windows build with the tests built on Linux.

NOTE: I had to lower the enclave memory requirements to the props test in order for the test to pass on Windows. Please review this change carefully, as I'm not sure how low it should be.