### PR TITLE
Build oelibcxx with OBJECT libraries

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -16,9 +16,8 @@ ExternalProject_Add(libcxx_includes
     INSTALL_COMMAND ""
     )
 
-# build sources
+add_library(libcxx OBJECT
 
-add_library(libcxx STATIC
     __dso_handle.cpp
 
     libcxx/src/algorithm.cpp
@@ -53,6 +52,9 @@ add_library(libcxx STATIC
     libcxx/src/vector.cpp
     )
 
+set_target_properties(libcxx PROPERTIES
+  POSITION_INDEPENDENT_CODE ON)
+
 target_compile_options(libcxx PRIVATE -std=c++14)
 target_compile_definitions(libcxx PRIVATE
     -DLIBCXXRT
@@ -66,10 +68,6 @@ add_dependencies(libcxx libcxx_includes)
 
 # this project (and is dependents) require the LIBC includes
 target_link_libraries(libcxx PUBLIC oelibc)
-# If we built an OBJECT library, we would want to do the following, though CMake does not allow
-#  using target_link_libraries on an OBJECT lib (yet?):
-#add_dependencies(libcxx oelibc)
-#target_include_directories(libcxx PUBLIC ${OE_INCDIR}/libc)
 
 target_include_directories(libcxx
   PUBLIC

--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -63,11 +63,6 @@ target_compile_definitions(libcxx PRIVATE
 
 # need the LIBCXX_CXX headers placed
 add_dependencies(libcxx libcxx_includes)
-# this project and its dependents require include/libcxx in the include path
-target_include_directories(libcxx PUBLIC
-    $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${OE_INCDIR}/openenclave/libcxx>>
-    $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
-    )
 
 # this project (and is dependents) require the LIBC includes
 target_link_libraries(libcxx PUBLIC oelibc)
@@ -76,9 +71,13 @@ target_link_libraries(libcxx PUBLIC oelibc)
 #add_dependencies(libcxx oelibc)
 #target_include_directories(libcxx PUBLIC ${OE_INCDIR}/libc)
 
-# when building this project, we also need a number of internal includes
-target_include_directories(libcxx PRIVATE libcxx/src)
-target_include_directories(libcxx PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/libcxxrt/libcxxrt/src)
+target_include_directories(libcxx
+  PUBLIC
+  $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${OE_INCDIR}/openenclave/libcxx>>
+  $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
+  PRIVATE
+  libcxx/src
+  ../libcxxrt/libcxxrt/src)
 
 # install target just to propagate include-location, but not the archive iself
 install(TARGETS libcxx EXPORT openenclave-targets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -15,7 +15,6 @@ ExternalProject_Add(oelibcxx_cxx_includes
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/__config ${OE_INCDIR}/openenclave/libcxx/__config
     INSTALL_COMMAND ""
     )
-install (DIRECTORY ${OE_INCDIR}/openenclave/libcxx DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
 
 # build sources
 
@@ -83,3 +82,6 @@ target_include_directories(oelibcxx_cxx PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/lib
 
 # install target just to propagate include-location, but not the archive iself
 install(TARGETS oelibcxx_cxx EXPORT openenclave-targets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+
+install(DIRECTORY ${OE_INCDIR}/openenclave/libcxx
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)

--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Use an external project to place the headers in the collector-dir
 include (ExternalProject)
-ExternalProject_Add(oelibcxx_cxx_includes
+ExternalProject_Add(libcxx_includes
     DOWNLOAD_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -18,7 +18,7 @@ ExternalProject_Add(oelibcxx_cxx_includes
 
 # build sources
 
-add_library(oelibcxx_cxx STATIC
+add_library(libcxx STATIC
     __dso_handle.cpp
 
     libcxx/src/algorithm.cpp
@@ -53,8 +53,8 @@ add_library(oelibcxx_cxx STATIC
     libcxx/src/vector.cpp
     )
 
-target_compile_options(oelibcxx_cxx PRIVATE -std=c++14)
-target_compile_definitions(oelibcxx_cxx PRIVATE
+target_compile_options(libcxx PRIVATE -std=c++14)
+target_compile_definitions(libcxx PRIVATE
     -DLIBCXXRT
     -D_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
     -D_LIBCPP_BUILDING_LIBRARY
@@ -62,26 +62,26 @@ target_compile_definitions(oelibcxx_cxx PRIVATE
     )
 
 # need the LIBCXX_CXX headers placed
-add_dependencies(oelibcxx_cxx oelibcxx_cxx_includes)
+add_dependencies(libcxx libcxx_includes)
 # this project and its dependents require include/libcxx in the include path
-target_include_directories(oelibcxx_cxx PUBLIC
+target_include_directories(libcxx PUBLIC
     $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${OE_INCDIR}/openenclave/libcxx>>
     $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
     )
 
 # this project (and is dependents) require the LIBC includes
-target_link_libraries(oelibcxx_cxx PUBLIC oelibc)
+target_link_libraries(libcxx PUBLIC oelibc)
 # If we built an OBJECT library, we would want to do the following, though CMake does not allow
 #  using target_link_libraries on an OBJECT lib (yet?):
-#add_dependencies(oelibcxx_cxx oelibc)
-#target_include_directories(oelibcxx_cxx PUBLIC ${OE_INCDIR}/libc)
+#add_dependencies(libcxx oelibc)
+#target_include_directories(libcxx PUBLIC ${OE_INCDIR}/libc)
 
 # when building this project, we also need a number of internal includes
-target_include_directories(oelibcxx_cxx PRIVATE libcxx/src)
-target_include_directories(oelibcxx_cxx PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/libcxxrt/libcxxrt/src)
+target_include_directories(libcxx PRIVATE libcxx/src)
+target_include_directories(libcxx PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/libcxxrt/libcxxrt/src)
 
 # install target just to propagate include-location, but not the archive iself
-install(TARGETS oelibcxx_cxx EXPORT openenclave-targets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+install(TARGETS libcxx EXPORT openenclave-targets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 
 install(DIRECTORY ${OE_INCDIR}/openenclave/libcxx
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)

--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -1,72 +1,63 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# Copy headers to collector-dir, patch, compile libcxx into intermittent library
-# place install rule
-
-# Use an external project to place the headers in the collector-dir
 include (ExternalProject)
 ExternalProject_Add(libcxx_includes
-    DOWNLOAD_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_LIST_DIR}/libcxx/include ${OE_INCDIR}/openenclave/libcxx
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/libcxx/include/__config ${OE_INCDIR}/openenclave/libcxx/__config_original
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/__config ${OE_INCDIR}/openenclave/libcxx/__config
-    INSTALL_COMMAND ""
-    )
+  DOWNLOAD_COMMAND ""
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_LIST_DIR}/libcxx/include ${OE_INCDIR}/openenclave/libcxx
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/libcxx/include/__config ${OE_INCDIR}/openenclave/libcxx/__config_original
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/__config ${OE_INCDIR}/openenclave/libcxx/__config
+  INSTALL_COMMAND "")
 
 add_library(libcxx OBJECT
+  __dso_handle.cpp
+  libcxx/src/algorithm.cpp
+  libcxx/src/any.cpp
+  libcxx/src/bind.cpp
+  libcxx/src/chrono.cpp
+  libcxx/src/condition_variable.cpp
+  libcxx/src/debug.cpp
+  libcxx/src/exception.cpp
+  libcxx/src/functional.cpp
+  libcxx/src/future.cpp
+  libcxx/src/hash.cpp
+  libcxx/src/ios.cpp
+  libcxx/src/iostream.cpp
+  libcxx/src/locale.cpp
+  libcxx/src/memory.cpp
+  libcxx/src/mutex.cpp
+  libcxx/src/new.cpp
+  libcxx/src/optional.cpp
+  libcxx/src/random.cpp
+  libcxx/src/regex.cpp
+  libcxx/src/shared_mutex.cpp
+  libcxx/src/stdexcept.cpp
+  libcxx/src/string.cpp
+  libcxx/src/strstream.cpp
+  libcxx/src/system_error.cpp
+  libcxx/src/thread.cpp
+  libcxx/src/typeinfo.cpp
+  libcxx/src/utility.cpp
+  libcxx/src/valarray.cpp
+  libcxx/src/variant.cpp
+  libcxx/src/vector.cpp)
 
-    __dso_handle.cpp
-
-    libcxx/src/algorithm.cpp
-    libcxx/src/any.cpp
-    libcxx/src/bind.cpp
-    libcxx/src/chrono.cpp
-    libcxx/src/condition_variable.cpp
-    libcxx/src/debug.cpp
-    libcxx/src/exception.cpp
-    libcxx/src/functional.cpp
-    libcxx/src/future.cpp
-    libcxx/src/hash.cpp
-    libcxx/src/ios.cpp
-    libcxx/src/iostream.cpp
-    libcxx/src/locale.cpp
-    libcxx/src/memory.cpp
-    libcxx/src/mutex.cpp
-    libcxx/src/new.cpp
-    libcxx/src/optional.cpp
-    libcxx/src/random.cpp
-    libcxx/src/regex.cpp
-    libcxx/src/shared_mutex.cpp
-    libcxx/src/stdexcept.cpp
-    libcxx/src/string.cpp
-    libcxx/src/strstream.cpp
-    libcxx/src/system_error.cpp
-    libcxx/src/thread.cpp
-    libcxx/src/typeinfo.cpp
-    libcxx/src/utility.cpp
-    libcxx/src/valarray.cpp
-    libcxx/src/variant.cpp
-    libcxx/src/vector.cpp
-    )
+add_dependencies(libcxx libcxx_includes)
 
 set_target_properties(libcxx PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
 
 target_compile_options(libcxx PRIVATE -std=c++14)
-target_compile_definitions(libcxx PRIVATE
-    -DLIBCXXRT
-    -D_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
-    -D_LIBCPP_BUILDING_LIBRARY
-    -DOE_LIBC_SUPPRESS_DEPRECATIONS
-    )
 
-# need the LIBCXX_CXX headers placed
-add_dependencies(libcxx libcxx_includes)
+target_compile_definitions(libcxx
+  PRIVATE
+  -DLIBCXXRT
+  -D_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
+  -D_LIBCPP_BUILDING_LIBRARY
+  -DOE_LIBC_SUPPRESS_DEPRECATIONS)
 
-# this project (and is dependents) require the LIBC includes
 target_link_libraries(libcxx PUBLIC oelibc)
 
 target_include_directories(libcxx
@@ -77,8 +68,8 @@ target_include_directories(libcxx
   libcxx/src
   ../libcxxrt/libcxxrt/src)
 
-# install target just to propagate include-location, but not the archive iself
-install(TARGETS libcxx EXPORT openenclave-targets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+install(TARGETS libcxx EXPORT openenclave-targets
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 
 install(DIRECTORY ${OE_INCDIR}/openenclave/libcxx
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)

--- a/3rdparty/libcxxrt/CMakeLists.txt
+++ b/3rdparty/libcxxrt/CMakeLists.txt
@@ -1,16 +1,28 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# Compile CXXRT
+# Compile libcxx for Open Enclave. Some of these build rules emulate
+# those found in the original sources, but instead this builds an
+# OBJECT library in our CMake graph.
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-compare")
+add_library(libcxxrt OBJECT
+  libcxxrt/src/dynamic_cast.cc
+  libcxxrt/src/exception.cc
+  libcxxrt/src/guard.cc
+  libcxxrt/src/stdexcept.cc
+  libcxxrt/src/typeinfo.cc
+  libcxxrt/src/memory.cc
+  libcxxrt/src/auxhelper.cc
+  libcxxrt/src/libelftc_dem_gnu3.c)
 
-# build cxxrt sources passing additional options
-add_subdirectory(libcxxrt/src)
-target_compile_options(cxxrt-static PRIVATE
-    -fPIC
-    # cannot use add_link_libraries on out-of-dir target
-    -nostdinc $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>
-    -I${OE_INCDIR}/openenclave/libc
-    )
-add_dependencies(cxxrt-static oelibc_includes)
+set_source_files_properties(libcxxrt/src/exception.cc
+  PROPERTIES COMPILE_FLAGS -Wno-unused-variable)
+
+set_target_properties(libcxxrt PROPERTIES
+  POSITION_INDEPENDENT_CODE ON)
+
+target_compile_options(libcxxrt PRIVATE -Wno-tautological-compare)
+
+target_compile_definitions(libcxxrt PRIVATE -D_GNU_SOURCE)
+
+target_link_libraries(libcxxrt PUBLIC oelibc)

--- a/3rdparty/libunwind/CMakeLists.txt
+++ b/3rdparty/libunwind/CMakeLists.txt
@@ -1,110 +1,160 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# Copy libunwind sources and build out-of-tree
+configure_file(
+  libunwind/include/libunwind-x86_64.h
+  libunwind.h
+  COPYONLY)
 
-string(CONCAT CFLAGS
-    "-Wall "
-    "-Werror "
-    "-Wno-pointer-to-int-cast "
-    "-Wno-unused-function "
-    "-Wno-unused-variable "
-    "-Wno-cpp "
-    "-fno-builtin "
-    "-fPIC "
-    "-include ${CMAKE_CURRENT_SOURCE_DIR}/stubs.h "
-    "-I${PROJECT_SOURCE_DIR}/include "
-    "${SPECTRE_MITIGATION_FLAGS} ")
+configure_file(
+  libunwind/src/x86_64/Gstep.c
+  Gstep.inc
+  COPYONLY)
 
-if (CMAKE_C_COMPILER_ID MATCHES "GNU")
-    string(CONCAT CFLAGS
-        ${CFLAGS}
-        "-Wno-unused-but-set-variable "
-        "-Wno-maybe-uninitialized ")
-elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
-    string(CONCAT CFLAGS 
-        ${CFLAGS}
-        "-Wno-header-guard "
-        "-Wno-uninitialized "
-        "-Wno-unused-variable ")
-endif()
+add_custom_command(
+  OUTPUT Gtrace.c
+  # TODO: We are doing this ugly workaround since we don't support
+  # thread local storage (__thread). Once the PR for Thread Local
+  # Storage goes in (#1157), we can remove this.
+  COMMAND grep -v "^static __thread"
+    ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/src/x86_64/Gtrace.c >
+    ${CMAKE_CURRENT_BINARY_DIR}/Gtrace.inc
+  COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_SOURCE_DIR}/Gtrace.c
+    ${CMAKE_CURRENT_BINARY_DIR}/Gtrace.c
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/src/x86_64/Gtrace.c)
 
-set(OPTS
-    --enable-shared=no
-    --disable-block-signals
-    --enable-cxx-exceptions
-    # Note that the C compiler is used for ASM as well.
-    CC=${CMAKE_C_COMPILER}
-    CXX=${CMAKE_CXX_COMPILER}
-    )
+file(GENERATE OUTPUT config.h CONTENT "/* Empty file */\n")
 
-string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)
+set(PKG_MAJOR 1)
+set(PKG_MINOR 3)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/include/libunwind-common.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libunwind-common.inc
+  COPYONLY)
 
-if ((BUILD_TYPE STREQUAL "DEBUG") OR (BUILD_TYPE STREQUAL "RELWITHDEBINFO"))
-    list(APPEND OPTS "--enable-debug=yes" "--enable-debug-frame==yes")
-    set(CFLAGS "${CFLAGS} -g")
-else()
-    list (APPEND OPTS "--enable-debug=no" "--enable-debug-frame==no")
-endif()
+file(COPY libunwind/include/tdep-x86_64/ DESTINATION tdep)
 
-include (ExternalProject)
+add_library(libunwind STATIC
+  # Total 67 items
+  libunwind/src/dwarf/global.c
+  libunwind/src/dwarf/Lexpr.c
+  libunwind/src/dwarf/Lfde.c
+  libunwind/src/dwarf/Lfind_proc_info-lsb.c
+  libunwind/src/dwarf/Lfind_unwind_table.c
+  libunwind/src/dwarf/Lparser.c
+  libunwind/src/dwarf/Lpe.c
+  libunwind/src/dwarf/Lstep.c
+  libunwind/src/mi/_ReadULEB.c
+  libunwind/src/mi/_ReadSLEB.c
+  libunwind/src/mi/backtrace.c
+  libunwind/src/mi/dyn-cancel.c
+  libunwind/src/mi/dyn-info-list.c
+  libunwind/src/mi/dyn-register.c
+  libunwind/src/mi/flush_cache.c
+  libunwind/src/mi/init.c
+  libunwind/src/mi/Ldestroy_addr_space.c
+  libunwind/src/mi/Ldyn-extract.c
+  libunwind/src/mi/Lfind_dynamic_proc_info.c
+  libunwind/src/mi/Lget_accessors.c
+  libunwind/src/mi/Lget_fpreg.c
+  libunwind/src/mi/Lget_proc_info_by_ip.c
+  libunwind/src/mi/Lget_proc_name.c
+  libunwind/src/mi/Lget_reg.c
+  libunwind/src/mi/Lput_dynamic_unwind_info.c
+  libunwind/src/mi/Lset_caching_policy.c
+  libunwind/src/mi/Lset_fpreg.c
+  libunwind/src/mi/Lset_reg.c
+  libunwind/src/mi/mempool.c
+  libunwind/src/mi/strerror.c
+  libunwind/src/unwind/Backtrace.c
+  libunwind/src/unwind/DeleteException.c
+  libunwind/src/unwind/FindEnclosingFunction.c
+  libunwind/src/unwind/ForcedUnwind.c
+  libunwind/src/unwind/GetBSP.c
+  libunwind/src/unwind/GetCFA.c
+  libunwind/src/unwind/GetDataRelBase.c
+  libunwind/src/unwind/GetGR.c
+  libunwind/src/unwind/GetIPInfo.c
+  libunwind/src/unwind/GetIP.c
+  libunwind/src/unwind/GetLanguageSpecificData.c
+  libunwind/src/unwind/GetRegionStart.c
+  libunwind/src/unwind/GetTextRelBase.c
+  libunwind/src/unwind/RaiseException.c
+  libunwind/src/unwind/Resume.c
+  libunwind/src/unwind/Resume_or_Rethrow.c
+  libunwind/src/unwind/SetGR.c
+  libunwind/src/unwind/SetIP.c
+  libunwind/src/x86_64/getcontext.S
+  libunwind/src/x86_64/is_fpreg.c
+  libunwind/src/x86_64/Los-linux.c
+  libunwind/src/x86_64/Lcreate_addr_space.c
+  libunwind/src/x86_64/Lget_save_loc.c
+  libunwind/src/x86_64/Lglobal.c
+  libunwind/src/x86_64/Linit.c
+  libunwind/src/x86_64/Linit_local.c
+  libunwind/src/x86_64/Linit_remote.c
+  libunwind/src/x86_64/Lget_proc_info.c
+  libunwind/src/x86_64/Lregs.c
+  libunwind/src/x86_64/Lresume.c
+  libunwind/src/x86_64/Lstash_frame.c
+  Gstep.c  # libunwind/src/x86_64/Lstep.c
+  Gtrace.c # libunwind/src/x86_64/Ltrace.c
+  libunwind/src/x86_64/regname.c
+  setcontext.S # libunwind/src/x86_64/setcontext.c
+  libunwind/src/os-linux.c
+  libunwind/src/elf64.c
 
-ExternalProject_Add(oelibcxx_unwind
+  # Add dependency to libunwind.h generation.
+  ${CMAKE_CURRENT_BINARY_DIR}/libunwind.h)
 
-    # Copy libunwind source tree to build directory.
-    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_LIST_DIR}/libunwind 
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind
+set_target_properties(libunwind PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-    # Remove -Wall as this is applied too late and will override -Wno-* flags in Clang.
-    # Instead we apply it ourselves using CFLAGS (see above).
-    COMMAND sed -e "s/-Wall//g"
-        ${CMAKE_CURRENT_LIST_DIR}/libunwind/configure.ac >
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind/configure.ac
+target_compile_options(libunwind PRIVATE
+  -Wall
+  -Werror
+  -Wno-pointer-to-int-cast
+  -Wno-unused-function
+  -Wno-unused-variable
+  -Wno-cpp
+  -fno-builtin
+  -include ${CMAKE_CURRENT_SOURCE_DIR}/stubs.h)
 
-    # Generate autoconf scripts and run configure.
-    CONFIGURE_COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/libunwind && 
-        ./autogen.sh "${OPTS}" "CFLAGS=${CFLAGS}"
+if (CMAKE_C_COMPILER_ID MATCHES GNU)
+  target_compile_options(libunwind PRIVATE
+    # TODO: GCC does not have the equivalent of -Wno-macro-redefined,
+    # and currently we define `UNW_LOCAL_ONLY` a bit more liberally
+    # than necessary. When this is cleaned up, we can go back to
+    # `-Werror`.
+    -Wno-error
+    -Wno-unused-but-set-variable
+    -Wno-maybe-uninitialized)
+elseif (CMAKE_C_COMPILER_ID MATCHES Clang)
+  target_compile_options(libunwind PRIVATE
+    -Wno-header-guard
+    -Wno-uninitialized
+    -Wno-unused-variable
+    -Wno-macro-redefined)
+endif ()
 
-    # Copy libunwind-common.h to libunwind-common.inc.
-    COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include/libunwind-common.h
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include/libunwind-common.inc
+target_compile_definitions(libunwind PRIVATE
+  HAVE_ELF_H
+  HAVE_ENDIAN_H
+  HAVE_LINK_H
+  _GNU_SOURCE
+  UNW_LOCAL_ONLY=1
+  #__x86_64__
+  HAVE_DL_ITERATE_PHDR
+  PACKAGE_STRING=\"libunwind-1.3\"
+  PACKAGE_BUGREPORT=\"unwind.org\")
 
-    # Copy libunwind-common.h to the build directory (this file includes
-    # libunwind-common.inc).
-    COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_CURRENT_LIST_DIR}/libunwind-common.h
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include/libunwind-common.h
+target_link_libraries(libunwind PUBLIC oelibc)
 
-    # Copy Gstep.c to Gstep.inc.
-    COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_CURRENT_LIST_DIR}/libunwind/src/x86_64/Gstep.c
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind/src/x86_64/Gstep.inc
-
-    # Copy Gstep.c to the the build directory.
-    COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_CURRENT_LIST_DIR}/Gstep.c
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind/src/x86_64/Gstep.c
-
-    # Copy Gtrace.c to Gtrace.inc while removing the line containing
-    # "static __thread".
-    COMMAND grep -v "^static __thread"
-        ${CMAKE_CURRENT_LIST_DIR}/libunwind/src/x86_64/Gtrace.c >
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind/src/x86_64/Gtrace.inc
-
-    # Copy Gtrace.c to the the build directory.
-    COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_CURRENT_LIST_DIR}/Gtrace.c
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind/src/x86_64/Gtrace.c
-
-    # Copy setcontext.S over the one in the build directory.
-    COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_CURRENT_LIST_DIR}/setcontext.S
-        ${CMAKE_CURRENT_BINARY_DIR}/libunwind/src/x86_64/setcontext.S
-
-    # Build libunwind.
-    BUILD_COMMAND $(MAKE) -C ${CMAKE_CURRENT_BINARY_DIR}/libunwind/src
-
-    # Empty install command.
-    INSTALL_COMMAND "")
+target_include_directories(libunwind PRIVATE
+  ${PROJECT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/src/x86_64
+  ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/src
+  ${CMAKE_CURRENT_BINARY_DIR}/tdep
+  ${CMAKE_CURRENT_BINARY_DIR})

--- a/3rdparty/libunwind/CMakeLists.txt
+++ b/3rdparty/libunwind/CMakeLists.txt
@@ -35,7 +35,7 @@ configure_file(
 
 file(COPY libunwind/include/tdep-x86_64/ DESTINATION tdep)
 
-add_library(libunwind STATIC
+add_library(libunwind OBJECT
   # Total 67 items
   libunwind/src/dwarf/global.c
   libunwind/src/dwarf/Lexpr.c

--- a/3rdparty/libunwind/Gstep.c
+++ b/3rdparty/libunwind/Gstep.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <libunwind.h>
 #include "unwind_i.h"
 #include <openenclave/enclave.h>
 

--- a/3rdparty/libunwind/Gtrace.c
+++ b/3rdparty/libunwind/Gtrace.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <libunwind.h>
 #include <pthread.h>
 #include <openenclave/internal/sgxtypes.h>
 

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -9,7 +9,7 @@ set(PATCHES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patches)
 set(MUSL_DIR ${CMAKE_CURRENT_BINARY_DIR}/musl)
 
 include (ExternalProject)
-ExternalProject_Add(oelibc_includes
+ExternalProject_Add(musl_includes
     DOWNLOAD_COMMAND
         ${CMAKE_COMMAND} -E copy_directory
         ${CMAKE_CURRENT_LIST_DIR}/musl
@@ -54,9 +54,24 @@ ExternalProject_Add(oelibc_includes
         ${OE_INCDIR}/openenclave/libc ${CMAKE_CURRENT_BINARY_DIR}/musl
     INSTALL_COMMAND "")
 
-# install-rule can be generated here, usage requirements defined in
-# <ROOT>/libc/.
-install(DIRECTORY
-    ${OE_INCDIR}/openenclave/libc
-    DESTINATION
-    ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
+add_library(oelibc_includes INTERFACE)
+
+add_dependencies(oelibc_includes musl_includes)
+
+# NOTE: This is explicitly marked as a `SYSTEM` directory because it
+# must be searched last. In particularly, the headers found in
+# `libcxx` utilize an unfortunate GNU pre-processor extension,
+# `#include_next`, which forces an order on the include paths. It
+# means that `-Ilibcxx` must come before `-Ilibc`, and the least
+# troublesome way to do this in CMake is set this as a `SYSTEM`
+# include path.
+target_include_directories(oelibc_includes
+  SYSTEM INTERFACE
+  $<BUILD_INTERFACE:${OE_INCDIR}/openenclave/libc>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libc>)
+
+install(TARGETS oelibc_includes EXPORT openenclave-targets
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+
+install(DIRECTORY ${OE_INCDIR}/openenclave/libc
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -10,49 +10,50 @@ set(MUSL_DIR ${CMAKE_CURRENT_BINARY_DIR}/musl)
 
 include (ExternalProject)
 ExternalProject_Add(musl_includes
-    DOWNLOAD_COMMAND
-        ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_LIST_DIR}/musl
-        ${CMAKE_CURRENT_BINARY_DIR}/musl
-    PATCH_COMMAND
-        COMMAND ${CMAKE_COMMAND} -E copy
-            ${MUSL_DIR}/arch/x86_64/syscall_arch.h
-            ${MUSL_DIR}/arch/x86_64/__syscall_arch.h
-        COMMAND ${CMAKE_COMMAND} -E copy
-            ${PATCHES_DIR}/syscall_arch.h
-            ${MUSL_DIR}/arch/x86_64/syscall_arch.h
-        COMMAND ${CMAKE_COMMAND} -E copy
-            ${PATCHES_DIR}/pthread_arch.h
-            ${MUSL_DIR}/arch/x86_64/pthread_arch.h
-    CONFIGURE_COMMAND
-        ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
-        ./configure
-            --includedir=${OE_INCDIR}/openenclave/libc
-            CFLAGS=${CFLAGS}
-            CC=${CMAKE_C_COMPILER}
-            CXX=${CMAKE_CXX_COMPILER}
-    BUILD_COMMAND
-        ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
-        make install-headers
-        COMMAND ${CMAKE_COMMAND} -E copy
-            ${OE_INCDIR}/openenclave/libc/endian.h
-            ${OE_INCDIR}/openenclave/libc/__endian.h
-        COMMAND ${CMAKE_COMMAND} -E copy
-            ${PATCHES_DIR}/endian.h
-            ${OE_INCDIR}/openenclave/libc/endian.h
+  DOWNLOAD_COMMAND
+    ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_LIST_DIR}/musl
+    ${CMAKE_CURRENT_BINARY_DIR}/musl
+  PATCH_COMMAND
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${MUSL_DIR}/arch/x86_64/syscall_arch.h
+      ${MUSL_DIR}/arch/x86_64/__syscall_arch.h
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${PATCHES_DIR}/syscall_arch.h
+      ${MUSL_DIR}/arch/x86_64/syscall_arch.h
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${PATCHES_DIR}/pthread_arch.h
+      ${MUSL_DIR}/arch/x86_64/pthread_arch.h
+  CONFIGURE_COMMAND
+    ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
+    ./configure
+      --includedir=${OE_INCDIR}/openenclave/libc
+      CFLAGS=${CFLAGS}
+      CC=${CMAKE_C_COMPILER}
+      CXX=${CMAKE_CXX_COMPILER}
+  BUILD_COMMAND
+    ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
+    make install-headers
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${OE_INCDIR}/openenclave/libc/endian.h
+      ${OE_INCDIR}/openenclave/libc/__endian.h
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${PATCHES_DIR}/endian.h
+      ${OE_INCDIR}/openenclave/libc/endian.h
 
-        # Append deprecations.h to all C header files.
-        COMMAND ${CMAKE_CURRENT_LIST_DIR}/append-deprecations
-            ${OE_INCDIR}/openenclave/libc
+    # Append deprecations.h to all C header files.
+    COMMAND ${CMAKE_CURRENT_LIST_DIR}/append-deprecations
+      ${OE_INCDIR}/openenclave/libc
 
-        # Copy local deprecations.h to include/bits/deprecated.h.
-        COMMAND ${CMAKE_COMMAND} -E copy
-            ${CMAKE_CURRENT_LIST_DIR}/deprecations.h
-            ${OE_INCDIR}/openenclave/libc/bits/deprecations.h
+    # Copy local deprecations.h to include/bits/deprecated.h.
+    COMMAND ${CMAKE_COMMAND} -E copy
+      ${CMAKE_CURRENT_LIST_DIR}/deprecations.h
+      ${OE_INCDIR}/openenclave/libc/bits/deprecations.h
 
-    BUILD_BYPRODUCTS
-        ${OE_INCDIR}/openenclave/libc ${CMAKE_CURRENT_BINARY_DIR}/musl
-    INSTALL_COMMAND "")
+  BUILD_BYPRODUCTS
+    ${OE_INCDIR}/openenclave/libc ${CMAKE_CURRENT_BINARY_DIR}/musl
+
+  INSTALL_COMMAND "")
 
 add_library(oelibc_includes INTERFACE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # Please read The Ultimate Guide to CMake:
 # https://rix0r.nl/blog/2015/08/13/cmake-guide/
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 # Read version from "VERSION" file.
 file(STRINGS "VERSION" OE_VERSION_WITH_V)

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# Build the C library, using local sources and sources from MUSL
-
+# Build the C library, using local sources and sources from musl.
 set(MUSLSRC ${PROJECT_SOURCE_DIR}/3rdparty/musl/musl/src)
 
 add_library(oelibasm OBJECT
@@ -706,30 +705,15 @@ if (USE_DEBUG_MALLOC)
 endif ()
 
 # This project (and its dependents) require the enclave headers and
-# library.
-target_link_libraries(oelibc PUBLIC oecore)
-
-# As a pre-build step, place the musl LIBC headers.
-add_dependencies(oelibc oelibc_includes)
+# library, and the musl headers.
+target_link_libraries(oelibc
+  PUBLIC oecore oelibc_includes)
 
 target_include_directories(oelibc PRIVATE
+  internal
   ${PROJECT_BINARY_DIR}/3rdparty/musl/musl/src/internal
   ${PROJECT_BINARY_DIR}/3rdparty/musl/musl/arch/x86_64)
 
-# This project and its dependents require include/libc in the include path.
-#
-# Note the difference between build time (absolute in build tree) and
-# install time (relative to install prefix).
-target_include_directories(oelibc PUBLIC
-  $<BUILD_INTERFACE:${OE_INCDIR}/openenclave/libc>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libc>)
-
-# When building this project, we also need a number of internal includes:
-target_include_directories(oelibc PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/internal
-  ${PROJECT_BINARY_DIR}/3rdparty/musl/musl/src/internal)
-
-# Assemble lib-archive into proper directory.
 set_property(TARGET oelibc PROPERTY
   ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/openenclave/enclave)
 

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -30,8 +30,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif ()
 
 add_library(oelibc STATIC
-    $<TARGET_OBJECTS:oelibasm>
-
     arc4random.c
     atexit.c
     dladdr.c
@@ -707,7 +705,8 @@ endif ()
 # This project (and its dependents) require the enclave headers and
 # library, and the musl headers.
 target_link_libraries(oelibc
-  PUBLIC oecore oelibc_includes)
+  PUBLIC oecore oelibc_includes
+  PRIVATE oelibasm)
 
 target_include_directories(oelibc PRIVATE
   internal
@@ -717,6 +716,5 @@ target_include_directories(oelibc PRIVATE
 set_property(TARGET oelibc PROPERTY
   ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/openenclave/enclave)
 
-# Install lib-archive upon install-time.
-install(TARGETS oelibc EXPORT openenclave-targets
+install(TARGETS oelibc oelibasm EXPORT openenclave-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -12,13 +12,13 @@
 # Use intermediate project and add properties later using an interface library
 include (ExternalProject)
 ExternalProject_Add(oelibcxx_tmp
-    DEPENDS cxxrt-static oelibcxx_unwind oelibcxx_cxx
+    DEPENDS cxxrt-static oelibcxx_unwind libcxx
     DOWNLOAD_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND sh -c "rm -f *.o ${OE_LIBDIR}/enclave/liboelibcxx.a"
             COMMAND ar x $<TARGET_FILE:cxxrt-static>
             COMMAND ar x ${PROJECT_BINARY_DIR}/3rdparty/libunwind/libunwind/src/.libs/libunwind.a
-            COMMAND ar x $<TARGET_FILE:oelibcxx_cxx>
+            COMMAND ar x $<TARGET_FILE:libcxx>
             COMMAND sh -c "ar qs ${OE_LIBDIR}/openenclave/enclave/liboelibcxx.a *.o"
         INSTALL_COMMAND ""
         )
@@ -30,7 +30,7 @@ target_link_libraries(oelibcxx INTERFACE
     $<BUILD_INTERFACE:${OE_LIBDIR}/openenclave/enclave/liboelibcxx.a>
     $<INSTALL_INTERFACE:\${_IMPORT_PREFIX}/${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/liboelibcxx.a>
     )
-target_link_libraries(oelibcxx INTERFACE oelibcxx_cxx)
+target_link_libraries(oelibcxx INTERFACE libcxx)
 install(FILES ${OE_LIBDIR}/openenclave/enclave/liboelibcxx.a DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 install(TARGETS oelibcxx EXPORT openenclave-targets)
 
@@ -39,11 +39,11 @@ install(TARGETS oelibcxx EXPORT openenclave-targets)
 #add_library(oelibcxx STATIC
 #   $<TARGET_OBJECTS:cxxrt-static>
 #   $<TARGET_OBJECTS:oelibcxx_unwind>
-#   $<TARGET_OBJECTS:oelibcxx_cxx>
+#   $<TARGET_OBJECTS:libcxx>
 #   )
 #target_link_libraries(oelibcxx cxxrt-static)
 #target_link_libraries(oelibcxx oelibcxx_unwind)
-#target_link_libraries(oelibcxx oelibcxx_cxx)
+#target_link_libraries(oelibcxx libcxx)
 # assemble lib-archive into proper dir
 #set_property(TARGET oelibcxx PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/enclave)
 # install lib-archive upon install-time

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -1,50 +1,20 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-#
-# CMake project for CXX lib - re-archive the objects from
-# external libcxx, libcxxrt, libunwind and wrap in easy-to-use CMake target
-#
-# Note: This approach might not work on Windows.
-# Solutions are either to convert to OBJECT libraries (see below), or
-# place/install all three libs (cxx, rt, unwind) and link against all
-# three.
 
-# Use intermediate project and add properties later using an interface library
-include (ExternalProject)
-ExternalProject_Add(oelibcxx_tmp
-    DEPENDS cxxrt-static oelibcxx_unwind libcxx
-    DOWNLOAD_COMMAND ""
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND sh -c "rm -f *.o ${OE_LIBDIR}/enclave/liboelibcxx.a"
-            COMMAND ar x $<TARGET_FILE:cxxrt-static>
-            COMMAND ar x ${PROJECT_BINARY_DIR}/3rdparty/libunwind/libunwind/src/.libs/libunwind.a
-            COMMAND ar x $<TARGET_FILE:libcxx>
-            COMMAND sh -c "ar qs ${OE_LIBDIR}/openenclave/enclave/liboelibcxx.a *.o"
-        INSTALL_COMMAND ""
-        )
+add_library(oelibcxx STATIC)
 
-# Interface lib to propagate includes&lib and install-rule
-add_library(oelibcxx INTERFACE)
-add_dependencies(oelibcxx oelibcxx_tmp)
-target_link_libraries(oelibcxx INTERFACE
-    $<BUILD_INTERFACE:${OE_LIBDIR}/openenclave/enclave/liboelibcxx.a>
-    $<INSTALL_INTERFACE:\${_IMPORT_PREFIX}/${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/liboelibcxx.a>
-    )
-target_link_libraries(oelibcxx INTERFACE libcxx)
-install(FILES ${OE_LIBDIR}/openenclave/enclave/liboelibcxx.a DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
-install(TARGETS oelibcxx EXPORT openenclave-targets)
+# NOTE: The three listed libraries are all `OBJECT` libraries, which
+# is just a collection of objects known to CMake. By "linking" them
+# here, we're actually combining all the objects into a single static
+# library using CMake, which is portable. This also transitively pulls
+# in all the public compile options, compile definitions, and include
+# directories of these targets and their dependencies (such as
+# `oelibc`). Hence this file has more comments than code.
+target_link_libraries(oelibcxx
+  PUBLIC libcxx libcxxrt libunwind)
 
-# At some point, we should convert the 3rdparty-libs into true CMake OBJECT libs,
-# so we could source the objects directly like this:
-#add_library(oelibcxx STATIC
-#   $<TARGET_OBJECTS:cxxrt-static>
-#   $<TARGET_OBJECTS:oelibcxx_unwind>
-#   $<TARGET_OBJECTS:libcxx>
-#   )
-#target_link_libraries(oelibcxx cxxrt-static)
-#target_link_libraries(oelibcxx oelibcxx_unwind)
-#target_link_libraries(oelibcxx libcxx)
-# assemble lib-archive into proper dir
-#set_property(TARGET oelibcxx PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/enclave)
-# install lib-archive upon install-time
-#install (TARGETS oelibcxx EXPORT openenclave ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/enclave)
+set_property(TARGET oelibcxx
+  PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/enclave)
+
+install(TARGETS oelibcxx EXPORT openenclave
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/tests/libc/enc/CMakeLists.txt
+++ b/tests/libc/enc/CMakeLists.txt
@@ -29,6 +29,8 @@ function(add_libc_test_enc NAME CFILE)
         )
     target_compile_options(libctest-${NAME}_enc PRIVATE
         -Wno-error
+        -Wno-unknown-pragmas
+        -Wno-unused-function
         )
     target_compile_definitions(libctest-${NAME}_enc PRIVATE -D__TEST__="${CFILE}")
     target_link_libraries(libctest-${NAME}_enc libctest-support)

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -47,6 +47,9 @@ function(add_libcxx_test_enc NAME CXXFILE)
         -std=c++14
         # These are third-party tests, so we don't care about their warnings.
         -Wno-error
+        -Wno-unused-function
+        -Wno-unused-local-typedef
+        -Wno-deprecated-declarations
         # Remove NDEBUG to enable the libcxx testsuite assertions in Release
         -UNDEBUG
         )

--- a/tests/libcxxrt/enc/CMakeLists.txt
+++ b/tests/libcxxrt/enc/CMakeLists.txt
@@ -11,9 +11,10 @@ oeedl_file(../libcxxrt.edl enclave gen)
 
 # helper lib to contain file needed by some tests
 add_library(libcxxrttest-support
-  ${gen}
+    ${gen}
     )
-target_compile_options(libcxxrttest-support PRIVATE
+target_compile_options(libcxxrttest-support PUBLIC
+    $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>
     -Wno-error
     )
 target_link_libraries(libcxxrttest-support PUBLIC oelibcxx oeenclave)
@@ -28,9 +29,8 @@ function(add_libcxxrt_test_enc NAME CXXFILE)
         ${PROJECT_SOURCE_DIR}/3rdparty/libcxxrt/libcxxrt/test
         ${CMAKE_CURRENT_BINARY_DIR}
         )
-    target_compile_options(libcxxrttest-${NAME}_enc PRIVATE -Wno-error $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>)
     target_compile_definitions(libcxxrttest-${NAME}_enc PRIVATE -DWITH_MAIN -D__TEST__="${CXXFILE}")
-    target_link_libraries(libcxxrttest-${NAME}_enc libcxxrttest-support oelibcxx oelibc cxxrt-static)
+    target_link_libraries(libcxxrttest-${NAME}_enc libcxxrttest-support)
     if("${NAME}" STREQUAL "test_foreign_exceptions")
         target_link_libraries(libcxxrttest-${NAME}_enc -Wl,--wrap,_Unwind_RaiseException)
     endif()

--- a/tests/libunwind/enc/CMakeLists.txt
+++ b/tests/libunwind/enc/CMakeLists.txt
@@ -9,7 +9,6 @@
 include(add_enclave_executable)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/get_testcase_name.cmake)
 
-set(LIBUNWIND_LIB_DIR ${PROJECT_BINARY_DIR}/3rdparty/libunwind/libunwind/src/.libs)
 set(LIBUNWIND_TEST_DIR ${PROJECT_SOURCE_DIR}/3rdparty/libunwind/libunwind/tests)
 
 # helper lib to contain file needed by some tests
@@ -20,33 +19,36 @@ add_library(libunwindtest-support
         ${LIBUNWIND_TEST_DIR}/flush-cache.h
         test_support.c
     )
-target_compile_options(libunwindtest-support PRIVATE -Wno-error)
-target_include_directories(libunwindtest-support PRIVATE
-        ${PROJECT_BINARY_DIR}/3rdparty/libunwind/libunwind/include
+target_compile_options(libunwindtest-support PRIVATE -Wno-error -DUNW_LOCAL_ONLY=1)
+target_include_directories(libunwindtest-support PUBLIC
+        ${PROJECT_SOURCE_DIR}/3rdparty/libunwind
+        ${PROJECT_BINARY_DIR}/3rdparty/libunwind
+        ${PROJECT_SOURCE_DIR}/3rdparty/libunwind/libunwind/include
     )
-target_link_libraries(libunwindtest-support PUBLIC oelibc oelibcxx oeenclave)
+target_link_libraries(libunwindtest-support PUBLIC oelibcxx oeenclave)
 
 function(add_libunwind_test_enc NAME TESTFILE)
     add_executable(libunwindtest-${NAME}_enc
         enc.c
         ${PROJECT_SOURCE_DIR}/${TESTFILE}
         )
-    add_dependencies(libunwindtest-${NAME}_enc oelibcxx_unwind)
     target_include_directories(libunwindtest-${NAME}_enc PRIVATE
         ..
-        ${PROJECT_BINARY_DIR}/3rdparty/libunwind/libunwind/include
         ${PROJECT_BINARY_DIR}/3rdparty/libunwind/libunwind/tests
         )
-    target_compile_options(libunwindtest-${NAME}_enc PRIVATE -Wno-error -fno-inline-functions)
+    target_compile_options(libunwindtest-${NAME}_enc
+        PRIVATE
+        -Wno-error
+        -Wno-macro-redefined # We need `UNW_LOCAL_ONLY=1` but some files already define it.
+        -fno-inline-functions)
     if(("${NAME}" STREQUAL "Ltest-varargs") AND ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
         target_compile_options(libunwindtest-${NAME}_enc PRIVATE -include enc/clang_varargs_extra.h)
     endif()
-    target_compile_definitions(libunwindtest-${NAME}_enc PRIVATE -DWITH_MAIN -D__TEST__="${TESTFILE}")
+    target_compile_definitions(libunwindtest-${NAME}_enc PRIVATE
+        -DWITH_MAIN -D__TEST__="${TESTFILE}" -DUNW_LOCAL_ONLY=1)
     target_link_libraries(libunwindtest-${NAME}_enc libunwindtest-support)
-    target_link_libraries(libunwindtest-${NAME}_enc ${LIBUNWIND_LIB_DIR}/libunwind-x86_64.a ${LIBUNWIND_LIB_DIR}/libunwind.a)
-    target_link_libraries(libunwindtest-${NAME}_enc oelibc oelibcxx oeenclave)
-    target_link_libraries(libunwindtest-${NAME}_enc -Wl,--require-defined=pthread_mutex_lock)
-    target_link_libraries(libunwindtest-${NAME}_enc -Wl,--require-defined=_U_dyn_info_list_addr)
+    target_link_libraries(libunwindtest-${NAME}_enc -Wl,--undefined=pthread_mutex_lock)
+    target_link_libraries(libunwindtest-${NAME}_enc -Wl,--undefined=_U_dyn_info_list_addr)
 endfunction(add_libunwind_test_enc)
 
 file(STRINGS "../tests.supported" alltests)

--- a/tests/libunwind/tests.supported
+++ b/tests/libunwind/tests.supported
@@ -4,8 +4,6 @@
 3rdparty/libunwind/libunwind/tests/Ltest-init.cxx
 3rdparty/libunwind/libunwind/tests/Ltest-varargs.c
 3rdparty/libunwind/libunwind/tests/test-flush-cache.c
-3rdparty/libunwind/libunwind/tests/test-init-remote.c
 3rdparty/libunwind/libunwind/tests/test-mem.c
-3rdparty/libunwind/libunwind/tests/test-proc-info.c
 3rdparty/libunwind/libunwind/tests/test-static-link-loc.c
 3rdparty/libunwind/libunwind/tests/test-strerror.c

--- a/tests/libunwind/tests.unsupported
+++ b/tests/libunwind/tests.unsupported
@@ -18,5 +18,7 @@
 3rdparty/libunwind/libunwind/tests/run-ptrace-mapper
 3rdparty/libunwind/libunwind/tests/run-ptrace-misc
 3rdparty/libunwind/libunwind/tests/test-async-sig.c
+3rdparty/libunwind/libunwind/tests/test-init-remote.c
+3rdparty/libunwind/libunwind/tests/test-proc-info.c
 3rdparty/libunwind/libunwind/tests/test-ptrace.c
 3rdparty/libunwind/libunwind/tests/test-setjmp.c


### PR DESCRIPTION
This PR resolves #1081, #1126, and #1127.

The normal tests pass CI for Linux and Windows, and the full C/CXX tests passed (on my machine).

You may want to review by commit instead of the diff as a whole, as I also did some formatting just and renaming just to make things easier while I was fixing things.