### PR TITLE
Add support for demuxing to appropriate file/socket provider

### DIFF
--- a/include/openenclave/bits/stdio.h
+++ b/include/openenclave/bits/stdio.h
@@ -123,3 +123,20 @@ int printf(const char* fmt, ...);
 #endif
 
 int vprintf(const char* format, va_list argptr);
+
+typedef struct {
+    int (*f_fclose)(intptr_t stream);
+    int (*f_feof)(intptr_t stream);
+    int (*f_ferror)(intptr_t stream);
+    int (*f_fflush)(intptr_t stream);
+    char* (*f_fgets)(char* str, int n, intptr_t stream);
+    int (*f_fputs)(const char* str, intptr_t stream);
+    size_t (*f_fread)(void* buffer, size_t size, size_t count, intptr_t stream);
+    int (*f_fseek)(intptr_t stream, long offset, int origin);
+    long (*f_ftell)(intptr_t stream);
+    size_t (*f_fwrite)(const void* buffer, size_t size, size_t count, intptr_t stream);
+} oe_file_provider_t;
+
+OE_FILE* oe_register_stream(
+    const oe_file_provider_t* provider,
+    intptr_t stream);

--- a/include/openenclave/socket.edl
+++ b/include/openenclave/socket.edl
@@ -6,7 +6,7 @@ enclave {
 
     struct accept_Result {
         oe_socket_error_t error;
-        void* hNewSocket;
+        intptr_t hNewSocket;
         int addrlen;
         char addr[256];
     };
@@ -58,7 +58,7 @@ enclave {
 
     struct oe_fd_set_internal {
         unsigned int fd_count;
-        void* fd_array[64];
+        intptr_t fd_array[64];
     };
 
     struct select_Result {
@@ -76,7 +76,7 @@ enclave {
 
     struct socket_Result {
         oe_socket_error_t error;
-        void* hSocket;
+        intptr_t hSocket;
     };
 
     trusted {
@@ -85,19 +85,19 @@ enclave {
 
     untrusted {
         accept_Result ocall_accept(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             int a_nAddrLen);
 
         oe_socket_error_t ocall_bind(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             [in, size=a_nNameLen] const void* a_Name,
             int a_nNameLen);
 
         oe_socket_error_t ocall_closesocket(
-            [user_check] void* a_hSocket);
+            intptr_t a_hSocket);
 
         oe_socket_error_t ocall_connect(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             [in, size=a_nNameLen] const void* a_Name,
             int a_nNameLen);
 
@@ -117,30 +117,30 @@ enclave {
             int a_Flags);
 
         GetSockName_Result ocall_getpeername(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             int a_nNameLen);
 
         GetSockName_Result ocall_getsockname(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             int a_nNameLen);
 
         getsockopt_Result ocall_getsockopt(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             int a_nLevel,
             int a_nOptName,
             int a_nOptLen);
 
         ioctlsocket_Result ocall_ioctlsocket(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             int a_nCommand,
             unsigned int a_uInputValue);
 
         oe_socket_error_t ocall_listen(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             int a_nMaxConnections);
 
         ssize_t ocall_recv(
-            [user_check] void* s,
+            intptr_t s,
             [out, size=len] void* buf,
             size_t len,
             int flags,
@@ -154,20 +154,20 @@ enclave {
             struct timeval a_Timeval);
 
         send_Result ocall_send(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             [in, size=a_nMessageLen] const void* a_Message,
             size_t a_nMessageLen,
             int a_Flags);
 
         oe_socket_error_t ocall_setsockopt(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             int a_nLevel,
             int a_nOptName,
             [in, size=a_nOptLen] const void* a_OptVal,
             int a_nOptLen);
 
         oe_socket_error_t ocall_shutdown(
-            [user_check] void* a_hSocket,
+            intptr_t a_hSocket,
             oe_shutdown_how_t a_How);
 
         socket_Result ocall_socket(

--- a/new_platforms/libsocket/enc/oesocket_enc.vcxproj
+++ b/new_platforms/libsocket/enc/oesocket_enc.vcxproj
@@ -496,7 +496,7 @@
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="socket_enc.c" />
+    <ClCompile Include="socket_insecure_enc.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/new_platforms/libsocket/enc/oesocket_enc.vcxproj.filters
+++ b/new_platforms/libsocket/enc/oesocket_enc.vcxproj.filters
@@ -26,7 +26,7 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="socket_enc.c">
+    <ClCompile Include="socket_insecure_enc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/new_platforms/libsocket/enc/optee/sub.mk
+++ b/new_platforms/libsocket/enc/optee/sub.mk
@@ -5,7 +5,7 @@ ROOT_RELATIVE_PATH = ../../../
 ../socket_t.h: $(OE_SDK_ROOT_PATH)include/openenclave/socket.edl
 	$(OEEDGER8R) --trusted --search-path "../..$(OEPATHSEP)$(OE_SDK_ROOT_PATH)include" --trusted-dir ".."  $(OE_SDK_ROOT_PATH)include/openenclave/socket.edl
 
-../socket_enc.c: ../socket_t.h
+../socket_insecure_enc.c: ../socket_t.h
 
 CFLAGS += -DOE_USE_OPTEE
 
@@ -19,4 +19,4 @@ global-incdirs-y += $(ROOT_RELATIVE_PATH)../include
 global-incdirs-y += $(ROOT_RELATIVE_PATH)../3rdparty/SGXSDK/include
 global-incdirs-y += ..
 
-srcs-y += ../socket_enc.c
+srcs-y += ../socket_insecure_enc.c

--- a/new_platforms/libsocket/host/linux/socket_host.c
+++ b/new_platforms/libsocket/host/linux/socket_host.c
@@ -43,12 +43,12 @@ socket_Result ocall_socket(
 {
     socket_Result result = { 0 };
     int fd = socket(a_AddressFamily, (int)a_Type, a_Protocol);
-    result.hSocket = (void *)fd;
+    result.hSocket = (intptr_t)fd;
     result.error = (fd == -1) ? (oe_socket_error_t)errno : 0;
     return result;
 }
 
-oe_socket_error_t ocall_listen(void* a_hSocket, int a_nMaxConnections)
+oe_socket_error_t ocall_listen(intptr_t a_hSocket, int a_nMaxConnections)
 {
     oe_socket_error_t result;
     int fd = (int)a_hSocket;
@@ -56,7 +56,7 @@ oe_socket_error_t ocall_listen(void* a_hSocket, int a_nMaxConnections)
     return s == -1 ? (oe_socket_error_t)s : 0;    
 }
 
-GetSockName_Result ocall_getsockname(void* a_hSocket, int a_nNameLen)
+GetSockName_Result ocall_getsockname(intptr_t a_hSocket, int a_nNameLen)
 {
     GetSockName_Result result = { 0 };
     int fd = (int)a_hSocket;
@@ -66,7 +66,7 @@ GetSockName_Result ocall_getsockname(void* a_hSocket, int a_nNameLen)
     return result;
 }
 
-GetSockName_Result ocall_getpeername(void* a_hSocket, int a_nNameLen)
+GetSockName_Result ocall_getpeername(intptr_t a_hSocket, int a_nNameLen)
 {
     GetSockName_Result result = { 0 };
     int fd = (int)a_hSocket;
@@ -77,7 +77,7 @@ GetSockName_Result ocall_getpeername(void* a_hSocket, int a_nNameLen)
 }
 
 send_Result ocall_send(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     const void* a_Message,
     size_t a_nMessageLen,
     int a_Flags)
@@ -92,7 +92,7 @@ send_Result ocall_send(
     return result;
 }
 
-ssize_t ocall_recv(void* a_hSocket, void* a_Buffer, size_t a_nBufferSize, int a_Flags, oe_socket_error_t* a_Error)
+ssize_t ocall_recv(intptr_t a_hSocket, void* a_Buffer, size_t a_nBufferSize, int a_Flags, oe_socket_error_t* a_Error)
 {
     int fd = (int)a_hSocket;
 
@@ -181,7 +181,7 @@ getaddrinfo_Result ocall_getaddrinfo(
 }
 
 getsockopt_Result ocall_getsockopt(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     int a_nLevel,
     int a_nOptName,
     int a_nOptLen)
@@ -195,7 +195,7 @@ getsockopt_Result ocall_getsockopt(
 }
 
 oe_socket_error_t ocall_setsockopt(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     int a_nLevel,
     int a_nOptName,
     const void* a_OptVal,
@@ -207,7 +207,7 @@ oe_socket_error_t ocall_setsockopt(
 }
 
 ioctlsocket_Result ocall_ioctlsocket(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     int a_nCommand,
     unsigned int a_uInputValue)
 {
@@ -274,21 +274,21 @@ select_Result ocall_select(
     return result;
 }
 
-oe_socket_error_t ocall_shutdown(void* a_hSocket, oe_shutdown_how_t a_How)
+oe_socket_error_t ocall_shutdown(intptr_t a_hSocket, oe_shutdown_how_t a_How)
 {
     int fd = (int)a_hSocket;
     int err = shutdown(fd, a_How);
     return (err == -1) ? (oe_socket_error_t)errno : 0;
 }
 
-oe_socket_error_t ocall_closesocket(void* a_hSocket)
+oe_socket_error_t ocall_closesocket(intptr_t a_hSocket)
 {
     int fd = (int)a_hSocket;
     int s = close(fd);
     return s == -1 ? (oe_socket_error_t)errno : 0;
 }
 
-oe_socket_error_t ocall_bind(void* a_hSocket, const void* a_Name, int a_nNameLen)
+oe_socket_error_t ocall_bind(intptr_t a_hSocket, const void* a_Name, int a_nNameLen)
 {
     int fd = (int)a_hSocket;
     int s = bind(fd, (const struct sockaddr *)a_Name, a_nNameLen);
@@ -296,7 +296,7 @@ oe_socket_error_t ocall_bind(void* a_hSocket, const void* a_Name, int a_nNameLen
 }
 
 oe_socket_error_t ocall_connect(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     const void* a_Name,
     int a_nNameLen)
 {
@@ -305,15 +305,15 @@ oe_socket_error_t ocall_connect(
     return s == -1 ? (oe_socket_error_t)errno : 0;
 }
 
-accept_Result ocall_accept(void* a_hSocket, int a_nAddrLen)
+accept_Result ocall_accept(intptr_t a_hSocket, int a_nAddrLen)
 {
     int fd = (int)a_hSocket;
     accept_Result result = { 0 };
     result.addrlen = a_nAddrLen;
-    result.hNewSocket = (void*)accept(fd, 
-                                      ((a_nAddrLen > 0) ? (struct sockaddr *)result.addr : NULL),
-                                      ((a_nAddrLen > 0) ? &result.addrlen : NULL));
-    result.error = (result.hNewSocket == (void *)(-1)) ? (oe_socket_error_t)errno : 0;
+    result.hNewSocket = (intptr_t)accept(fd, 
+                                         ((a_nAddrLen > 0) ? (struct sockaddr *)result.addr : NULL),
+                                         ((a_nAddrLen > 0) ? &result.addrlen : NULL));
+    result.error = (result.hNewSocket == (intptr_t)(-1)) ? (oe_socket_error_t)errno : 0;
     return result;
 }
 

--- a/new_platforms/libsocket/host/win32/socket_host.c
+++ b/new_platforms/libsocket/host/win32/socket_host.c
@@ -35,19 +35,19 @@ socket_Result ocall_socket(
 {
     socket_Result result = { 0 };
     SOCKET s = socket(a_AddressFamily, a_Type, a_Protocol);
-    result.hSocket = (void*)s;
+    result.hSocket = (intptr_t)s;
     result.error = (s == INVALID_SOCKET) ? (oe_socket_error_t)WSAGetLastError() : 0;
     return result;
 }
 
-oe_socket_error_t ocall_listen(void* a_hSocket, int a_nMaxConnections)
+oe_socket_error_t ocall_listen(intptr_t a_hSocket, int a_nMaxConnections)
 {
     SOCKET s = (SOCKET)a_hSocket;
     int err = listen(s, a_nMaxConnections);
     return (err == SOCKET_ERROR) ? (oe_socket_error_t)WSAGetLastError() : 0;
 }
 
-GetSockName_Result ocall_getsockname(void* a_hSocket, int a_nNameLen)
+GetSockName_Result ocall_getsockname(intptr_t a_hSocket, int a_nNameLen)
 {
     GetSockName_Result result = { 0 };
     SOCKET s = (SOCKET)a_hSocket;
@@ -57,7 +57,7 @@ GetSockName_Result ocall_getsockname(void* a_hSocket, int a_nNameLen)
     return result;
 }
 
-GetSockName_Result ocall_getpeername(void* a_hSocket, int a_nNameLen)
+GetSockName_Result ocall_getpeername(intptr_t a_hSocket, int a_nNameLen)
 {
     GetSockName_Result result = { 0 };
     SOCKET s = (SOCKET)a_hSocket;
@@ -68,7 +68,7 @@ GetSockName_Result ocall_getpeername(void* a_hSocket, int a_nNameLen)
 }
 
 send_Result ocall_send(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     const void* a_Message,
     size_t a_nMessageLen,
     int a_Flags)
@@ -89,7 +89,7 @@ send_Result ocall_send(
 }
 
 ssize_t ocall_recv(
-    _In_ void* a_hSocket,
+    _In_ intptr_t a_hSocket,
     _Out_writes_bytes_(len) void* buf,
     _In_ size_t len,
     _In_ int flags,
@@ -176,7 +176,7 @@ getaddrinfo_Result ocall_getaddrinfo(
 }
 
 getsockopt_Result ocall_getsockopt(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     int a_nLevel,
     int a_nOptName,
     int a_nOptLen)
@@ -190,7 +190,7 @@ getsockopt_Result ocall_getsockopt(
 }
 
 oe_socket_error_t ocall_setsockopt(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     int a_nLevel,
     int a_nOptName,
     const void* a_OptVal,
@@ -202,7 +202,7 @@ oe_socket_error_t ocall_setsockopt(
 }
 
 ioctlsocket_Result ocall_ioctlsocket(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     int a_nCommand,
     unsigned int a_uInputValue)
 {
@@ -222,10 +222,10 @@ copy_output_fds(
     unsigned int i;
     dest->fd_count = src->fd_count;
     for (i = 0; i < src->fd_count; i++) {
-        dest->fd_array[i] = (void*)src->fd_array[i];
+        dest->fd_array[i] = (intptr_t)src->fd_array[i];
     }
     for (; i < FD_SETSIZE; i++) {
-        dest->fd_array[i] = NULL;
+        dest->fd_array[i] = (intptr_t)NULL;
     }
 }
 
@@ -238,7 +238,7 @@ copy_input_fds(
     FD_ZERO(dest);
     dest->fd_count = src->fd_count;
     for (i = 0; i < src->fd_count; i++) {
-        (void*)dest->fd_array[i] = src->fd_array[i];
+        dest->fd_array[i] = src->fd_array[i];
     }
 }
 
@@ -267,21 +267,21 @@ select_Result ocall_select(
     return result;
 }
 
-oe_socket_error_t ocall_shutdown(void* a_hSocket, int a_How)
+oe_socket_error_t ocall_shutdown(intptr_t a_hSocket, int a_How)
 {
     SOCKET s = (SOCKET)a_hSocket;
     int err = shutdown(s, a_How);
     return (err == SOCKET_ERROR) ? (oe_socket_error_t)WSAGetLastError() : 0;
 }
 
-oe_socket_error_t ocall_closesocket(void* a_hSocket)
+oe_socket_error_t ocall_closesocket(intptr_t a_hSocket)
 {
     SOCKET s = (SOCKET)a_hSocket;
     int err = closesocket(s);
     return (err == SOCKET_ERROR) ? (oe_socket_error_t)WSAGetLastError() : 0;
 }
 
-oe_socket_error_t ocall_bind(void* a_hSocket, const void* a_Name, int a_nNameLen)
+oe_socket_error_t ocall_bind(intptr_t a_hSocket, const void* a_Name, int a_nNameLen)
 {
     SOCKET s = (SOCKET)a_hSocket;
     int err = bind(s, (const SOCKADDR*)a_Name, a_nNameLen);
@@ -289,7 +289,7 @@ oe_socket_error_t ocall_bind(void* a_hSocket, const void* a_Name, int a_nNameLen
 }
 
 oe_socket_error_t ocall_connect(
-    void* a_hSocket,
+    intptr_t a_hSocket,
     const void* a_Name,
     int a_nNameLen)
 {
@@ -298,15 +298,15 @@ oe_socket_error_t ocall_connect(
     return (err == SOCKET_ERROR) ? (oe_socket_error_t)WSAGetLastError() : 0;
 }
 
-accept_Result ocall_accept(void* a_hSocket, int a_nAddrLen)
+accept_Result ocall_accept(intptr_t a_hSocket, int a_nAddrLen)
 {
     SOCKET s = (SOCKET)a_hSocket;
     accept_Result result = { 0 };
     result.addrlen = a_nAddrLen;
-    result.hNewSocket = (void*)accept(s,
-                                      ((a_nAddrLen > 0) ? (SOCKADDR*)result.addr : NULL),
-                                      ((a_nAddrLen > 0) ? &result.addrlen : NULL));
-    result.error = (result.hNewSocket == (void*)INVALID_SOCKET) ? (oe_socket_error_t)WSAGetLastError() : 0;
+    result.hNewSocket = (intptr_t)accept(s,
+                                         ((a_nAddrLen > 0) ? (SOCKADDR*)result.addr : NULL),
+                                         ((a_nAddrLen > 0) ? &result.addrlen : NULL));
+    result.error = (result.hNewSocket == (intptr_t)INVALID_SOCKET) ? (oe_socket_error_t)WSAGetLastError() : 0;
     return result;
 }
 

--- a/new_platforms/src/Trusted/files_enc.c
+++ b/new_platforms/src/Trusted/files_enc.c
@@ -1,0 +1,111 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Licensed under the MIT License. */
+#include <openenclave/enclave.h>
+#define OE_NO_POSIX_FILE_API
+#include <openenclave/bits/stdio.h>
+#include <stdlib.h>
+
+typedef struct {
+    intptr_t provider_stream;
+    const oe_file_provider_t* provider;
+} oe_internal_file_t;
+
+OE_FILE* oe_register_stream(
+    const oe_file_provider_t* provider,
+    intptr_t stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)malloc(sizeof(*fp));
+    if (fp == NULL) {
+        return NULL;
+    }
+    fp->provider = provider;
+    fp->provider_stream = stream;
+    return (OE_FILE*)fp;
+}
+
+int oe_fclose(OE_FILE* stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    int result = fp->provider->f_fclose(fp->provider_stream);
+    free(fp);
+    return result;
+}
+
+int oe_feof(
+    OE_FILE* stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    return fp->provider->f_feof(fp->provider_stream);
+}
+
+int oe_ferror(
+    OE_FILE* stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    return fp->provider->f_ferror(fp->provider_stream);
+}
+
+int oe_fflush(
+    OE_FILE* stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    return fp->provider->f_fflush(fp->provider_stream);
+}
+
+char* oe_fgets(
+    char* str,
+    int n,
+    OE_FILE* stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    return fp->provider->f_fgets(str, n, fp->provider_stream);
+}
+
+int oe_fputs(const char* str, OE_FILE* stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    if (fp->provider->f_fputs != NULL) {
+        return fp->provider->f_fputs(str, fp->provider_stream);
+    }
+
+    /* Default to implementing fputs over fwrite. */
+    size_t bytesToWrite = strlen(str);
+    size_t bytesWritten = oe_fwrite(str, 1, bytesToWrite, stream);
+    return (bytesWritten == bytesToWrite) ? 0 : -1;
+}
+
+size_t oe_fread(
+    void* buffer,
+    size_t size,
+    size_t count,
+    OE_FILE* stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    return fp->provider->f_fread(buffer, size, count, fp->provider_stream);
+}
+
+int oe_fseek(
+    OE_FILE* stream,
+    long offset,
+    int origin)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    return fp->provider->f_fseek(fp->provider_stream, offset, origin);
+}
+
+long oe_ftell(
+    OE_FILE* stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    return fp->provider->f_ftell(fp->provider_stream);
+}
+
+size_t oe_fwrite(
+    const void* buffer,
+    size_t size,
+    size_t count,
+    OE_FILE* stream)
+{
+    oe_internal_file_t* fp = (oe_internal_file_t*)stream;
+    return fp->provider->f_fwrite(buffer, size, count, fp->provider_stream);
+}

--- a/new_platforms/src/Trusted/oeenclave.vcxproj
+++ b/new_platforms/src/Trusted/oeenclave.vcxproj
@@ -72,6 +72,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DebugOpteeSimulation|ARM'">false</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="cborhelper.c" />
+    <ClCompile Include="files_enc.c" />
     <ClCompile Include="optee\cyres_optee.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -194,6 +195,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DebugOpteeSimulation|ARM'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DebugOpteeSimulation|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="socket_enc.c" />
     <ClCompile Include="string_t.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</ExcludedFromBuild>

--- a/new_platforms/src/Trusted/oeenclave.vcxproj.filters
+++ b/new_platforms/src/Trusted/oeenclave.vcxproj.filters
@@ -165,6 +165,12 @@
     <ClCompile Include="..\optee_common.c">
       <Filter>optee</Filter>
     </ClCompile>
+    <ClCompile Include="files_enc.c">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="socket_enc.c">
+      <Filter>common</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="optee\linux_gcc.mak">

--- a/new_platforms/src/Trusted/optee/sub.mk
+++ b/new_platforms/src/Trusted/optee/sub.mk
@@ -27,6 +27,7 @@ srcs-y += ../oeoverintelsgx_t.c
 srcs-y += ../../buffer.c
 srcs-y += ../CallbackHelper.c
 srcs-y += ../cborhelper.c
+srcs-y += ../files_enc.c
 srcs-y += ../Io.c
 srcs-y += ../keygen.c
 srcs-y += ../../oeresult.c
@@ -34,6 +35,7 @@ srcs-y += ../../optee_common.c
 srcs-y += ../oeshim_t.c
 srcs-y += ../logapp.c
 srcs-y += ../log_ocall_file.c
+srcs-y += ../socket_enc.c
 srcs-y += ../string_t.c
 
 srcs-y += ctype_optee.c

--- a/new_platforms/src/Trusted/socket_enc.c
+++ b/new_platforms/src/Trusted/socket_enc.c
@@ -1,0 +1,355 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Licensed under the MIT License. */
+#include <openenclave/enclave.h>
+#include "enclavelibc.h"
+#include "tcps_string_t.h"
+#include <errno.h>
+
+typedef struct {
+    intptr_t provider_socket;
+    const oe_socket_provider_t* provider;
+} oe_internal_socket_t;
+
+oe_socket_t oe_register_socket(
+    const oe_socket_provider_t* provider,
+    intptr_t provider_socket)
+{
+    oe_internal_socket_t* s = (oe_internal_socket_t*)malloc(sizeof(*s));
+    if (s == NULL) {
+        return NULL;
+    }
+    s->provider = provider;
+    s->provider_socket = provider_socket;
+    return s;
+}
+
+void ecall_InitializeSockets() {}
+
+static int
+fill_internal_fd_set(
+    _Out_ oe_provider_fd_set* provider_fds,
+    _In_opt_ const oe_fd_set* fds,
+    _Inout_ const oe_socket_provider_t** provider)
+{
+    unsigned int i;
+    memset(provider_fds, 0, sizeof(*provider_fds));
+    if (fds == NULL) {
+        return 0;
+    }
+
+    provider_fds->fd_count = fds->fd_count;
+    for (i = 0; i < fds->fd_count; i++) {
+        oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)fds->fd_array[i];
+        if (internal_socket == NULL) {
+            continue;
+        }
+        if (*provider == NULL) {
+            *provider = internal_socket->provider;
+        } else if (*provider != internal_socket->provider) {
+            /* We currently only support select() among sockets from the same provider. */
+            return -1;
+        }
+        provider_fds->fd_array[i] = internal_socket->provider_socket; 
+    }
+    return 0;
+}
+
+static void
+set_fd_set_results(
+    _In_ const oe_provider_fd_set* provider_fds,
+    _Inout_opt_ oe_fd_set* fds)
+{
+    unsigned int i;
+    if (fds == NULL) {
+        return;
+    }
+    for (i = 0; i < provider_fds->fd_count; i++) {
+        if (provider_fds->fd_array[i] == 0) {
+            fds->fd_array[i] = NULL;
+        }
+    }
+}
+
+int
+oe_select(
+    int a_nFds,
+    _Inout_opt_ oe_fd_set* a_readfds,
+    _Inout_opt_ oe_fd_set* a_writefds,
+    _Inout_opt_ oe_fd_set* a_exceptfds,
+    _In_opt_ const struct timeval* a_Timeout)
+{
+    const oe_socket_provider_t* provider = NULL;
+    oe_provider_fd_set provider_readfds;
+    oe_provider_fd_set provider_writefds;
+    oe_provider_fd_set provider_exceptfds;
+
+    if (fill_internal_fd_set(&provider_readfds, a_readfds, &provider) < 0) {
+        return -1;
+    }
+    if (fill_internal_fd_set(&provider_writefds, a_writefds, &provider) < 0) {
+        return -1;
+    }
+    if (fill_internal_fd_set(&provider_exceptfds, a_exceptfds, &provider) < 0) {
+        return -1;
+    }
+
+    int result = provider->s_select(
+        a_nFds,
+        (provider_readfds.fd_count == 0) ? NULL : &provider_readfds,
+        (provider_writefds.fd_count == 0) ? NULL : &provider_writefds,
+        (provider_exceptfds.fd_count == 0) ? NULL : &provider_exceptfds,
+        a_Timeout);
+
+    if (result == 0) {
+        set_fd_set_results(&provider_readfds, a_readfds);
+        set_fd_set_results(&provider_writefds, a_writefds);
+        set_fd_set_results(&provider_exceptfds, a_exceptfds);
+    }
+
+    return result;
+}
+
+int oe_fd_isset(_In_ oe_socket_t fd, _In_ fd_set* set)
+{
+    unsigned int i;
+    for (i = 0; i < set->fd_count; i++) {
+        if (fd == set->fd_array[i]) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+int
+oe_shutdown(
+    _In_ oe_socket_t s,
+    int how)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_shutdown(internal_socket->provider_socket, how);
+}
+
+int
+oe_closesocket(
+    _In_ oe_socket_t s)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    int result = internal_socket->provider->s_close(internal_socket->provider_socket);
+    free(internal_socket);
+    return result;
+}
+
+int
+oe_listen(
+    _In_ oe_socket_t s,
+    int backlog)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_listen(internal_socket->provider_socket, backlog);
+}
+
+int
+oe_getsockopt(
+    _In_ oe_socket_t s,
+    int level,
+    int optname,
+    _Out_writes_(*optlen) char *optval,
+    _Inout_ socklen_t *optlen)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_getsockopt(internal_socket->provider_socket, level, optname, optval, optlen);
+}
+
+ssize_t
+oe_recv(
+    _In_ oe_socket_t s,
+    _Out_writes_(len) void *buf,
+    size_t len,
+    int flags)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_recv(internal_socket->provider_socket, buf, len, flags);
+}
+
+int
+oe_send(
+    _In_ oe_socket_t s,
+    _In_reads_bytes_(len) const char *buf,
+    int len,
+    int flags)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_send(internal_socket->provider_socket, buf, len, flags);
+}
+
+static uint32_t swap_uint32(uint32_t const net)
+{
+    uint8_t data[4];
+    memcpy(&data, &net, sizeof(data));
+
+    return ((uint32_t)data[3] << 0)
+        | ((uint32_t)data[2] << 8)
+        | ((uint32_t)data[1] << 16)
+        | ((uint32_t)data[0] << 24);
+}
+
+static uint32_t swap_uint16(uint16_t const net)
+{
+    uint8_t data[2];
+    memcpy(&data, &net, sizeof(data));
+
+    return ((uint16_t)data[1] << 0)
+        | ((uint16_t)data[0] << 8);
+}
+
+uint32_t
+oe_ntohl(
+    uint32_t netLong)
+{
+    return swap_uint32(netLong);
+}
+
+uint16_t
+oe_ntohs(
+    uint16_t netShort)
+{
+    return swap_uint16(netShort);
+}
+
+uint32_t
+oe_htonl(
+    uint32_t hostLong)
+{
+    return swap_uint32(hostLong);
+}
+
+uint16_t
+oe_htons(
+    uint16_t hostShort)
+{
+    return swap_uint16(hostShort);
+}
+
+int
+oe_setsockopt(
+    _In_ oe_socket_t s,
+    int level,
+    int optname,
+    _In_reads_bytes_(optlen) const char* optval,
+    socklen_t optlen)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_setsockopt(internal_socket->provider_socket, level, optname, optval, optlen);
+}
+
+int
+oe_ioctlsocket(
+    _In_ oe_socket_t s,
+    long cmd,
+    _Inout_ u_long *argp)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_ioctl(internal_socket->provider_socket, cmd, argp);
+}
+
+int
+oe_connect(
+    _In_ oe_socket_t s,
+    _In_reads_bytes_(namelen) const oe_sockaddr *name,
+    int namelen)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_connect(internal_socket->provider_socket, name, namelen);
+}
+
+oe_socket_t
+oe_accept(
+    _In_ oe_socket_t s,
+    _Out_writes_bytes_(*addrlen) struct sockaddr* addr,
+    _Inout_ int *addrlen)
+{
+    oe_internal_socket_t* new_internal_socket = (oe_internal_socket_t*)malloc(sizeof(*new_internal_socket));
+    if (new_internal_socket == (intptr_t)NULL) {
+    }
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    intptr_t new_provider_socket = internal_socket->provider->s_accept(internal_socket->provider_socket, addr, addrlen);
+    if (new_provider_socket == (intptr_t)NULL) {
+        free(new_internal_socket);
+        return OE_INVALID_SOCKET;
+    }
+    new_internal_socket->provider = internal_socket->provider;
+    new_internal_socket->provider_socket = new_provider_socket;
+    return new_internal_socket;
+}
+
+int
+oe_getpeername(
+    _In_ oe_socket_t s,
+    _Out_writes_bytes_(*addrlen) struct sockaddr* addr,
+    _Inout_ int *addrlen)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_getpeername(internal_socket->provider_socket, addr, addrlen);
+}
+
+int
+oe_getsockname(
+    _In_ oe_socket_t s,
+    _Out_writes_bytes_(*addrlen) struct sockaddr* addr,
+    _Inout_ int *addrlen)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_getsockname(internal_socket->provider_socket, addr, addrlen);
+}
+
+int
+oe_bind(
+    _In_ oe_socket_t s,
+    _In_reads_bytes_(addrlen) const oe_sockaddr *addr,
+    int addrlen)
+{
+    oe_internal_socket_t* internal_socket = (oe_internal_socket_t*)s;
+    return internal_socket->provider->s_bind(internal_socket->provider_socket, addr, addrlen);
+}
+
+uint32_t
+oe_inet_addr(
+    _In_z_ const char *cp)
+{
+    /* We only support dotted decimal. */
+    uint32_t value;
+    uint8_t* byte = (uint8_t*)&value;
+    int field = 0;
+    const char* next;
+    const char* p = cp;
+
+    for (p = cp; field < 4; p = next) {
+        const char* dot = strchr(p, '.');
+        next = (dot != NULL) ? dot + 1 : p + strlen(p);
+        byte[field++] = (uint8_t)atoi(p);
+    }
+    if (*p != 0) {
+        return INADDR_NONE;
+    }
+    return value;
+}
+
+void
+oe_freeaddrinfo(
+    _In_ oe_addrinfo* ailist)
+{
+    oe_addrinfo* ai;
+    oe_addrinfo* next;
+
+    for (ai = ailist; ai != NULL; ai = next) {
+        next = ai->ai_next;
+        if (ai->ai_canonname != NULL) {
+            oe_free(ai->ai_canonname);
+        }
+        if (ai->ai_addr != NULL) {
+            oe_free(ai->ai_addr);
+        }
+        oe_free(ai);
+        ailist = next;
+    }
+}


### PR DESCRIPTION
This is the rest of the change started in commit
3f45f08f5a859ea5a9306274fd1e4df19448e2ed

This retains compliance with the reviewed APIs, and just adds 2 internal "register" APIs that were mentioned in the above commit.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>