### PR TITLE
Enable unused command line arg errors for C++, disable for ASM

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -67,10 +67,8 @@ else ()
 endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # Disable this particular warning because `-isystem` is being to
-  # sent to clang when assembling, and is at that point unrecognized.
-  # TODO: See #760: Fix this when errors are better propagated.
-  add_compile_options(-Wno-error=unused-command-line-argument)
+  # While compiling ASM files, suppress unused command line argument errors.
+  add_compile_options($<$<COMPILE_LANGUAGE:ASM>:-Wno-error=unused-command-line-argument>)
 endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)


### PR DESCRIPTION
I fixed this using $<COMPILE_LANGUAGE:lang> generator expression to scope -Wunused-command-line-argument while compiling ASM.