### PR TITLE
Switch to using C++14 as our default (internal) standard

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -49,8 +49,6 @@ add_dependencies(libcxx libcxx_includes)
 set_target_properties(libcxx PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
 
-target_compile_options(libcxx PRIVATE -std=c++14)
-
 target_compile_definitions(libcxx
   PRIVATE
   -DLIBCXXRT

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -16,6 +16,12 @@ if (NOT CMAKE_C_COMPILER_ID STREQUAL CMAKE_CXX_COMPILER_ID)
     "${CMAKE_C_COMPILER_ID} != ${CMAKE_CXX_COMPILER_ID}")
 endif ()
 
+# Set the default standard to C++14 for all targets.
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# Do not use, for example, `-std=gnu++14`.
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Set default build type and sanitize.
 # TODO: See #756: Fix this since debug is the default.
 if (NOT CMAKE_BUILD_TYPE)

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -655,6 +655,7 @@ add_library(oelibc STATIC
     ${MUSLSRC}/unistd/dup.c
     ${MUSLSRC}/unistd/dup3.c)
 
+# NOTE: This is the minimum required for musl sources.
 set_property(TARGET oelibc PROPERTY C_STANDARD 99)
 
 target_compile_options(oelibc PRIVATE

--- a/tests/abortStatus/host/CMakeLists.txt
+++ b/tests/abortStatus/host/CMakeLists.txt
@@ -12,10 +12,8 @@ if(USE_DEBUG_MALLOC)
     target_compile_definitions(abortStatus_host PRIVATE OE_USE_DEBUG_MALLOC)
 endif()
 
-target_include_directories(abortStatus_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-                           ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_compile_options(abortStatus_host PRIVATE
-                       $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>)
+target_include_directories(abortStatus_host PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(abortStatus_host oehostapp)

--- a/tests/create-rapid/host/CMakeLists.txt
+++ b/tests/create-rapid/host/CMakeLists.txt
@@ -7,8 +7,5 @@ oeedl_file(../create_rapid.edl host gen)
 
 add_executable(create_rapid_host host.cpp ${gen})
 
-target_compile_options(create_rapid_host PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:-std=c++11>)
-
 target_include_directories(create_rapid_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(create_rapid_host oehostapp)

--- a/tests/crypto_crls_cert_chains/enc/CMakeLists.txt
+++ b/tests/crypto_crls_cert_chains/enc/CMakeLists.txt
@@ -3,9 +3,4 @@
 
 include(add_enclave_executable)
 add_executable(crypto-extra_enc enc.cpp)
-
-target_compile_options(crypto-extra_enc PRIVATE
-    -std=c++11
-)
-
 target_link_libraries(crypto-extra_enc oelibcxx oeenclave)

--- a/tests/crypto_crls_cert_chains/host/CMakeLists.txt
+++ b/tests/crypto_crls_cert_chains/host/CMakeLists.txt
@@ -80,9 +80,4 @@ add_custom_command(TARGET crypto-extra_host
             COMMAND openssl crl -inform pem -outform der -in ${DATA_DIR}/intermediate_crl2.pem -out ${DATA_DIR}/intermediate_crl2.der
             )
 
-target_compile_options(crypto-extra_host PRIVATE
-    -std=c++11
-)
-
 target_link_libraries(crypto-extra_host oehostapp)
-

--- a/tests/ecall_ocall/host/CMakeLists.txt
+++ b/tests/ecall_ocall/host/CMakeLists.txt
@@ -1,10 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_executable(ecall_ocall_host
-    host.cpp
-    )
-target_compile_options(ecall_ocall_host PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>
-    )
+add_executable(ecall_ocall_host host.cpp)
 target_link_libraries(ecall_ocall_host oehostapp)

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -14,7 +14,6 @@ add_library(libcxxtest-support
     )
 
 target_compile_options(libcxxtest-support PRIVATE
-    -std=c++14
     -Wno-error=attributes
     -Wno-error=strict-overflow
     -Wno-error=unused-local-typedefs
@@ -44,7 +43,7 @@ function(add_libcxx_test_enc NAME CXXFILE)
         )
 
       target_compile_options(libcxxtest-${NAME}_enc PRIVATE
-        -std=c++14
+
         # These are third-party tests, so we don't care about their warnings.
         -Wno-error
         -Wno-unused-function

--- a/tests/libcxx/host/CMakeLists.txt
+++ b/tests/libcxx/host/CMakeLists.txt
@@ -2,5 +2,4 @@
 # Licensed under the MIT License.
 
 add_executable(libcxx_host host.cpp)
-target_compile_options(libcxx_host PRIVATE -std=c++14)
 target_link_libraries(libcxx_host oehostapp)

--- a/tests/libcxxrt/enc/CMakeLists.txt
+++ b/tests/libcxxrt/enc/CMakeLists.txt
@@ -10,13 +10,8 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/get_testcase_name.cmake)
 oeedl_file(../libcxxrt.edl enclave gen)
 
 # helper lib to contain file needed by some tests
-add_library(libcxxrttest-support
-    ${gen}
-    )
-target_compile_options(libcxxrttest-support PUBLIC
-    $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>
-    -Wno-error
-    )
+add_library(libcxxrttest-support ${gen})
+target_compile_options(libcxxrttest-support PUBLIC -Wno-error)
 target_link_libraries(libcxxrttest-support PUBLIC oelibcxx oeenclave)
 target_link_libraries(libcxxrttest-support INTERFACE -Wl,--undefined=test)
 

--- a/tests/memory/host/CMakeLists.txt
+++ b/tests/memory/host/CMakeLists.txt
@@ -7,9 +7,5 @@ oeedl_file(../memory.edl host gen)
 
 add_executable(memory_host host.cpp ${gen})
 
-target_compile_options(memory_host PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:-std=c++11>
-    )
-
 target_include_directories(memory_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(memory_host oehostapp)

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -32,10 +32,4 @@ add_executable(edl_enc
     )
 
 target_include_directories(edl_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
-
-set_property(
-    TARGET edl_enc
-    PROPERTY CXX_STANDARD 11
-)
-
 target_link_libraries(edl_enc oelibcxx oeenclave)

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -33,9 +33,4 @@ add_executable(edl_host
 )
 
 target_include_directories(edl_host PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
-
-set_property(
-    TARGET edl_host
-    PROPERTY CXX_STANDARD 11
-)
 target_link_libraries(edl_host oehostapp)

--- a/tests/qeidentity/enc/CMakeLists.txt
+++ b/tests/qeidentity/enc/CMakeLists.txt
@@ -7,10 +7,6 @@ include(add_enclave_executable)
 oeedl_file(../tests.edl enclave gen)
 add_executable(qeidentity_enc enc.cpp ${gen})
 
-target_compile_options(qeidentity_enc PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:-std=c++11>
-)
-
 if(USE_LIBSGX)
     target_compile_definitions(qeidentity_enc PRIVATE OE_USE_LIBSGX)
 endif()    

--- a/tests/report/enc/CMakeLists.txt
+++ b/tests/report/enc/CMakeLists.txt
@@ -7,9 +7,7 @@ include(add_enclave_executable)
 oeedl_file(../tests.edl enclave gen)
 add_executable(report_enc enc.cpp datetime.cpp ${gen})
 
-target_compile_options(report_enc PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:-std=c++11>
-)
-
-target_include_directories(report_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../common)
+target_include_directories(report_enc PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common)
 target_link_libraries(report_enc oeenclave)

--- a/tests/sealKey/host/CMakeLists.txt
+++ b/tests/sealKey/host/CMakeLists.txt
@@ -7,11 +7,7 @@ oeedl_file(../sealKey.edl host gen)
 
 add_executable(sealKey_host host.cpp ${gen})
 
-target_compile_options(sealKey_host PRIVATE
-                       $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>
-                       )
-
-target_include_directories(sealKey_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-                           ${CMAKE_CURRENT_SOURCE_DIR})
-  
+target_include_directories(sealKey_host PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(sealKey_host oehostapp)

--- a/tests/stdcxx/enc/CMakeLists.txt
+++ b/tests/stdcxx/enc/CMakeLists.txt
@@ -12,7 +12,6 @@ target_compile_options(stdcxx_enc PRIVATE
     -fno-builtin-memset
     -fno-builtin-fprintf
     -fno-builtin-printf
-    -std=c++14
     )
 
 target_link_libraries(stdcxx_enc oelibcxx oeenclave)

--- a/tests/thread/host/CMakeLists.txt
+++ b/tests/thread/host/CMakeLists.txt
@@ -2,6 +2,4 @@
 # Licensed under the MIT License.
 
 add_executable(thread_host host.cpp rwlocks_test_host.cpp)
-target_compile_options(thread_host PRIVATE
-    --std=c++11)
 target_link_libraries(thread_host oehostapp)

--- a/tests/threadcxx/enc/CMakeLists.txt
+++ b/tests/threadcxx/enc/CMakeLists.txt
@@ -3,6 +3,4 @@
 
 include(add_enclave_executable)
 add_executable(threadcxx_enc enc.cpp cond_tests.cpp)
-target_compile_options(threadcxx_enc PRIVATE
-    --std=c++11)
 target_link_libraries(threadcxx_enc oelibcxx oeenclave)

--- a/tests/threadcxx/host/CMakeLists.txt
+++ b/tests/threadcxx/host/CMakeLists.txt
@@ -2,6 +2,4 @@
 # Licensed under the MIT License.
 
 add_executable(threadcxx_host host.cpp)
-target_compile_options(threadcxx_host PRIVATE
-    --std=c++11)
 target_link_libraries(threadcxx_host oehostapp)


### PR DESCRIPTION
Note that this does not affect consumers linking to Open Enclave; this is just for building our sources. The tests already required a mix of C++11 and C++14, and our minimum supported compilers (GCC 5.4 and Clang 7) all support C++14. The musl sources explicitly require C99.

This resolves #1018 (but not #749).