### PR TITLE
Enable race_condition test that uses pthread_create/join

### DIFF
--- a/tests/libcxx/tests.supported
+++ b/tests/libcxx/tests.supported
@@ -4718,3 +4718,4 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.assign/move2.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.assign/move.pass.cpp
+../../3rdparty/libcxx/libcxx/test/libcxx/utilities/memory/util.smartptr/race_condition.pass.cpp

--- a/tests/libcxx/tests.supported.default
+++ b/tests/libcxx/tests.supported.default
@@ -42,3 +42,4 @@
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/lock_shared.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.locking/lock.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.member/join.pass.cpp
+../../3rdparty/libcxx/libcxx/test/libcxx/utilities/memory/util.smartptr/race_condition.pass.cpp

--- a/tests/libcxx/tests.unsupported
+++ b/tests/libcxx/tests.unsupported
@@ -22,7 +22,6 @@
 ../../3rdparty/libcxx/libcxx/test/libcxx/thread/thread.threads/thread.thread.this/sleep_for.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/utilities/any/size_and_alignment.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/utilities/any/small_type.pass.cpp
-../../3rdparty/libcxx/libcxx/test/libcxx/utilities/memory/util.smartptr/race_condition.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/utilities/optional/optional.object/optional.object.assign/copy.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/utilities/optional/optional.object/optional.object.assign/move.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/utilities/optional/optional.object/optional.object.ctor/copy.pass.cpp


### PR DESCRIPTION
Since pthread_create/join hooks/shimmer has been implemented in tests/libcxx, able to enable one more test (Was marked broken in #151 and then moved to tests.unsupported).