### PR TITLE
oe-gdb: Support debugging in simulation mode.

### DIFF
--- a/debugger/pythonExtension/gdb_sgx_plugin.py
+++ b/debugger/pythonExtension/gdb_sgx_plugin.py
@@ -153,9 +153,16 @@ def enable_oeenclave_debug(oe_enclave_addr, enclave_path):
     # Check if it's SGX debug mode enclave.
     flags_blob = read_from_memory(oe_enclave_addr + OE_ENCLAVE_FLAGS_OFFSET, OE_ENCLAVE_FLAGS_LENGTH)
     flags_tuple = struct.unpack(OE_ENCLAVE_FLAGS_FORMAT, flags_blob)
-    # Debug == 1 and simulation == 0
-    if flags_tuple[0] == 0 or flags_tuple[1] != 0:
+
+    # Check if debugging is enabled.
+    if flags_tuple[0] == 0:
+        print ("oe-gdb: Debugging not enabled for enclave %s" % enclave_path)
         return False
+
+    # Check if the enclave is loaded in simulation mode.
+    if flags_tuple[1] != 0:
+        print ("oe-gdb: Enclave %s loaded in simulation mode" % enclave_path)
+
     # Load symbol.
     if load_enclave_symbol(enclave_path, enclave_tuple[OE_ENCLAVE_ADDR_FIELD]) != 1:
         return False
@@ -168,7 +175,7 @@ def enable_oeenclave_debug(oe_enclave_addr, enclave_path):
         set_tcs_debug_flag(thread_binding_tuple[0])
         # Iterate the array
         thread_binding_addr = thread_binding_addr + THREAD_BINDING_SIZE
-        thread_binding_blob = read_from_memory(thread_binding_addr, THREAD_BINDING_HEADER_LENGTH);
+        thread_binding_blob = read_from_memory(thread_binding_addr, THREAD_BINDING_HEADER_LENGTH)
         thread_binding_tuple = struct.unpack(THREAD_BINDING_HEADER_FORMAT, thread_binding_blob)
     return True
 

--- a/host/sgxload.c
+++ b/host/sgxload.c
@@ -108,6 +108,17 @@ static uint32_t _make_memory_protect_param(uint64_t inflags, bool simulate)
 #endif
     }
 
+#if defined(__linux__)
+    if (simulate)
+    {
+        // GDB cannot set breakpoints in write protected pages.
+        // Therefore in simulation mode, enable write to pages so that GDB can
+        // insert breakpoints (int 3 instruction). Note: PROT_WRITE means enable
+        // page write.
+        outflags |= PROT_WRITE;
+    }
+#endif
+
     return outflags;
 }
 

--- a/tests/debugger/oe-gdb/CMakeLists.txt
+++ b/tests/debugger/oe-gdb/CMakeLists.txt
@@ -5,10 +5,17 @@ add_subdirectory(host)
 add_subdirectory(enc)
 
 add_test(
-    NAME oe_gdb_test
+    NAME oe-gdb-test
     COMMAND 
         ${OE_BINDIR}/oe-gdb --batch 
         --command=${CMAKE_CURRENT_SOURCE_DIR}/commands.gdb 
         -arg host/oe_gdb_test_host enc/oe_gdb_test_enc
 )
 
+add_test(
+    NAME oe-gdb-test-simulation-mode
+    COMMAND 
+        ${OE_BINDIR}/oe-gdb --batch 
+        --command=${CMAKE_CURRENT_SOURCE_DIR}/commands.gdb 
+        -arg host/oe_gdb_test_host enc/oe_gdb_test_enc --simulation-mode
+)

--- a/tests/debugger/oe-gdb/host/host.c
+++ b/tests/debugger/oe-gdb/host/host.c
@@ -10,26 +10,28 @@
 #include <string.h>
 #include "oe_gdb_test_u.h"
 
-#define SKIP_RETURN_CODE 2
-
 int main(int argc, const char* argv[])
 {
     oe_result_t result;
     oe_enclave_t* enclave1 = NULL;
+    bool simulation_mode = false;
 
-    if (argc != 2)
+    if (argc < 2)
     {
-        fprintf(stderr, "Usage: %s ENCLAVE_PATH\n", argv[0]);
+        fprintf(
+            stderr, "Usage: %s ENCLAVE_PATH [--simulation-mode]\n", argv[0]);
         return 1;
     }
 
-    const uint32_t flags = oe_get_create_flags();
-    if ((flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
+    uint32_t flags = oe_get_create_flags();
+
+    simulation_mode =
+        (argc == 3 && (strcmp(argv[2], "--simulation-mode") == 0));
+
+    if (simulation_mode)
     {
-        printf(
-            "=== Skipped unsupported test in simulation mode "
-            "(oe_gdb_test)\n");
-        return SKIP_RETURN_CODE;
+        // Force simulation mode if --simulation-mode is specified.
+        flags |= OE_ENCLAVE_FLAG_SIMULATE;
     }
 
     if ((result = oe_create_oe_gdb_test_enclave(
@@ -48,7 +50,9 @@ int main(int argc, const char* argv[])
     result = oe_terminate_enclave(enclave1);
     OE_TEST(result == OE_OK);
 
-    printf("=== passed all tests (oe-gdb)\n");
+    printf(
+        "=== passed all tests (oe-gdb-test%s)\n",
+        simulation_mode ? "-simulation-mode" : "");
 
     return 0;
 }


### PR DESCRIPTION
In simulation mode, we were creating write-protected pages to load
the enclave. This made it impossible for gdb to set a breakpoint.
GDB tries to insert an 'int 3' instruction in enclave code but since
the code resided in write-protected memory, the insert fails.
To support debugging, in simulation mode, the enclave pages
are made writable using the PROT_WRITE flag.
The oe-gdb test is also always run in simulation mode as well.

This addresses #1050