### PR TITLE
Test to verify TCS exhaustion to address missing thread binding coverage 

### DIFF
--- a/tests/thread/args.h
+++ b/tests/thread/args.h
@@ -38,10 +38,10 @@ typedef struct _test_rwlock_args
 
 typedef struct _test_tcs_args
 {
-    // The number of threads
-    size_t num_threads;
-    // Number of TCSes
-    size_t tcs_count;
+    // Counter to keep track of the tcs bindings that are used
+    size_t num_tcs_used;
+    // Number of total thread bindings requested
+    size_t tcs_req_count;
     // Number of times oe_call_enclave returned OE_OUT_OF_THREADS
     size_t num_out_threads;
 } TestTCSArgs;

--- a/tests/thread/args.h
+++ b/tests/thread/args.h
@@ -36,4 +36,14 @@ typedef struct _test_rwlock_args
     bool readers_and_writers;
 } TestRWLockArgs;
 
+typedef struct _test_tcs_args
+{
+    // The number of threads
+    size_t num_threads;
+    // Number of TCSes
+    size_t tcs_count;
+    // Number of times oe_call_enclave returned OE_OUT_OF_THREADS
+    size_t num_out_threads;
+} TestTCSArgs;
+
 #endif /* _stdc_args_h */

--- a/tests/thread/host/host.cpp
+++ b/tests/thread/host/host.cpp
@@ -244,14 +244,9 @@ void* ThreadTCS(void* args)
     oe_result_t result =
         oe_call_enclave(enclave, "TestTCSExhaustion", &_tcsargs);
     if (result == OE_OUT_OF_THREADS)
-    {
         _tcsargs.num_out_threads++;
-    }
     else
-    {
-        printf("ThreadTCS() - result str is %s\n", oe_result_str(result));
         OE_TEST(result == OE_OK);
-    }
 
     return NULL;
 }

--- a/tests/thread/host/host.cpp
+++ b/tests/thread/host/host.cpp
@@ -4,6 +4,7 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/tests.h>
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cstdio>
@@ -11,7 +12,6 @@
 #include <cstring>
 #include <thread>
 #include <vector>
-#include <atomic>
 #include "../../../host/enclave.h"
 #include "../args.h"
 
@@ -355,7 +355,7 @@ int main(int argc, const char* argv[])
 
     TestThreadLockingPatterns(enclave);
 
-    TestReadersWriterLock(enclave); 
+    TestReadersWriterLock(enclave);
 
     TestTCSExhaustion(enclave);
 

--- a/tests/thread/host/host.cpp
+++ b/tests/thread/host/host.cpp
@@ -4,7 +4,6 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
 #include <openenclave/internal/tests.h>
-#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cstdio>
@@ -12,6 +11,7 @@
 #include <cstring>
 #include <thread>
 #include <vector>
+#include <atomic>
 #include "../../../host/enclave.h"
 #include "../args.h"
 
@@ -345,7 +345,7 @@ int main(int argc, const char* argv[])
         oe_put_err("oe_create_enclave(): result=%u", result);
     }
 
-    /* TestMutex(enclave);
+    TestMutex(enclave);
 
     TestCond(enclave);
 
@@ -355,7 +355,7 @@ int main(int argc, const char* argv[])
 
     TestThreadLockingPatterns(enclave);
 
-    TestReadersWriterLock(enclave); */
+    TestReadersWriterLock(enclave); 
 
     TestTCSExhaustion(enclave);
 

--- a/tests/thread/host/host.cpp
+++ b/tests/thread/host/host.cpp
@@ -10,9 +10,12 @@
 #include <cstdlib>
 #include <cstring>
 #include <thread>
+#include <vector>
+#include "../../../host/enclave.h"
 #include "../args.h"
 
 static TestMutexArgs _args;
+static TestTCSArgs _tcsargs;
 
 const size_t NUM_THREADS = 8;
 
