### PR TITLE
Make oe_create_enclave work with or without a file extension

### DIFF
--- a/new_platforms/src/Untrusted/linux/Makefile
+++ b/new_platforms/src/Untrusted/linux/Makefile
@@ -1,6 +1,6 @@
 # All objects we build and store in our shared library.
 OBJECTS = oeoverintelsgx_u.o teehost_optee.o urpc_optee.o \
-          buffer.o uhelper_shared.o uhelper.o oeshim_u.o oeresult.o \
+          buffer.o uhelper_shared.o uhelper.o oeshim_host.o oeresult.o \
           optee_common.o stdext.o
 
 # Path to where OpenEnclave resides.
@@ -68,7 +68,7 @@ optee_common.o: ../../optee_common.c
 	@echo " [CC]\t$@"
 	@$(CC) $(CFLAGS) $(COMMON_CFLAGS) -c -o $@ $<
 
-oeshim_u.o: ../oeshim_u.c ../oeoverintelsgx_u.h
+oeshim_host.o: ../oeshim_host.c ../oeoverintelsgx_u.h
 	@echo " [CC]\t$@"
 	@$(CC) $(CFLAGS) $(COMMON_CFLAGS) -c -o $@ $<
 

--- a/new_platforms/src/Untrusted/linux/teehost_optee.c
+++ b/new_platforms/src/Untrusted/linux/teehost_optee.c
@@ -107,9 +107,9 @@ static oe_result_t uuid_from_string(
     return OE_OK;
 }
 
-oe_result_t Tcps_CreateTAInternal(
+oe_result_t oe_create_enclave_internal(
     _In_z_ const char* a_TaIdString,
-    _In_ uint32_t a_Flags,
+    uint32_t a_Flags,
     _Out_ sgx_enclave_id_t* a_pId)
 {
     oe_result_t status;
@@ -119,12 +119,17 @@ oe_result_t Tcps_CreateTAInternal(
     struct tcps_optee_context *optee;
     uint32_t err_origin;
     int s;
+
+    char uuidstring[80];
+    strcpy_s(uuidstring, sizeof(uuidstring), a_TaIdString);
+
+    /* Remove ".ta" extension, if one is present. */
+    size_t len = strlen(uuidstring);
+    if ((len > 3) && (strcmp(&uuidstring[len - 3], ".ta") == 0)) {
+        uuidstring[len - 3] = 0;
+    }
    
     OE_UNUSED(a_Flags);
-
-    if (!a_TaIdString || !a_pId) {
-        return OE_INVALID_PARAMETER;
-    }
 
     status = uuid_from_string((char *)a_TaIdString, &uuid);
     if (status != OE_OK) {

--- a/new_platforms/src/Untrusted/win32/oehost.vcxproj
+++ b/new_platforms/src/Untrusted/win32/oehost.vcxproj
@@ -81,7 +81,7 @@
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='DebugOpteeSimulation|ARM'">$(NewPlatformsDir)include;$(OESdkDir)include;$(ProjectDir)..;$(ProjectDir);$(UrchinDir)ScTrm\PuScTrmLib;$(OpteeCallsDir)OpteeCalls\inc;%(AdditionalIncludeDirectories);$(SGXSDKInstallPath)include</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='DebugOpteeSimulation|x64'">$(NewPlatformsDir)include;$(OESdkDir)include;$(ProjectDir)..;$(ProjectDir);$(UrchinDir)ScTrm\PuScTrmLib;$(OpteeCallsDir)OpteeCalls\inc;%(AdditionalIncludeDirectories);$(SGXSDKInstallPath)include</AdditionalIncludeDirectories>
     </ClCompile>
-    <ClCompile Include="..\oeshim_u.c" />
+    <ClCompile Include="..\oeshim_host.c" />
     <ClCompile Include="teehost_optee.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/new_platforms/src/Untrusted/win32/oehost.vcxproj.filters
+++ b/new_platforms/src/Untrusted/win32/oehost.vcxproj.filters
@@ -4,7 +4,6 @@
     <ClCompile Include="uhelper.c" />
     <ClCompile Include="..\..\buffer.c" />
     <ClCompile Include="..\..\oeresult.c" />
-    <ClCompile Include="..\oeshim_u.c" />
     <ClCompile Include="..\oeoverintelsgx_u.c">
       <Filter>Generated Files</Filter>
     </ClCompile>
@@ -30,6 +29,7 @@
     <ClCompile Include="..\..\optee_common.c">
       <Filter>OP-TEE</Filter>
     </ClCompile>
+    <ClCompile Include="..\oeshim_host.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(OpteeCallsDir)OpteeCalls\inc\targetver.h" />

--- a/new_platforms/src/Untrusted/win32/teehost_optee.c
+++ b/new_platforms/src/Untrusted/win32/teehost_optee.c
@@ -68,18 +68,27 @@ static HANDLE OpenServiceHandleByFilename(_In_ LPCGUID ServiceGuid)
     return serviceHandle;
 }
 
-oe_result_t Tcps_CreateTAInternal(
+oe_result_t oe_create_enclave_internal(
     _In_z_ const char* a_TaIdString,
-    _In_ uint32_t a_Flags,
+    uint32_t a_Flags,
     _Out_ sgx_enclave_id_t* a_pId)
 {
+    char uuidstring[80];
+    strcpy_s(uuidstring, sizeof(uuidstring), a_TaIdString);
+
+    /* Remove ".ta" extension, if one is present. */
+    size_t len = strlen(uuidstring);
+    if ((len > 3) && (strcmp(&uuidstring[len - 3], ".ta") == 0)) {
+        uuidstring[len - 3] = 0;
+    }
+
     *a_pId = (sgx_enclave_id_t)INVALID_HANDLE_VALUE;
 
     OE_UNUSED(a_Flags);
 
     /* Convert string to GUID. */
     UUID uuid;
-    HRESULT hr = UuidFromString((RPC_CSTR)a_TaIdString, &uuid);
+    HRESULT hr = UuidFromString((RPC_CSTR)uuidstring, &uuid);
     if (hr != S_OK) {
         return OE_FAILURE;
     }

--- a/new_platforms/src/oeresult.c
+++ b/new_platforms/src/oeresult.c
@@ -25,6 +25,7 @@ oe_result_t GetOEResultFromSgxStatus(sgx_status_t status)
     case SGX_ERROR_INVALID_ISVSVN:        return OE_INVALID_ISVSVN;
     case SGX_ERROR_INVALID_KEYNAME:       return OE_INVALID_KEYNAME;
     case SGX_ERROR_BUSY:                  return OE_BUSY;
+    case SGX_ERROR_ENCLAVE_FILE_ACCESS:   return OE_NOT_FOUND;
     default:                              return OE_FAILURE;
     }
 }


### PR DESCRIPTION
Implement logic per discussion with Paul.

Other style notes:
* it's better for both debugging and security to AV immediately
  rather than returning an invalid parameter error, if there's
  clearly a bug in the caller.
* updated SAL guidance is that value parameters (i.e., not pointers)
  should not have SAL annotation.  Hence, opportunistically removed
  _In_ from prototypes that this change was touching anyway.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>