### PR TITLE
Added non-simulation container builds for hardware with SGX1+FLC.

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -43,14 +43,17 @@
 FROM ubuntu:16.04
 
 RUN \
-  apt-get update && apt-get install --no-install-recommends -y wget ca-certificates \
+  apt-get update && apt-get install --no-install-recommends -y wget ca-certificates apt-transport-https \
   # Install the LLVM 7 toolchain repo.
-  && echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" >> /etc/apt/sources.list.d/llvm-toolchain-xenial-7.list \
-  && echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" >> /etc/apt/sources.list.d/llvm-toolchain-xenial-7.list \
-  && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+  && echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu xenial main' | tee /etc/apt/sources.list.d/intel-sgx.list \
+  && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
+  && echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" | tee /etc/apt/sources.list.d/llvm-toolchain-xenial-7.list \
+  && wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+  && echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/prod xenial main" | tee /etc/apt/sources.list.d/msprod.list \
+  && wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && apt-get update \
   # Install Clang 7 to build with Spectre mitigation.
-  && apt-get install --no-install-recommends -y clang-7 lldb-7 lld-7 \
+  && apt-get install --no-install-recommends -y clang-7 \
   # Install all the packages specified in install-prereqs except CMake.
   && apt-get install --no-install-recommends -y \
   # Please keep these sorted alphabetically.
@@ -79,36 +82,19 @@ RUN \
   shellcheck \
   subversion \
   sudo \
