### PR TITLE
Removing include dir 'PROJECT_SOURCE_DIR/include'  from CMakeList#958

### DIFF
--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -220,12 +220,11 @@ install(FILES
 set(PREFIX "$OE_PREFIX")
 
 set(ENCLAVE_CINCLUDES
-    "-I\${includedir}/openenclave/3rdparty/libc -I\${includedir}/openenclave/3rdparty -I\${includedir} -I${PROJECT_SOURCE_DIR}/include")
+    "-I\${includedir}/openenclave/3rdparty/libc -I\${includedir}/openenclave/3rdparty -I\${includedir}")
 
 set(ENCLAVE_CXXINCLUDES
     "-I\${includedir}/openenclave/3rdparty/libcxx ${ENCLAVE_CINCLUDES}")
 
-set(HOST_INCLUDES "-I${PROJECT_SOURCE_DIR}/include")
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/oeenclave-gcc.pc


### PR DESCRIPTION
Even if we  comment line install(DIRECTORY openenclave/edger8r DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/) in include/CMakelists  ,sample tests get success because it takes  'openenclave/include' as one of include directory.So it takes headers from source.It is fixed by Modifying openenclave/pkgconfig cmake file by removing -I{PROJECT_SOURCE_DIR}/include flag from it.