@@ -45,9 +48,9 @@ void TestMutex(oe_enclave_t* enclave)
 void* WaiterThread(void* args)
 {
     oe_enclave_t* enclave = (oe_enclave_t*)args;
-    static WaitArgs _args = {NUM_THREADS};
+    static WaitArgs _waitargs = {NUM_THREADS};
 
-    oe_result_t result = oe_call_enclave(enclave, "Wait", &_args);
+    oe_result_t result = oe_call_enclave(enclave, "Wait", &_waitargs);
     OE_TEST(result == OE_OK);
 
     return NULL;
@@ -63,7 +66,9 @@ void TestCond(oe_enclave_t* enclave)
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
     for (size_t i = 0; i < NUM_THREADS; i++)
+    {
         OE_TEST(oe_call_enclave(enclave, "Signal", NULL) == OE_OK);
+    }
 
     for (size_t i = 0; i < NUM_THREADS; i++)
         threads[i].join();
@@ -232,6 +237,76 @@ void TestThreadLockingPatterns(oe_enclave_t* enclave)
 
 void TestReadersWriterLock(oe_enclave_t* enclave);
 
+void* ThreadTCS(void* args)
+{
+    oe_enclave_t* enclave = (oe_enclave_t*)args;
+
+    oe_result_t result =
+        oe_call_enclave(enclave, "TestTCSExhaustion", &_tcsargs);
+    if (result == OE_OUT_OF_THREADS)
+    {
+        _tcsargs.num_out_threads++;
+    }
+    else
+    {
+        printf("ThreadTCS() - result str is %s\n", oe_result_str(result));
+        OE_TEST(result == OE_OK);
+    }
+
+    return NULL;
+}
+
+// Thread binding test to verify TCS exhaustion i.e. enter on N threads when
+// there are M TCSes where N > M; oe_call should return OE_OUT_OF_THREADS when
+// M enclaves are in use.
+// Trick is to keep the M enclaves busy until we get TCS exhaustion
+void TestTCSExhaustion(oe_enclave_t* enclave)
+{
+    std::vector<std::thread> threads;
+    // Set the test_tcs_count to a value greater than the enclave TCSCount
+    size_t test_tcs_count = enclave->num_bindings * 3;
+    printf(
+        "TestTCSExhaust() - Number of TCS bindings in enclave=%zu\n",
+        enclave->num_bindings);
+    // Initialization of the shared variables before creating threads/launching
+    // enclaves
+    _tcsargs.num_threads = 0;
+    _tcsargs.num_out_threads = 0;
+    _tcsargs.tcs_count = test_tcs_count;
+
+    for (size_t i = 0; i < test_tcs_count; i++)
+    {
+        threads.push_back(std::thread(ThreadTCS, enclave));
+    }
+
+    for (size_t i = 0; i < test_tcs_count; i++)
+        threads[i].join();
+
+    printf(
+        "TestTCSExhaustion(): tcs_count=%d; num_threads=%d; "
+        "num_out_threads=%d\n",
+        (int)test_tcs_count,
+        (int)_tcsargs.num_threads,
+        (int)(int)_tcsargs.num_out_threads);
+    if (!_tcsargs.num_out_threads)
+        printf(
+            "TestTCSExhaustion() FAILED as oe_call_enclave did not return "
+            "OE_OUT_OF_THREADS\n");
+    else
+        printf(
+            "TestTCSExhaustion() PASSED as oe_call_enclave returned "
+            "OE_OUT_OF_THREADS\n");
+
+    // Cleanup -- Removes all elements from the vector threads
+    threads.clear();
+    // Crux of the test is to get OE_OUT_OF_THREADS i.e. to exhaust the TCSes
+    OE_TEST(_tcsargs.num_out_threads > 0);
+    // Verifying that everything adds up fine
+    OE_TEST(_tcsargs.num_threads + _tcsargs.num_out_threads == test_tcs_count);
+    // Sanity test that we are not reusing the bindings
+    OE_TEST(_tcsargs.num_threads <= enclave->num_bindings);
+}
+
 int main(int argc, const char* argv[])
 {
     oe_result_t result;
@@ -269,6 +344,8 @@ int main(int argc, const char* argv[])
     TestThreadLockingPatterns(enclave);
 
     TestReadersWriterLock(enclave);
+
+    TestTCSExhaustion(enclave);
 
     if ((result = oe_terminate_enclave(enclave)) != OE_OK)
     {

--- a/tests/thread/oethread_enc/enc.cpp
+++ b/tests/thread/oethread_enc/enc.cpp
@@ -248,14 +248,12 @@ OE_ECALL void LockAndUnlockMutexes(void* arg)
 // Keep the enclave busy until we get TCS exhaustion
 OE_ECALL void TestTCSExhaustion(void* args_)
 {
-    TestTCSArgs* args = (TestTCSArgs*)args_;
+    TestTCSArgs* volatile args = (TestTCSArgs*)args_;
     static oe_spinlock_t _tcs_lock = OE_SPINLOCK_INITIALIZER;
 
     // Increment the number of threads only on getting the _tcs_lock
     oe_spin_lock(&_tcs_lock);
     args->num_threads++;
-    // oe_host_printf("Enclave TestTCSExhaust(): %lld num_threads=%zu\n",
-    // OE_LLU(oe_thread_self()), args->num_threads);
     oe_spin_unlock(&_tcs_lock);
     while (args->num_threads + args->num_out_threads < args->tcs_count)
         ;

--- a/tests/thread/oethread_enc/enc.cpp
+++ b/tests/thread/oethread_enc/enc.cpp
@@ -253,9 +253,12 @@ OE_ECALL void TestTCSExhaustion(void* args_)
 
     // Increment the number of threads only on getting the _tcs_lock
     oe_spin_lock(&_tcs_lock);
-    args->num_threads++;
+    args->num_tcs_used++;
     oe_spin_unlock(&_tcs_lock);
-    while (args->num_threads + args->num_out_threads < args->tcs_count)
+    // Wait until all the threads have returned from oe_call_enclave from
+    // the host - these include those with unique TCSes and the ones
+    // which failed.
+    while (args->num_tcs_used + args->num_out_threads < args->tcs_req_count)
         ;
 }
 

--- a/tests/thread/oethread_enc/enc.cpp
+++ b/tests/thread/oethread_enc/enc.cpp
@@ -245,6 +245,22 @@ OE_ECALL void LockAndUnlockMutexes(void* arg)
     }
 }
 
+// Keep the enclave busy until we get TCS exhaustion
+OE_ECALL void TestTCSExhaustion(void* args_)
+{
+    TestTCSArgs* args = (TestTCSArgs*)args_;
+    static oe_spinlock_t _tcs_lock = OE_SPINLOCK_INITIALIZER;
+
+    // Increment the number of threads only on getting the _tcs_lock
+    oe_spin_lock(&_tcs_lock);
+    args->num_threads++;
+    // oe_host_printf("Enclave TestTCSExhaust(): %lld num_threads=%zu\n",
+    // OE_LLU(oe_thread_self()), args->num_threads);
+    oe_spin_unlock(&_tcs_lock);
+    while (args->num_threads + args->num_out_threads < args->tcs_count)
+        ;
+}
+
 OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */


### PR DESCRIPTION
New thread binding test coverage to verify TCS exhaustion i.e. enter on N threads when there are M TCSes where N > M 
oe_call should return OE_OUT_OF_THREADS when M enclaves are in use.
Trick is to keep the M enclaves busy until we get TCS exhaustion and run out of all the threads.
This was mentioned in Issue #24 