### PR TITLE
Temporarily disable flaky test so PRs aren't blocked

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -160,5 +160,6 @@ parallel "Check Pre-Commit Requirements" : { checkPreCommitRequirements() },
         "Coffeelake gcc SGX1-FLC Release" : { coffeelakeTest('gcc', 'SGX1FLC', 'Release') },
         "Coffeelake gcc SGX1-FLC RelWithDebInfo" : { coffeelakeTest('gcc', 'SGX1FLC', 'RelWithDebInfo') },
         "Windows Debug Cross-platform" : { windowsDebugCrossPlatform() },
-        "Windows Release Cross-platform" : { windowsReleaseCrossPlatform() },
-        "Non-Simulation Container SGX1-FLC RelWithDebInfo" : { nonSimulationTest() }
+        "Windows Release Cross-platform" : { windowsReleaseCrossPlatform() }
+        // TODO: Re-enable this once it is no longer flaky.
+        // "Non-Simulation Container SGX1-FLC RelWithDebInfo" : { nonSimulationTest() }


### PR DESCRIPTION
We will re-enable this stage in #1170, but they need to be disabled for now so that PRs can be merged.