### PR TITLE
Fix Linux build & enable QEMU in CI

### DIFF
--- a/new_platforms/run_tests_aarch64.sh
+++ b/new_platforms/run_tests_aarch64.sh
@@ -87,7 +87,11 @@ CMD="su -c \""
 CMD="$CMD mkdir /mnt/oe &&"
 CMD="$CMD mount -t 9p -o trans=virtio sh0 /mnt/oe -oversion=9p2000.L &&"
 CMD="$CMD cp /mnt/oe/new_platforms/bin/optee/tests/3156152a-19d1-423c-96ea-5adf5675798f.ta /lib/optee_armtz &&"
-CMD="$CMD /mnt/oe/new_platforms/tests/oetests_host/oetests_host"
+if [ -z "$TESTS_NOT_TO_RUN" ]; then
+    CMD="$CMD /mnt/oe/new_platforms/tests/oetests_host/oetests_host"
+else
+    CMD="$CMD /mnt/oe/new_platforms/tests/oetests_host/oetests_host --gtest_filter=-$TESTS_NOT_TO_RUN"
+fi
 CMD="$CMD \""
 
 sshpass -p test ssh test@localhost -p 5555 "$CMD"

--- a/new_platforms/src/Untrusted/linux/Makefile
+++ b/new_platforms/src/Untrusted/linux/Makefile
@@ -16,6 +16,7 @@ OPTEE_CLIENT = ../../../../3rdparty/optee_client
 
 DEFINES = -DOE_USE_OPTEE -D_DEBUG
 INCLUDES =                             \
+    -I./                               \
     -I../                              \
     -I../../                           \
     -I../../../include/optee/host      \

--- a/new_platforms/src/Untrusted/linux/tcps.h
+++ b/new_platforms/src/Untrusted/linux/tcps.h
@@ -7,6 +7,6 @@
  * would not be needed if oeedger8r had an option to do this
  * for us for internal APIs.
  */
-#include "..\..\..\include\tcps.h"
+#include "../../../include/tcps.h"
 #define oe_call_enclave_function oe_call_internal_enclave_function
 #define oe_create_enclave oe_create_internal_enclave

--- a/new_platforms/src/Untrusted/linux/teehost_optee.c
+++ b/new_platforms/src/Untrusted/linux/teehost_optee.c
@@ -73,7 +73,7 @@ static void *generic_rpc_thread_procedure(void *param)
 }
 
 static oe_result_t uuid_from_string(
-    char *a_TaIdString,
+    const char *a_TaIdString,
     TEEC_UUID *a_Uuid)
 {
     int i;
@@ -81,13 +81,19 @@ static oe_result_t uuid_from_string(
     char *id_copy;
     const char *current_token;
 
-    if (strlen(a_TaIdString) != 36)
-        return OE_INVALID_PARAMETER;
-
     id_copy = strdup(a_TaIdString);
 
+    /* Remove ".ta" extension, if one is present. */
+    size_t len = strlen(id_copy);
+    if ((len > 3) && (strcmp(&id_copy[len - 3], ".ta") == 0)) {
+        id_copy[len - 3] = 0;
+    }
+
+    if (strlen(id_copy) != 36)
+        return OE_INVALID_PARAMETER;
+
     i = 5;
-    current_token = strtok((char *)id_copy, "-");
+    current_token = strtok(id_copy, "-");
     while (current_token != NULL && i >= 0) {
         uuid_parts[--i] = strtoull(current_token, NULL, 16);
         current_token = strtok(NULL, "-");
@@ -126,18 +132,9 @@ oe_result_t oe_create_enclave_helper(
     uint32_t err_origin;
     int s;
 
-    char uuidstring[80];
-    strcpy_s(uuidstring, sizeof(uuidstring), a_TaIdString);
-
-    /* Remove ".ta" extension, if one is present. */
-    size_t len = strlen(uuidstring);
-    if ((len > 3) && (strcmp(&uuidstring[len - 3], ".ta") == 0)) {
-        uuidstring[len - 3] = 0;
-    }
-   
     OE_UNUSED(a_Flags);
 
-    status = uuid_from_string((char *)a_TaIdString, &uuid);
+    status = uuid_from_string(a_TaIdString, &uuid);
     if (status != OE_OK) {
         return status;
     }

--- a/new_platforms/src/Untrusted/linux/teehost_optee.c
+++ b/new_platforms/src/Untrusted/linux/teehost_optee.c
@@ -28,7 +28,7 @@ static TEEC_Result handle_generic_rpc(
         if (type >= g_internal_ocall_table_v2.nr_ocall)
             return TEEC_ERROR_BAD_PARAMETERS;
 
-        uint32_t bytes_written = 0;
+        size_t bytes_written = 0;
         g_internal_ocall_table_v2.call_addr[type](
             input_buffer,
             input_buffer_size,
@@ -46,7 +46,7 @@ static TEEC_Result handle_generic_rpc(
         if (type >= g_ocall_table_v2.nr_ocall)
             return TEEC_ERROR_BAD_PARAMETERS;
 
-        uint32_t bytes_written = 0;
+        size_t bytes_written = 0;
         g_ocall_table_v2.call_addr[type](
             input_buffer,
             input_buffer_size,


### PR DESCRIPTION
This PR:

1. Fixes the header include paths for the OE untrusted side on Linux;
2. Fixes parsing of the TA UUID's with extensions;
3. Minor type fixes.