### PR TITLE
Fix #990: Clarify or change result of oe_create_enclave if initialization fails

### DIFF
--- a/host/create.c
+++ b/host/create.c
@@ -457,7 +457,14 @@ static oe_result_t _initialize_enclave(oe_enclave_t* enclave)
     // Pass the enclave handle to the enclave.
     args.enclave = enclave;
 
-    OE_CHECK(oe_ecall(enclave, OE_ECALL_INIT_ENCLAVE, (uint64_t)&args, NULL));
+    {
+        uint64_t arg_out = 0;
+
+        OE_CHECK(
+            oe_ecall(
+                enclave, OE_ECALL_INIT_ENCLAVE, (uint64_t)&args, &arg_out));
+        OE_CHECK(arg_out);
+    }
 
     result = OE_OK;
 

--- a/tests/stdcxx/CMakeLists.txt
+++ b/tests/stdcxx/CMakeLists.txt
@@ -7,4 +7,5 @@ if (UNIX)
 	add_subdirectory(enc)
 endif()
 
-add_enclave_test(tests/stdcxx ./host stdcxx_host ./enc stdcxx_enc)
+add_enclave_test(tests/stdcxx ./host stdcxx_host ./enc stdcxx_enc OE_OK)
+add_enclave_test(tests/global_init_exception ./host stdcxx_host ./enc global_init_exception_enc OE_ENCLAVE_ABORTING)

--- a/tests/stdcxx/enc/CMakeLists.txt
+++ b/tests/stdcxx/enc/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 include(add_enclave_executable)
 add_executable(stdcxx_enc enc.cpp f.cpp)
+add_executable(global_init_exception_enc global_init_exception.cpp)
 
 target_compile_options(stdcxx_enc PRIVATE
     -fno-builtin-strcpy
@@ -15,3 +16,4 @@ target_compile_options(stdcxx_enc PRIVATE
     )
 
 target_link_libraries(stdcxx_enc oelibcxx oeenclave)
+target_link_libraries(global_init_exception_enc oelibcxx oeenclave)

--- a/tests/stdcxx/enc/global_init_exception.cpp
+++ b/tests/stdcxx/enc/global_init_exception.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/edger8r/enclave.h>
+#include <openenclave/enclave.h>
+#include <stdio.h>
+#include <stdexcept>
+
+/* This test is to check that oe_create_enclave does not return success
+   when enclave initialisation fails */
+
+class Foo
+{
+  public:
+    Foo()
+    {
+        throw std::runtime_error("Aborting..");
+    }
+};
+
+Foo f;
+
+OE_ECALL void foo()
+{
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* AllowDebug */
+    1024, /* HeapPageCount */
+    1024, /* StackPageCount */
+    2);   /* TCSCount */
+
+OE_DEFINE_EMPTY_ECALL_TABLE();

--- a/tests/stdcxx/host/host.cpp
+++ b/tests/stdcxx/host/host.cpp
@@ -35,35 +35,52 @@ int main(int argc, const char* argv[])
     oe_result_t result;
     oe_enclave_t* enclave = NULL;
 
-    if (argc != 2)
+    if (argc != 3)
     {
-        fprintf(stderr, "Usage: %s ENCLAVE\n", argv[0]);
+        fprintf(
+            stderr,
+            "Usage: %s ENCLAVE_PATH OE_OK/OE_ENCLAVE_ABORTING\n",
+            argv[0]);
         exit(1);
     }
 
     const uint32_t flags = oe_get_create_flags();
 
-    if ((result = oe_create_enclave(
-             argv[1],
-             OE_ENCLAVE_TYPE_SGX,
-             flags,
-             NULL,
-             0,
-             NULL,
-             0,
-             &enclave)) != OE_OK)
+    result = oe_create_enclave(
+        argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, NULL, 0, &enclave);
+
+    if (strcmp(argv[2], oe_result_str(OE_ENCLAVE_ABORTING)) == 0)
     {
+        if (strcmp(oe_result_str(result), argv[2]) == 0)
+        {
+            printf(
+                "=== Passed: enclave not created, enclave status: (%s)\n",
+                oe_result_str(result));
+            goto done;
+        }
         oe_put_err("oe_create_enclave(): result=%u", result);
     }
-
-    TestStdcxx(enclave);
-
-    if ((result = oe_terminate_enclave(enclave)) != OE_OK)
+    else if (strcmp(argv[2], oe_result_str(OE_OK)) == 0)
     {
-        oe_put_err("oe_terminate_enclave(): result=%u", result);
+        if (strcmp(oe_result_str(result), argv[2]) == 0)
+        {
+            TestStdcxx(enclave);
+            printf("=== passed all tests (%s)\n", argv[0]);
+            goto done;
+        }
+        oe_put_err("oe_create_enclave(): result=%u", result);
     }
+    else
+        oe_put_err("Invalid argument: %s", argv[2]);
 
-    printf("=== passed all tests (%s)\n", argv[0]);
+done:
+    if (enclave)
+    {
+        if ((result = oe_terminate_enclave(enclave)) != OE_OK)
+        {
+            oe_put_err("oe_terminate_enclave(): result=%u", result);
+        }
+    }
 
     return 0;
 }


### PR DESCRIPTION
 The `arg_out` output parameter is not checked in the enclave initialisation ecall. As a result the failure to initialise is detected only in subsequent ecall, where the `arg_out` parameter is checked. Added `OE_CHECK` for `arg_out` for the `OE_ECALL_INIT_ENCLAVE` ecall.