### PR TITLE
Create _v2 of APIs that have bad calling style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Both GNU __thread and C++11 thread_local
    - Both hardware and simulation mode 
    - Local-Exec and Initial-Exec thread-local storage models
+- Added v2 versions of the following APIs that instead of passing in buffers now
+  return a buffer that needs to be freed via an associated free method. OE_API_VERSION
+  needs to be set to 2 to pick up the versions. The mentioned APIs have a *_V1 and *_V2
+  version that the below versions map to detending on the OE_API_VERSION.
+   - oe_get_report, free report buffer via oe_free_report
+   - oe_get_target_info, free target_info_buffer via oe_free_target_info
+   - oe_get_seal_key, free key_buffer and key_info via oe_free_seal_key
+   - oe_get_seal_key_by_policy, free key_buffer and key_info via oe_free_seal_key
 
 ### Changed
 

--- a/common/sgx/report.c
+++ b/common/sgx/report.c
@@ -158,7 +158,7 @@ done:
     return result;
 }
 
-oe_result_t oe_get_target_info(
+oe_result_t oe_get_target_info_v1(
     const uint8_t* report,
     size_t report_size,
     void* target_info_buffer,
@@ -192,4 +192,57 @@ oe_result_t oe_get_target_info(
 
 done:
     return result;
+}
+
+oe_result_t oe_get_target_info_v2(
+    const uint8_t* report,
+    size_t report_size,
+    void** target_info_buffer,
+    size_t* target_info_size)
+{
+    oe_result_t result = OE_FAILURE;
+    size_t temp_size = 0;
+    void* temp_info = NULL;
+
+    if (!target_info_buffer || !target_info_size)
+    {
+        return OE_INVALID_PARAMETER;
+    }
+
+    *target_info_buffer = NULL;
+    *target_info_size = 0;
+
+    result = oe_get_target_info_v1(report, report_size, NULL, &temp_size);
+    if (result != OE_BUFFER_TOO_SMALL)
+    {
+        if (result == OE_OK)
+        {
+            /* Should not succeed! */
+            result = OE_UNEXPECTED;
+        }
+        return result;
+    }
+
+    temp_info = malloc(temp_size);
+    if (temp_info == NULL)
+    {
+        return OE_OUT_OF_MEMORY;
+    }
+
+    result = oe_get_target_info_v1(report, report_size, temp_info, &temp_size);
+    if (result != OE_OK)
+    {
+        free(temp_info);
+
+        return result;
+    }
+    *target_info_size = temp_size;
+    *target_info_buffer = temp_info;
+
+    return OE_OK;
+}
+
+void oe_free_target_info(void* target_info_buffer)
+{
+    free(target_info_buffer);
 }

--- a/enclave/asym_keys.c
+++ b/enclave/asym_keys.c
@@ -32,7 +32,6 @@ static oe_result_t _load_seal_key_by_policy(
     size_t* key_info_size)
 {
     oe_result_t result = OE_UNEXPECTED;
-    uint8_t temp;
     uint8_t* key_buffer_local = NULL;
     size_t key_buffer_size_local = 0;
     uint8_t* key_info_local = NULL;
@@ -41,45 +40,12 @@ static oe_result_t _load_seal_key_by_policy(
     if (!key_buffer || !key_buffer_size || (key_info && !key_info_size))
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    /* Get size of key buffer. */
-    result = oe_get_seal_key_by_policy(
-        policy, &temp, &key_buffer_size_local, NULL, 0);
-
-    if (result == OE_OK)
-        OE_RAISE(OE_UNEXPECTED);
-    if (result != OE_BUFFER_TOO_SMALL)
-        OE_RAISE(result);
-
-    key_buffer_local = (uint8_t*)oe_malloc(key_buffer_size_local);
-    if (key_buffer_local == NULL)
-        OE_RAISE(OE_OUT_OF_MEMORY);
-
-    /* Get the size of key info if requested. */
-    if (key_info)
-    {
-        result = oe_get_seal_key_by_policy(
-            policy,
-            key_buffer_local,
-            &key_buffer_size_local,
-            &temp,
-            &key_info_size_local);
-
-        if (result == OE_OK)
-            OE_RAISE(OE_UNEXPECTED);
-        if (result != OE_BUFFER_TOO_SMALL)
-            OE_RAISE(result);
-
-        key_info_local = (uint8_t*)oe_malloc(key_info_size_local);
-        if (key_info_local == NULL)
-            OE_RAISE(OE_OUT_OF_MEMORY);
-    }
-
     /* Now, get the key buffers. */
     result = oe_get_seal_key_by_policy(
         policy,
-        key_buffer_local,
+        &key_buffer_local,
         &key_buffer_size_local,
-        key_info_local,
+        &key_info_local,
         &key_info_size_local);
 
     if (result != OE_OK)
@@ -93,21 +59,14 @@ static oe_result_t _load_seal_key_by_policy(
         *key_info = key_info_local;
         *key_info_size = key_info_size_local;
     }
+    else
+    {
+        oe_free_seal_key(NULL, key_info_local);
+    }
     key_buffer_local = NULL;
     key_info_local = NULL;
 
 done:
-    if (key_buffer_local != NULL)
-    {
-        oe_secure_zero_fill(key_buffer_local, key_buffer_size_local);
-        oe_free(key_buffer_local);
-    }
-
-    if (key_info_local != NULL)
-    {
-        oe_secure_zero_fill(key_info_local, key_info_size_local);
-        oe_free(key_info_local);
-    }
 
     return result;
 }
@@ -121,27 +80,12 @@ static oe_result_t _load_seal_key(
     oe_result_t result = OE_UNEXPECTED;
     uint8_t* key_buffer_local = NULL;
     size_t key_buffer_size_local = 0;
-    uint8_t temp;
 
     if (!key_info || !key_buffer || !key_buffer_size)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    /* Call once to get the size. */
-    result =
-        oe_get_seal_key(key_info, key_info_size, &temp, &key_buffer_size_local);
-
-    if (result == OE_OK)
-        OE_RAISE(OE_UNEXPECTED);
-    if (result != OE_BUFFER_TOO_SMALL)
-        OE_RAISE(result);
-
-    /* Allocate and call again. */
-    key_buffer_local = (uint8_t*)oe_malloc(key_buffer_size_local);
-    if (key_buffer_local == NULL)
-        OE_RAISE(OE_OUT_OF_MEMORY);
-
     result = oe_get_seal_key(
-        key_info, key_info_size, key_buffer_local, &key_buffer_size_local);
+        key_info, key_info_size, &key_buffer_local, &key_buffer_size_local);
 
     if (result != OE_OK)
         OE_RAISE(result);
@@ -152,12 +96,6 @@ static oe_result_t _load_seal_key(
     key_buffer_local = NULL;
 
 done:
-    if (key_buffer_local != NULL)
-    {
-        oe_secure_zero_fill(key_buffer_local, key_buffer_size_local);
-        oe_free(key_buffer_local);
-    }
-
     return result;
 }
 

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -85,7 +85,7 @@ if (OE_SGX)
     set_source_files_properties(sgx/keys.c PROPERTIES COMPILE_FLAGS -Wno-type-limits)
 
     # -m64 is an x86_64 specific flag
-   target_compile_options(oecore PUBLIC -m64)
+    target_compile_options(oecore PUBLIC -m64)
 endif()
 
 if (CMAKE_C_COMPILER_ID MATCHES GNU)
@@ -100,6 +100,11 @@ target_compile_options(oecore PUBLIC
 
 target_compile_options(oecore INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 
+target_compile_definitions(oecore
+    PUBLIC
+    OE_BUILD_ENCLAVE
+    OE_API_VERSION=2)
+
 if(USE_LIBSGX)
     target_compile_definitions(oecore PUBLIC OE_USE_LIBSGX)
 endif()
@@ -108,8 +113,6 @@ if(USE_DEBUG_MALLOC)
     target_compile_definitions(oecore PRIVATE OE_USE_DEBUG_MALLOC)
     message("USE_DEBUG_MALLOC is set, building oecore with memory leak detection.")
 endif()
-
-target_compile_definitions(oecore PUBLIC OE_BUILD_ENCLAVE)
 
 # addl link-options for enclave apps
 target_link_libraries(oecore INTERFACE

--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -261,7 +261,7 @@ done:
     return result;
 }
 
-oe_result_t oe_get_report(
+oe_result_t oe_get_report_v1(
     uint32_t flags,
     const uint8_t* report_data,
     size_t report_data_size,
@@ -327,6 +327,71 @@ done:
     }
 
     return result;
+}
+
+oe_result_t oe_get_report_v2(
+    uint32_t flags,
+    const uint8_t* report_data,
+    size_t report_data_size,
+    const void* opt_params,
+    size_t opt_params_size,
+    uint8_t** report_buffer,
+    size_t* report_buffer_size)
+{
+    oe_result_t result;
+    uint8_t* tmp_buffer = NULL;
+    size_t tmp_buffer_size = 0;
+
+    if ((report_buffer == NULL) || (report_buffer_size == NULL))
+    {
+        return OE_INVALID_PARAMETER;
+    }
+
+    *report_buffer = NULL;
+    *report_buffer_size = 0;
+
+    result = oe_get_report_v1(
+        flags,
+        report_data,
+        report_data_size,
+        opt_params,
+        opt_params_size,
+        NULL,
+        &tmp_buffer_size);
+    if (result != OE_BUFFER_TOO_SMALL)
+    {
+        return result;
+    }
+
+    tmp_buffer = oe_calloc(1, tmp_buffer_size);
+    if (tmp_buffer == NULL)
+    {
+        return OE_OUT_OF_MEMORY;
+    }
+
+    result = oe_get_report_v1(
+        flags,
+        report_data,
+        report_data_size,
+        opt_params,
+        opt_params_size,
+        tmp_buffer,
+        &tmp_buffer_size);
+    if (result != OE_OK)
+    {
+        oe_free(tmp_buffer);
+        return result;
+    }
+
+    *report_buffer = tmp_buffer;
+    *report_buffer_size = tmp_buffer_size;
+
+    return OE_OK;
+}
+
+void oe_free_report(uint8_t* report_buffer)
+{
+    oe_free(report_buffer);
 }
 
 oe_result_t _handle_get_sgx_report(uint64_t arg_in)

--- a/enclave/core/sgx/tracee.c
+++ b/enclave/core/sgx/tracee.c
@@ -53,14 +53,10 @@ bool is_enclave_debug_allowed()
         const sgx_report_t* sgx_report = NULL;
         oe_report_header_t* header = NULL;
 
-        report_buffer = (uint8_t*)oe_malloc(OE_MAX_REPORT_SIZE);
-        if (report_buffer == NULL)
-            goto done;
-
         // get a report on the enclave itself for enclave identity information
         report_buffer_size = OE_MAX_REPORT_SIZE;
         result = oe_get_report(
-            0, NULL, 0, NULL, 0, report_buffer, &report_buffer_size);
+            0, NULL, 0, NULL, 0, &report_buffer, &report_buffer_size);
         if (result != OE_OK)
             goto done;
 
@@ -70,7 +66,7 @@ bool is_enclave_debug_allowed()
     }
 done:
     if (report_buffer)
-        oe_free(report_buffer);
+        oe_free_report(report_buffer);
 #elif defined(_WIN32)
     // WIN32 support is still under development.
     // We will have to come back to handle this case

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -153,10 +153,12 @@ if (USE_LIBSGX)
 endif ()
 
 # Compile definitions and options
-target_compile_definitions(oehost PRIVATE
-  -DOE_BUILD_UNTRUSTED
-  -DOE_REPO_BRANCH_NAME="${GIT_BRANCH}"
-  -DOE_REPO_LAST_COMMIT="${GIT_COMMIT}")
+target_compile_definitions(oehost
+  PUBLIC -DOE_API_VERSION=2
+  PRIVATE
+  OE_BUILD_UNTRUSTED
+  OE_REPO_BRANCH_NAME="${GIT_BRANCH}"
+  OE_REPO_LAST_COMMIT="${GIT_COMMIT}")
 
 if (USE_DEBUG_MALLOC)
   target_compile_definitions(oehost PRIVATE OE_USE_DEBUG_MALLOC)

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -153,7 +153,7 @@ done:
     return result;
 }
 
-oe_result_t oe_get_report(
+oe_result_t oe_get_report_v1(
     oe_enclave_t* enclave,
     uint32_t flags,
     const void* opt_params,
@@ -225,6 +225,70 @@ done:
     }
 
     return result;
+}
+
+oe_result_t oe_get_report_v2(
+    oe_enclave_t* enclave,
+    uint32_t flags,
+    const void* opt_params,
+    size_t opt_params_size,
+    uint8_t** report_buffer,
+    size_t* report_buffer_size)
+{
+    oe_result_t result;
+    uint8_t* tmp_report_buffer = NULL;
+    size_t tmp_report_buffer_size = 0;
+
+    if (!report_buffer || !report_buffer_size)
+        return OE_INVALID_PARAMETER;
+
+    *report_buffer = NULL;
+    *report_buffer_size = 0;
+
+    result = oe_get_report_v1(
+        enclave,
+        flags,
+        opt_params,
+        opt_params_size,
+        NULL,
+        &tmp_report_buffer_size);
+    if (result != OE_BUFFER_TOO_SMALL)
+    {
+        if (result == OE_OK)
+        {
+            result = OE_UNEXPECTED;
+        }
+        return result;
+    }
+
+    tmp_report_buffer = calloc(1, tmp_report_buffer_size);
+    if (tmp_report_buffer == NULL)
+    {
+        return OE_OUT_OF_MEMORY;
+    }
+
+    result = oe_get_report_v1(
+        enclave,
+        flags,
+        opt_params,
+        opt_params_size,
+        tmp_report_buffer,
+        &tmp_report_buffer_size);
+    if (result != OE_OK)
+    {
+        free(tmp_report_buffer);
+        return result;
+    }
+
+    *report_buffer = tmp_report_buffer;
+    *report_buffer_size = tmp_report_buffer_size;
+
+    return OE_OK;
+}
+
+void oe_free_report(uint8_t* report_buffer)
+{
+    free(report_buffer);
 }
 
 oe_result_t oe_verify_report(

--- a/include/openenclave/host.h
+++ b/include/openenclave/host.h
@@ -154,6 +154,12 @@ oe_result_t oe_call_enclave(
     const char* func,
     void* args);
 
+#if (OE_API_VERSION < 2)
+#define oe_get_report oe_get_report_v1
+#else
+#define oe_get_report oe_get_report_v2
+#endif
+
 /**
  * Get a report signed by the enclave platform for use in attestation.
  *
@@ -161,6 +167,8 @@ oe_result_t oe_call_enclave(
  *
  * If the *report_buffer* is NULL or *report_size* parameter is too small,
  * this function returns OE_BUFFER_TOO_SMALL.
+ *
+ * @deprecated This function is deprecated. Use oe_get_report_v2() instead.
  *
  * @param enclave The instance of the enclave that will generate the report.
  * @param flags Specifying default value (0) generates a report for local
@@ -171,8 +179,7 @@ oe_result_t oe_call_enclave(
  * @param opt_params_size The size of the **opt_params** buffer.
  * @param report_buffer The buffer to where the resulting report will be copied.
  * @param report_buffer_size The size of the **report** buffer. This is set to
- * the
- * required size of the report buffer on return.
+ * the required size of the report buffer on return.
  *
  * @retval OE_OK The report was successfully created.
  * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
@@ -181,13 +188,56 @@ oe_result_t oe_call_enclave(
  * @retval OE_OUT_OF_MEMORY Failed to allocate memory.
  *
  */
-oe_result_t oe_get_report(
+
+oe_result_t oe_get_report_v1(
     oe_enclave_t* enclave,
     uint32_t flags,
     const void* opt_params,
     size_t opt_params_size,
     uint8_t* report_buffer,
     size_t* report_buffer_size);
+
+/**
+ * Get a report signed by the enclave platform for use in attestation.
+ *
+ * This function creates a report to be used in local or remote attestation.
+ *
+ * @param[in] enclave The instance of the enclave that will generate the report.
+ * @param[in] flags Specifying default value (0) generates a report for local
+ * attestation. Specifying OE_REPORT_FLAGS_REMOTE_ATTESTATION generates a
+ * report for remote attestation.
+ * @param[in] opt_params Optional additional parameters needed for the current
+ * enclave type. For SGX, this can be sgx_target_info_t for local attestation.
+ * @param[in] opt_params_size The size of the **opt_params** buffer.
+ * @param[out] report_buffer This points to the resulting report upon success.
+ * @param[out] report_buffer_size This is set to the size of the report buffer
+ * on success.
+ *
+ * @retval OE_OK The report was successfully created.
+ * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
+ * @retval OE_OUT_OF_MEMORY Failed to allocate memory.
+ *
+ */
+oe_result_t oe_get_report_v2(
+    oe_enclave_t* enclave,
+    uint32_t flags,
+    const void* opt_params,
+    size_t opt_params_size,
+    uint8_t** report_buffer,
+    size_t* report_buffer_size);
+
+/**
+ * Frees a report buffer obtained from oe_get_report.
+ *
+ * @param[in] report_buffer The report buffer to free.
+ */
+void oe_free_report(uint8_t* report_buffer);
+
+#if (OE_API_VERSION < 2)
+#define oe_get_target_info oe_get_target_info_v1
+#else
+#define oe_get_target_info oe_get_target_info_v2
+#endif
 
 /**
  * Extracts additional platform specific data from the report and writes
@@ -199,6 +249,8 @@ oe_result_t oe_get_report(
  *
  * If the *target_info_buffer* is NULL or the *target_info_size* parameter is
  * too small, this function returns OE_BUFFER_TOO_SMALL.
+ *
+ * @deprecated This function is deprecated. Use oe_get_target_info_v2() instead.
  *
  * @param report The report returned by **oe_get_report**.
  * @param report_size The size of **report** in bytes.
@@ -212,11 +264,44 @@ oe_result_t oe_get_report(
  * @retval OE_BUFFER_TOO_SMALL **target_info_buffer** is NULL or too small.
  *
  */
-oe_result_t oe_get_target_info(
+oe_result_t oe_get_target_info_v1(
     const uint8_t* report,
     size_t report_size,
     void* target_info_buffer,
     size_t* target_info_size);
+
+/**
+ * Extracts additional platform specific data from the report and writes
+ * it to *target_info_buffer*. After calling this function, the
+ * *target_info_buffer* can used for the *opt_params* field in *oe_get_report*.
+ *
+ * For example, on SGX, the *target_info_buffer* can be used as a
+ * sgx_target_info_t for local attestation.
+ *
+ * @param[in] report The report returned by **oe_get_report**.
+ * @param[in] report_size The size of **report** in bytes.
+ * @param[out] target_info_buffer This points to the platform specific data
+ * upon success.
+ * @param[out] target_info_size This is set to
+ * the size of **target_info_buffer** on success.
+ *
+ * @retval OE_OK The platform specific data was successfully extracted.
+ * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
+ * @retval OE_OUT_OF_MEMORY Failed to allocate memory.
+ *
+ */
+oe_result_t oe_get_target_info_v2(
+    const uint8_t* report,
+    size_t report_size,
+    void** target_info_buffer,
+    size_t* target_info_size);
+
+/**
+ * Frees a target info obtained from oe_get_target_info.
+ *
+ * @param[in] target_info_buffer The target info to free.
+ */
+void oe_free_target_info(void* target_info_buffer);
 
 /**
  * Parse an enclave report into a standard format for reading.

--- a/tests/report/enc/enc.cpp
+++ b/tests/report/enc/enc.cpp
@@ -35,8 +35,12 @@ oe_result_t test_verify_tcb_info(
 void test_minimum_issue_date(oe_datetime_t now)
 {
 #ifdef OE_USE_LIBSGX
-    static uint8_t report[OE_MAX_REPORT_SIZE];
-    size_t report_size = sizeof(report);
+    static uint8_t* report;
+    size_t report_size = 0;
+    static uint8_t report_v1[OE_MAX_REPORT_SIZE];
+    size_t report_v1_size = sizeof(report_v1);
+    static uint8_t* report_v2;
+    size_t report_v2_size = 0;
 
     // Generate reports.
     OE_TEST(
@@ -46,11 +50,39 @@ void test_minimum_issue_date(oe_datetime_t now)
             0,
             NULL,
             0,
-            report,
+            &report,
             &report_size) == OE_OK);
 
     // Verify the report.
     OE_TEST(oe_verify_report(report, report_size, NULL) == OE_OK);
+
+    // Generate reports.
+    OE_TEST(
+        oe_get_report_v1(
+            OE_REPORT_FLAGS_REMOTE_ATTESTATION,
+            NULL,
+            0,
+            NULL,
+            0,
+            report_v1,
+            &report_v1_size) == OE_OK);
+
+    // Verify the report.
+    OE_TEST(oe_verify_report(report_v1, report_v1_size, NULL) == OE_OK);
+
+    // Generate reports.
+    OE_TEST(
+        oe_get_report_v2(
+            OE_REPORT_FLAGS_REMOTE_ATTESTATION,
+            NULL,
+            0,
+            NULL,
+            0,
+            &report_v2,
+            &report_v2_size) == OE_OK);
+
+    // Verify the report.
+    OE_TEST(oe_verify_report(report_v2, report_v2_size, NULL) == OE_OK);
 
     // Set the minimum issue date to current time.
     char str[256];
@@ -74,6 +106,17 @@ void test_minimum_issue_date(oe_datetime_t now)
     OE_TEST(
         oe_verify_report(report, report_size, NULL) ==
         OE_INVALID_REVOCATION_INFO);
+
+    OE_TEST(
+        oe_verify_report(report_v1, report_v1_size, NULL) ==
+        OE_INVALID_REVOCATION_INFO);
+
+    OE_TEST(
+        oe_verify_report(report_v2, report_v2_size, NULL) ==
+        OE_INVALID_REVOCATION_INFO);
+
+    oe_free_report(report);
+    oe_free_report(report_v2);
 
     printf("test_minimum_issue_date passed.\n");
 #else

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -22,20 +22,21 @@ extern std::vector<uint8_t> FileToBytes(const char* path);
 void generate_and_save_report(oe_enclave_t* enclave)
 {
 #ifdef OE_USE_LIBSGX
-    static uint8_t report[OE_MAX_REPORT_SIZE];
-    size_t report_size = sizeof(report);
+    static uint8_t* report;
+    size_t report_size;
     OE_TEST(
         oe_get_report(
             enclave,
             OE_REPORT_FLAGS_REMOTE_ATTESTATION,
             NULL,
             0,
-            report,
+            &report,
             &report_size) == OE_OK);
 
     FILE* file = fopen("./data/generated_report.bytes", "wb");
     fwrite(report, 1, report_size, file);
     fclose(file);
+    oe_free_report(report);
 #else
     OE_UNUSED(enclave);
 #endif


### PR DESCRIPTION
Issue https://github.com/Microsoft/openenclave/issues/841 states that we
should return buffers directly instead of passing in a buffer. The old
style overloads the APIs to first get the length and then call in with a
buffer. The V2 versions of the APIs allocate the memory and returns
that, adding a function to free the returned buffers.