### PR TITLE
Remove failFast flag from Jenkins Pipeline.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -2,7 +2,6 @@ pipeline {
   agent any
   stages {
     stage('Build and Test') {
-      failFast true
       parallel {
         stage('Check pre-commit requirements') {
           agent {


### PR DESCRIPTION
Due to popular demand from the developers, we will be removing this flag from the Jenkins pipeline.