+  libsgx-enclave-common \
+  libsgx-enclave-common-dev \
+  libsgx-dcap-ql \
+  libsgx-dcap-ql-dev \
+  az-dcap-client \
   && rm -rf /var/lib/apt/lists/*
 
 # Install packages not available in repositories.
-ARG webserver=10.31.100.105
 RUN \
   # Install CMake 3.12 so that skipped tests are not marked as failures.
   wget https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.tar.gz \
   && tar xf cmake-3.12.2-Linux-x86_64.tar.gz \
-  && rm cmake-3.12.2-Linux-x86_64.tar.gz \
-  # Install the Intel DCAP dependencies.
-  && wget https://download.01.org/intel-sgx/dcap-1.0/SGX_installers/ubuntu16.04/libsgx-enclave-common_2.3.100.46354-1_amd64.deb \
-  && dpkg -i libsgx-enclave-common_2.3.100.46354-1_amd64.deb \
-  && rm      libsgx-enclave-common_2.3.100.46354-1_amd64.deb \
-  && wget https://download.01.org/intel-sgx/sgx_repo/ubuntu/pool/main/libs/libsgx-enclave-common-dev/libsgx-enclave-common-dev_2.3.100.0-1_amd64.deb \
-  && dpkg -i libsgx-enclave-common-dev_2.3.100.0-1_amd64.deb \
-  && rm      libsgx-enclave-common-dev_2.3.100.0-1_amd64.deb \
-  && wget https://download.01.org/intel-sgx/dcap-1.0/DCAP_installers/ubuntu16.04/libsgx-dcap-ql_1.0.100.46460-1.0_amd64.deb \
-  && dpkg -i libsgx-dcap-ql_1.0.100.46460-1.0_amd64.deb \
-  && rm      libsgx-dcap-ql_1.0.100.46460-1.0_amd64.deb \
-  && wget https://download.01.org/intel-sgx/dcap-1.0/DCAP_installers/ubuntu16.04/libsgx-dcap-ql-dev_1.0.100.46460-1.0_amd64.deb \
-  && dpkg -i libsgx-dcap-ql-dev_1.0.100.46460-1.0_amd64.deb \
-  && rm      libsgx-dcap-ql-dev_1.0.100.46460-1.0_amd64.deb \
-  && wget https://download.01.org/intel-sgx/dcap-1.0/sgx_linux_x64_driver_dcap_36594a7.bin -O sgx_linux_x64_driver.bin \
-  && chmod +x sgx_linux_x64_driver.bin \
-  && mkdir -p /opt/bits \
-  && mv       sgx_linux_x64_driver.bin /opt/bits \
-  # Install the Azure Quote Provider package.
-  && wget http://$webserver/azquotprov_0.3-1_amd64.deb \
-  && dpkg -i azquotprov_0.3-1_amd64.deb \
-  && rm      azquotprov_0.3-1_amd64.deb
+  && rm cmake-3.12.2-Linux-x86_64.tar.gz 
 
 ENV PATH="/cmake-3.12.2-Linux-x86_64/bin:${PATH}"
 

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -249,7 +249,7 @@ pipeline {
             }
           }
         }
-        stage('Coffeelake Container SGX1-FLC RelWithDebInfo') {
+        stage('Non-Simulation Container SGX1-FLC RelWithDebInfo') {
           agent {
             docker {
               image 'oetools-azure:1.7'
@@ -260,7 +260,6 @@ pipeline {
 
           steps {
             timeout(15) {
-              sh 'ls -l /dev'
               sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d'
             }
           }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         stage('Check pre-commit requirements') {
           agent {
             docker {
-              image 'oetools-azure:1.6'
+              image 'oetools-azure:1.7'
             }
           }
           steps {
@@ -50,7 +50,7 @@ pipeline {
         stage('Simulation clang-7 SGX1 Debug') {
           agent {
             docker {
-              image 'oetools-azure:1.6'
+              image 'oetools-azure:1.7'
             }
           }
           steps {
@@ -62,7 +62,7 @@ pipeline {
         stage('Simulation clang-7 SGX1 Release') {
           agent {
             docker {
-              image 'oetools-azure:1.6'
+              image 'oetools-azure:1.7'
             }
           }
           steps {
@@ -74,7 +74,7 @@ pipeline {
         stage('Simulation clang-7 SGX1 RelWithDebInfo') {
           agent {
             docker {
-              image 'oetools-azure:1.6'
+              image 'oetools-azure:1.7'
             }
           }
           steps {
@@ -86,7 +86,7 @@ pipeline {
         stage('Simulation clang-7 SGX1-FLC Debug') {
           agent {
             docker {
-              image 'oetools-azure:1.6'
+              image 'oetools-azure:1.7'
             }
           }
           steps {
@@ -98,7 +98,7 @@ pipeline {
         stage('Simulation clang-7 SGX1-FLC Release') {
           agent {
             docker {
-              image 'oetools-azure:1.6'
+              image 'oetools-azure:1.7'
             }
           }
           steps {
@@ -110,7 +110,7 @@ pipeline {
         stage('Simulation clang-7 SGX1-FLC RelWithDebInfo') {
           agent {
             docker {
-              image 'oetools-azure:1.6'
+              image 'oetools-azure:1.7'
             }
           }
           steps {
@@ -196,7 +196,7 @@ pipeline {
             stage('Linux SGX1 Debug') {
               agent {
                 docker {
-                  image 'oetools-azure:1.6'
+                  image 'oetools-azure:1.7'
                 }
               }
               steps {
@@ -225,7 +225,7 @@ pipeline {
             stage('Linux SGX1 Release') {
               agent {
                 docker {
-                  image 'oetools-azure:1.6'
+                  image 'oetools-azure:1.7'
                 }
               }
               steps {
@@ -249,7 +249,25 @@ pipeline {
             }
           }
         }
+        stage('Coffeelake Container SGX1-FLC RelWithDebInfo') {
+          agent {
+            docker {
+              image 'oetools-azure:1.7'
+              label 'hardware'
+              args '--privileged -v /dev/sgx:/dev/sgx'
+            }
+          }
+
+          steps {
+            timeout(15) {
+              sh 'ls -l /dev'
+              sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d'
+            }
+          }
+        }
       }
     }
   }
 }
+
+


### PR DESCRIPTION
This adds one non-simulation mode container build to the CI and updates the Dockerfile to pull the intel/dcap packages from apt repos instead of URLs.

We could add Debug and Release builds as well, but I just don't want to overstress our CI systems so I didn't include them in the PR. What do you think?