### PR TITLE
Restored tests/libc HeapPageCount/StackPagecount

### DIFF
--- a/tests/libc/enc/enc.c
+++ b/tests/libc/enc/enc.c
@@ -86,8 +86,8 @@ OE_SET_ENCLAVE_SGX(
     1,    /* ProductID */
     1,    /* SecurityVersion */
     true, /* AllowDebug */
-    256,  /* HeapPageCount */
-    256,  /* StackPageCount */
-    2);   /* TCSCount */
+    4096, /* HeapPageCount */
+    1024, /* StackPageCount */
+    8);   /* TCSCount */
 
 OE_DEFINE_EMPTY_ECALL_TABLE();


### PR DESCRIPTION
Restoring tests/libc/enc/enc.c to its original i.e. restoring HeapPageCount/StackPageCount sizes to its original as this is not yet enabled with ELF enclaves with my PR #1173 . The change also broke one test with the libc Jenkins pipeline run. 
https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/OpenEnclave-libc_tests/detail/OpenEnclave-libc_tests/119/pipeline