### PR TITLE
Clean up OE_USE_LIBSGX

### DIFF
--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -30,10 +30,6 @@ if(CMAKE_C_COMPILER_ID MATCHES GNU)
 target_compile_options(oeenclave PRIVATE -Wjump-misses-init)
 endif()
 
-if(USE_LIBSGX)
-target_compile_definitions(oeenclave PUBLIC OE_USE_LIBSGX)
-endif()    
-
 target_link_libraries(oeenclave PUBLIC
     mbedcrypto
     oelibc)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -115,7 +115,6 @@ find_library(LIBSGX_COMMON NAMES sgx_enclave_common)
 find_library(LIBSGX_QE NAMES sgx_dcap_ql)
 find_library(LIBSGX_URTS NAMES sgx_urts)
 target_link_libraries(oehost PUBLIC ${LIBSGX_COMMON} ${LIBSGX_QE} ${LIBSGX_URTS})
-target_compile_definitions(oehost PRIVATE OE_USE_LIBSGX)
 endif()
 
 if(OE_TRACE_LEVEL)
@@ -124,6 +123,10 @@ endif()
 
 if(USE_DEBUG_MALLOC)
 target_compile_definitions(oehost PRIVATE OE_USE_DEBUG_MALLOC)
+endif()
+
+if(USE_LIBSGX)
+    target_compile_definitions(oehost PUBLIC OE_USE_LIBSGX)
 endif()
 
 # convenience library for creating a host-app (that needs the -rdynamic link flag)

--- a/tests/aesm/CMakeLists.txt
+++ b/tests/aesm/CMakeLists.txt
@@ -4,10 +4,5 @@
 add_executable(aesm main.cpp)
 target_link_libraries(aesm oehost)
 
-# Additional compilation options when using libsgx instead of AESM
-if(USE_LIBSGX)
-target_compile_definitions(aesm PRIVATE OE_USE_LIBSGX)
-endif()
-
 add_test(NAME tests/aesm COMMAND ./aesm)
 set_tests_properties(tests/aesm PROPERTIES SKIP_RETURN_CODE 2)

--- a/tests/debug-mode/host/CMakeLists.txt
+++ b/tests/debug-mode/host/CMakeLists.txt
@@ -3,8 +3,4 @@
 
 add_executable(debug_host host.c)
 
-if(USE_LIBSGX)
-    target_compile_definitions(debug_host PRIVATE OE_USE_LIBSGX)
-endif()
-
 target_link_libraries(debug_host oehostapp)

--- a/tests/report/enc/CMakeLists.txt
+++ b/tests/report/enc/CMakeLists.txt
@@ -11,9 +11,5 @@ target_compile_options(report_enc PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:-std=c++11>
 )
 
-if(USE_LIBSGX)
-    target_compile_definitions(report_enc PRIVATE OE_USE_LIBSGX)
-endif()    
-
 target_include_directories(report_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../common)
 target_link_libraries(report_enc oeenclave)


### PR DESCRIPTION
This is now on just `oehost` and `oecore`, and propogates up the graph transitively.

This resolves #969.