### PR TITLE
Build with -Wpointer-arith

### DIFF
--- a/3rdparty/libunwind/CMakeLists.txt
+++ b/3rdparty/libunwind/CMakeLists.txt
@@ -137,6 +137,9 @@ elseif (CMAKE_C_COMPILER_ID MATCHES Clang)
     -Wno-macro-redefined)
 endif ()
 
+# Allow arithmetic on void*
+set_source_files_properties(libunwind/src/elf64.c PROPERTIES COMPILE_FLAGS -Wno-pointer-arith)
+
 target_compile_definitions(libunwind PRIVATE
   HAVE_ELF_H
   HAVE_ENDIAN_H

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -70,7 +70,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
   # Enables all the warnings about constructions that some users consider questionable,
   # and that are easy to avoid. Treat at warnings-as-errors, which forces developers
   # to fix warnings as they arise, so they don't accumulate "to be fixed later".
-  add_compile_options(-Wall -Werror)
+  add_compile_options(-Wall -Werror -Wpointer-arith)
 
   add_compile_options(-fno-strict-aliasing)
 

--- a/tests/file/file.edl
+++ b/tests/file/file.edl
@@ -16,7 +16,7 @@ enclave {
             [in, string] const char *modes);
 
         size_t Fread(
-            [in, out, count=size, isptr] void_ptr ptr,
+            [in, out, size=size, isptr] void_ptr ptr,
             size_t size,
             [user_check] MY_FILE *stream);
 


### PR DESCRIPTION
Any arithmetic on void* will be flagged as error.
Disable warning for one file in libunwind.
Fix file.edl to use size instead of count.