### PR TITLE
Move openenclaverc file under openenclave folder

### DIFF
--- a/cmake/package_settings.cmake
+++ b/cmake/package_settings.cmake
@@ -63,11 +63,11 @@ include(CPack)
 # Generate the openenclaverc script.
 configure_file(
     ${PROJECT_SOURCE_DIR}/cmake/openenclaverc.in
-    ${CMAKE_BINARY_DIR}/output/share/openenclaverc
+    ${CMAKE_BINARY_DIR}/output/share/openenclave/openenclaverc
     @ONLY)
 
 # Install the openenclaverc script.
 install(FILES
-    ${CMAKE_BINARY_DIR}/output/share/openenclaverc
+    ${CMAKE_BINARY_DIR}/output/share/openenclave/openenclaverc
     DESTINATION
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}")
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/openenclave")

--- a/docs/GettingStartedDocs/using_oe_sdk.md
+++ b/docs/GettingStartedDocs/using_oe_sdk.md
@@ -27,7 +27,7 @@ For ease of development, we recommend adding:
 You can do this by sourcing the openenclaverc file that is distributed with the SDK:
 
 ```bash
-source /opt/openenclave/share/openenclaverc
+source /opt/openenclave/share/openenclave/openenclaverc
 ```
 
 ## Samples

--- a/samples/README.md
+++ b/samples/README.md
@@ -47,18 +47,18 @@ binaries.
 
 #### Source the openenclaverc file (Required)
 
-Before building any samples, you need to source the `openenclaverc` file to setup environment variables for sample building. `openenclaverc` file can be found in  the `share` subdirectory of the package installation destination.
+Before building any samples, you need to source the `openenclaverc` file to setup environment variables for sample building. `openenclaverc` file can be found in  the `share/openenclave` subdirectory of the package installation destination.
 
 You can use `.` in Bash to `source`:
 
 ```bash
-. <package_installation_destination>/share/openenclaverc
+. <package_installation_destination>/share/openenclave/openenclaverc
 ```
 
 For example, if your package_installation_destination is /opt/openenclave:
 
 ```bash
-. /opt/openenclave/share/openenclaverc
+. /opt/openenclave/share/openenclave/openenclaverc
 ```
 
 Note: You will get error messages like the following if this sourcing step was skipped.


### PR DESCRIPTION
Moved the openenclaverc file distributed in the SDK to /opt/openenclave/share/openenclave from /opt/openenclave/share as requested in issue #893 .