### PR TITLE
Add two more libcxx tests that build with clang

### DIFF
--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 foreach(testcase ${alltests})
     get_testcase_name(${testcase} name "../../3rdparty/libcxx/libcxx/test/")
 
-# the allocations are entirely optimized out by Clang in these tests and are excluded from Clang release builds
+# the allocations are entirely optimized out by Clang in these tests and are excluded from Clang release builds -- Skip running these tests
     if ("${name}" MATCHES "cons_default_throws_bad_alloc.pass" OR "${name}" MATCHES "allocator_allocator.members_construct.pass")
         string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
         if (CMAKE_CXX_COMPILER_ID MATCHES Clang AND BUILD_TYPE_UPPER MATCHES REL)
@@ -28,10 +28,12 @@ foreach(testcase ${alltests})
         endif()
     endif()
 
-# few functions invoked in these tests are not considered const expression in gnu
-    if ("${name}" MATCHES "convert_file_time.sh" OR "${name}" MATCHES "sequences_array_at.pass")
-	if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-	    continue()
+# few functions invoked in these tests are not supported in gnu -- Skip running these tests
+    if ("${name}" MATCHES "convert_file_time.sh" OR "${name}" MATCHES "sequences_array_at.pass" 
+            OR "${name}" MATCHES "libcxx_containers_unord_next_pow2.pass" 
+            OR "${name}" MATCHES "std_utilities_template.bitset_bitset.members_count.pass")
+	    if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
+	        continue()
         endif()
     endif()
 

--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -29,7 +29,8 @@ foreach(testcase ${alltests})
     endif()
 
 # few functions invoked in these tests are not supported in gnu -- Skip running these tests
-    if ("${name}" MATCHES "convert_file_time.sh" OR "${name}" MATCHES "sequences_array_at.pass" 
+    if ("${name}" MATCHES "convert_file_time.sh" 
+            OR "${name}" MATCHES "sequences_array_at.pass" 
             OR "${name}" MATCHES "libcxx_containers_unord_next_pow2.pass" 
             OR "${name}" MATCHES "std_utilities_template.bitset_bitset.members_count.pass")
 	    if (CMAKE_CXX_COMPILER_ID MATCHES GNU)

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -79,10 +79,12 @@ foreach(testcase ${alltests})
 	endif()
     endif()
 
-# few functions invoked in these tests are not considered const expression in gnu
-    if ("${name}" MATCHES "convert_file_time.sh" OR "${name}" MATCHES "sequences_array_at.pass")
-	if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-	    continue()
+# few functions invoked in these tests are not supported in gnu and excluded from GCC builds
+    if ("${name}" MATCHES "convert_file_time.sh" OR "${name}" MATCHES "sequences_array_at.pass" 
+        OR "${name}" MATCHES "libcxx_containers_unord_next_pow2.pass" 
+        OR "${name}" MATCHES "std_utilities_template.bitset_bitset.members_count.pass")
+	    if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
+	        continue()
         endif()
     endif()
 

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -80,12 +80,13 @@ foreach(testcase ${alltests})
     endif()
 
 # few functions invoked in these tests are not supported in gnu and excluded from GCC builds
-    if ("${name}" MATCHES "convert_file_time.sh" OR "${name}" MATCHES "sequences_array_at.pass" 
-        OR "${name}" MATCHES "libcxx_containers_unord_next_pow2.pass" 
-        OR "${name}" MATCHES "std_utilities_template.bitset_bitset.members_count.pass")
-	    if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    if ("${name}" MATCHES "convert_file_time.sh" 
+            OR "${name}" MATCHES "sequences_array_at.pass" 
+            OR "${name}" MATCHES "libcxx_containers_unord_next_pow2.pass" 
+            OR "${name}" MATCHES "std_utilities_template.bitset_bitset.members_count.pass")
+            if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
 	        continue()
-        endif()
+            endif()
     endif()
 
     add_libcxx_test_enc("${name}" "${testcase}")

--- a/tests/libcxx/tests.supported
+++ b/tests/libcxx/tests.supported
@@ -59,6 +59,7 @@
 ../../3rdparty/libcxx/libcxx/test/libcxx/containers/sequences/vector/db_iterators_8.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/containers/sequences/vector/version.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/containers/unord/key_value_traits.pass.cpp
+../../3rdparty/libcxx/libcxx/test/libcxx/containers/unord/next_pow2.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/containers/unord/next_prime.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/containers/unord/unord.map/db_iterators_7.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/containers/unord/unord.map/db_iterators_8.pass.cpp
@@ -4440,6 +4441,7 @@
 ../../3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.hash/enabled_hash.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.members/all.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.members/any.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.members/count.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.members/flip_all.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.members/flip_one.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.members/index_const.pass.cpp

--- a/tests/libcxx/tests.supported.default
+++ b/tests/libcxx/tests.supported.default
@@ -1,3 +1,5 @@
+../../3rdparty/libcxx/libcxx/test/libcxx/containers/unord/next_pow2.pass.cpp
+../../3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.members/count.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/depr/depr.c.headers/complex.h.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/input.output/file.streams/c.files/version_ccstdio.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/input.output/file.streams/fstreams/version.pass.cpp

--- a/tests/libcxx/tests.unsupported
+++ b/tests/libcxx/tests.unsupported
@@ -1,5 +1,4 @@
 ../../3rdparty/libcxx/libcxx/test/libcxx/atomics/atomics.align/align.pass.sh.cpp
-../../3rdparty/libcxx/libcxx/test/libcxx/containers/unord/next_pow2.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/debug/containers/db_associative_container_tests.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/debug/containers/db_sequence_container_iterators.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/libcxx/debug/containers/db_string.pass.cpp
@@ -616,7 +615,6 @@
 ../../3rdparty/libcxx/libcxx/test/std/utilities/optional/optional.specalg/make_optional.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/optional/optional.specalg/swap.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/optional/optional.syn/optional_includes_initializer_list.pass.cpp
-../../3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.members/count.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/time/time.clock/time.clock.hires/now.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/time/time.clock/time.clock.steady/now.pass.cpp
 ../../3rdparty/libcxx/libcxx/test/std/utilities/time/time.duration/time.duration.alg/abs.pass.cpp


### PR DESCRIPTION
Enabled 2 libcxx tests to build and PASS with clang. These were unsupported earlier as they do not build with GCC due to invoking unsupported functions.
3rdparty/libcxx/libcxx/test/libcxx/containers/unord/next_pow2.pass.cpp
3rdparty/libcxx/libcxx/test/std/utilities/template.bitset/bitset.members/count.pass.cp