### PR TITLE
Fix the CMake package

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -1,14 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+set(LIBCXX_INCLUDES ${OE_INCDIR}/openenclave/libcxx)
+
 include (ExternalProject)
 ExternalProject_Add(libcxx_includes
   DOWNLOAD_COMMAND ""
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_LIST_DIR}/libcxx/include ${OE_INCDIR}/openenclave/libcxx
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/libcxx/include/__config ${OE_INCDIR}/openenclave/libcxx/__config_original
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/__config ${OE_INCDIR}/openenclave/libcxx/__config
+    ${CMAKE_CURRENT_LIST_DIR}/libcxx/include ${LIBCXX_INCLUDES}
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/libcxx/include/__config ${LIBCXX_INCLUDES}/__config_original
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/__config ${LIBCXX_INCLUDES}/__config
   INSTALL_COMMAND "")
 
 add_library(libcxx OBJECT
@@ -60,7 +62,7 @@ target_link_libraries(libcxx PUBLIC oelibc)
 
 target_include_directories(libcxx
   PUBLIC
-  $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${OE_INCDIR}/openenclave/libcxx>>
+  $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${LIBCXX_INCLUDES}>>
   $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
   PRIVATE
   libcxx/src
@@ -69,16 +71,14 @@ target_include_directories(libcxx
 # Prevent warnings treated as error
 set_source_files_properties(
   libcxx/src/locale.cpp
-  PROPERTIES COMPILE_FLAGS "-Wno-conversion"
-)
+  PROPERTIES COMPILE_FLAGS "-Wno-conversion")
 
 set_source_files_properties(
   libcxx/src/system_error.cpp
-  PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter"
-)
+  PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 
-install(TARGETS libcxx EXPORT openenclave-targets
-  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+install(TARGETS libcxx EXPORT openenclave-targets)
 
-install(DIRECTORY ${OE_INCDIR}/openenclave/libcxx
+install(DIRECTORY ${LIBCXX_INCLUDES}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
+

--- a/3rdparty/libcxxrt/CMakeLists.txt
+++ b/3rdparty/libcxxrt/CMakeLists.txt
@@ -44,3 +44,5 @@ target_compile_options(libcxxrt PRIVATE -Wno-tautological-compare)
 target_compile_definitions(libcxxrt PRIVATE -D_GNU_SOURCE)
 
 target_link_libraries(libcxxrt PUBLIC oelibc)
+
+install(TARGETS libcxxrt EXPORT openenclave-targets)

--- a/3rdparty/libunwind/CMakeLists.txt
+++ b/3rdparty/libunwind/CMakeLists.txt
@@ -163,3 +163,5 @@ target_include_directories(libunwind PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/src
   ${CMAKE_CURRENT_BINARY_DIR}/tdep
   ${CMAKE_CURRENT_BINARY_DIR})
+
+install(TARGETS libunwind EXPORT openenclave-targets)

--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -4,15 +4,15 @@
 # Copy mbedtls sources to replace config.h and build w/ own flags
 
 set(MBEDTLS_WRAP_CFLAGS "-nostdinc -I${OE_INCDIR}/openenclave/libc -fPIC -fno-builtin-udivti3 ${SPECTRE_MITIGATION_FLAGS}")
+set(MBEDTLS_INCLUDES ${OE_INCDIR}/openenclave/mbedtls)
 
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
-
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
-	configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/config.h ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h COPYONLY)
-	file(APPEND ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h "\#define\ MBEDTLS_CERTS_C\n\n\#define\ MBEDTLS_DEBUG_C\n")
-else()
-	configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/config.h ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h COPYONLY)
-endif()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h COPYONLY)
+  file(APPEND ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h "\#define\ MBEDTLS_CERTS_C\n\n\#define\ MBEDTLS_DEBUG_C\n")
+else ()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h COPYONLY)
+endif ()
 
 include (ExternalProject)
 ExternalProject_Add(mbedtls-wrap
@@ -20,8 +20,10 @@ ExternalProject_Add(mbedtls-wrap
 
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${CMAKE_CURRENT_LIST_DIR}/mbedtls <SOURCE_DIR>
+
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h <SOURCE_DIR>/include/mbedtls/config.h
+
     # Addl args for compiler
     CMAKE_ARGS
         -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
@@ -32,31 +34,65 @@ ExternalProject_Add(mbedtls-wrap
 
     # copy headers/libs
     INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory
-        <SOURCE_DIR>/include/mbedtls ${OE_INCDIR}/openenclave/mbedtls
+        <SOURCE_DIR>/include/mbedtls ${MBEDTLS_INCLUDES}
         COMMAND ${CMAKE_COMMAND} -E copy
         <BINARY_DIR>/library/libmbedx509.a ${OE_LIBDIR}/openenclave/enclave/
         <BINARY_DIR>/library/libmbedtls.a ${OE_LIBDIR}/openenclave/enclave/
         <BINARY_DIR>/library/libmbedcrypto.a ${OE_LIBDIR}/openenclave/enclave/
     )
-install (DIRECTORY ${OE_INCDIR}/openenclave/mbedtls DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
-install (FILES ${OE_LIBDIR}/openenclave/enclave/libmbedtls.a DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
-install (FILES ${OE_LIBDIR}/openenclave/enclave/libmbedx509.a DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
-install (FILES ${OE_LIBDIR}/openenclave/enclave/libmbedcrypto.a DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+
+# NOTE: These imported libraries must be specified before `oelibc`
+# when linking, hence their dependency on it.
+add_library(mbedtls_imported IMPORTED STATIC)
+set_target_properties(mbedtls_imported PROPERTIES
+  IMPORTED_LOCATION ${OE_LIBDIR}/openenclave/enclave/libmbedtls.a)
+target_link_libraries(mbedtls_imported INTERFACE oelibc)
+
+add_library(mbedx509_imported IMPORTED STATIC)
+set_target_properties(mbedx509_imported PROPERTIES
+  IMPORTED_LOCATION ${OE_LIBDIR}/openenclave/enclave/libmbedx509.a)
+target_link_libraries(mbedx509_imported INTERFACE oelibc)
+
+add_library(mbedcrypto_imported IMPORTED STATIC)
+set_target_properties(mbedcrypto_imported PROPERTIES
+  IMPORTED_LOCATION ${OE_LIBDIR}/openenclave/enclave/libmbedcrypto.a)
+target_link_libraries(mbedcrypto_imported INTERFACE oelibc)
 
 # Convenience lib for use in target_link_libraries
 add_library(mbedcrypto INTERFACE)
+
 add_dependencies(mbedcrypto mbedtls-wrap)
-target_include_directories(mbedcrypto INTERFACE ${OE_INCDIR}/openenclave/)
-target_link_libraries(mbedcrypto INTERFACE 
-    ${OE_LIBDIR}/openenclave/enclave/libmbedtls.a
-    ${OE_LIBDIR}/openenclave/enclave/libmbedx509.a
-    ${OE_LIBDIR}/openenclave/enclave/libmbedcrypto.a
-)
-# For the libc dependency, We would just want to use "oelibc". However, we need
-# an actual lib-dependency between crypto an libc, which is not expressable
-# with CMake. If using the target "oelibc", CMake reorders the libs, resulting
-# in undefined LIBC symbols from crypto. Using the explicit lib-name preserves
-# order.
+
+target_include_directories(mbedcrypto INTERFACE
+  $<BUILD_INTERFACE:${OE_INCDIR}/openenclave>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
+
 target_link_libraries(mbedcrypto INTERFACE
-	${OE_LIBDIR}/openenclave/enclave/liboelibc.a
-	${OE_LIBDIR}/openenclave/enclave/liboecore.a)
+  $<BUILD_INTERFACE:mbedtls_imported>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/libmbedtls.a>
+  $<BUILD_INTERFACE:mbedx509_imported>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/libmbedx509.a>
+  $<BUILD_INTERFACE:mbedcrypto_imported>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/libmbedcrypto.a>
+  # NOTE: This dependency is repeated because during installation the
+  # imported libraries are not part of the CMake dependency graph, so
+  # this transitive dependency would be left out.
+  oelibc)
+
+install(TARGETS mbedcrypto EXPORT openenclave-targets)
+
+install(DIRECTORY ${MBEDTLS_INCLUDES}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
+
+# NOTE: Because these libraries are `IMPORTED`, it is not possible
+# with CMake to install them as targets, so instead they must be
+# installed as files. This is what causes the above problem with the
+# repeated dependency on `oelibc`.
+install(FILES ${OE_LIBDIR}/openenclave/enclave/libmbedtls.a
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+
+install(FILES ${OE_LIBDIR}/openenclave/enclave/libmbedx509.a
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+
+install(FILES ${OE_LIBDIR}/openenclave/enclave/libmbedcrypto.a
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -1,61 +1,56 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# Copy mbedtls sources to replace config.h and build w/ own flags
-
 set(MBEDTLS_WRAP_CFLAGS "-nostdinc -I${OE_INCDIR}/openenclave/libc -fPIC -fno-builtin-udivti3 ${SPECTRE_MITIGATION_FLAGS}")
-set(MBEDTLS_INCLUDES ${OE_INCDIR}/openenclave/mbedtls)
 
+# Create a patched version of mbed TLS's `config.h` that the external
+# project depends on.
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h COPYONLY)
-  file(APPEND ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h "\#define\ MBEDTLS_CERTS_C\n\n\#define\ MBEDTLS_DEBUG_C\n")
-else ()
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h COPYONLY)
+  set(MBEDTLS_CERTS_C TRUE)
+  set(MBEDTLS_DEBUG_C TRUE)
 endif ()
 
-include (ExternalProject)
+configure_file(config.h config.h) # This copies from source to binary folders.
+
+include(ExternalProject)
 ExternalProject_Add(mbedtls-wrap
-    DEPENDS oelibc_includes
+  DEPENDS oelibc_includes
 
-    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_LIST_DIR}/mbedtls <SOURCE_DIR>
+  DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_LIST_DIR}/mbedtls <SOURCE_DIR>
 
-    PATCH_COMMAND ${CMAKE_COMMAND} -E copy
-        ${CMAKE_BINARY_DIR}/3rdparty/mbedtls/config_final.h <SOURCE_DIR>/include/mbedtls/config.h
+  UPDATE_COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_CURRENT_BINARY_DIR}/config.h <SOURCE_DIR>/include/mbedtls/config.h
 
-    # Addl args for compiler
-    CMAKE_ARGS
-        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-        -DCMAKE_C_FLAGS=${MBEDTLS_WRAP_CFLAGS}
-        -DENABLE_PROGRAMS=OFF
-        -DENABLE_TESTING=OFF
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+  CMAKE_ARGS
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_C_FLAGS=${MBEDTLS_WRAP_CFLAGS}
+    -DENABLE_PROGRAMS=OFF
+    -DENABLE_TESTING=OFF
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 
-    # copy headers/libs
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory
-        <SOURCE_DIR>/include/mbedtls ${MBEDTLS_INCLUDES}
-        COMMAND ${CMAKE_COMMAND} -E copy
-        <BINARY_DIR>/library/libmbedx509.a ${OE_LIBDIR}/openenclave/enclave/
-        <BINARY_DIR>/library/libmbedtls.a ${OE_LIBDIR}/openenclave/enclave/
-        <BINARY_DIR>/library/libmbedcrypto.a ${OE_LIBDIR}/openenclave/enclave/
-    )
+  # This is a no-op to override the default.
+  INSTALL_COMMAND "")
+
+ExternalProject_Get_property(mbedtls-wrap SOURCE_DIR)
+ExternalProject_Get_property(mbedtls-wrap BINARY_DIR)
 
 # NOTE: These imported libraries must be specified before `oelibc`
 # when linking, hence their dependency on it.
 add_library(mbedtls_imported IMPORTED STATIC)
 set_target_properties(mbedtls_imported PROPERTIES
-  IMPORTED_LOCATION ${OE_LIBDIR}/openenclave/enclave/libmbedtls.a)
+  IMPORTED_LOCATION ${BINARY_DIR}/library/libmbedtls.a)
 target_link_libraries(mbedtls_imported INTERFACE oelibc)
 
 add_library(mbedx509_imported IMPORTED STATIC)
 set_target_properties(mbedx509_imported PROPERTIES
-  IMPORTED_LOCATION ${OE_LIBDIR}/openenclave/enclave/libmbedx509.a)
+  IMPORTED_LOCATION ${BINARY_DIR}/library/libmbedx509.a)
 target_link_libraries(mbedx509_imported INTERFACE oelibc)
 
 add_library(mbedcrypto_imported IMPORTED STATIC)
 set_target_properties(mbedcrypto_imported PROPERTIES
-  IMPORTED_LOCATION ${OE_LIBDIR}/openenclave/enclave/libmbedcrypto.a)
+  IMPORTED_LOCATION ${BINARY_DIR}/library/libmbedcrypto.a)
 target_link_libraries(mbedcrypto_imported INTERFACE oelibc)
 
 # Convenience lib for use in target_link_libraries
@@ -64,7 +59,7 @@ add_library(mbedcrypto INTERFACE)
 add_dependencies(mbedcrypto mbedtls-wrap)
 
 target_include_directories(mbedcrypto INTERFACE
-  $<BUILD_INTERFACE:${OE_INCDIR}/openenclave>
+  $<BUILD_INTERFACE:${SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
 
 target_link_libraries(mbedcrypto INTERFACE
@@ -81,18 +76,18 @@ target_link_libraries(mbedcrypto INTERFACE
 
 install(TARGETS mbedcrypto EXPORT openenclave-targets)
 
-install(DIRECTORY ${MBEDTLS_INCLUDES}
+install(DIRECTORY ${SOURCE_DIR}/include/mbedtls
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
 
 # NOTE: Because these libraries are `IMPORTED`, it is not possible
 # with CMake to install them as targets, so instead they must be
 # installed as files. This is what causes the above problem with the
 # repeated dependency on `oelibc`.
-install(FILES ${OE_LIBDIR}/openenclave/enclave/libmbedtls.a
+install(FILES ${BINARY_DIR}/library/libmbedtls.a
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 
-install(FILES ${OE_LIBDIR}/openenclave/enclave/libmbedx509.a
+install(FILES ${BINARY_DIR}/library/libmbedx509.a
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 
-install(FILES ${OE_LIBDIR}/openenclave/enclave/libmbedcrypto.a
+install(FILES ${BINARY_DIR}/library/libmbedcrypto.a
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/3rdparty/mbedtls/config.h
+++ b/3rdparty/mbedtls/config.h
@@ -1859,8 +1859,8 @@
  *
  * This module is used for testing (ssl_client/server).
  */
-// Open Enclave: Disabled along with tests that don't run in enclaves
-//#define MBEDTLS_CERTS_C
+// Open Enclave: Enabled conditionally
+#cmakedefine MBEDTLS_CERTS_C
 
 /**
  * \def MBEDTLS_CIPHER_C
@@ -1914,7 +1914,8 @@
  *
  * This module provides debugging functions.
  */
-//#define MBEDTLS_DEBUG_C
+// Open Enclave: Enabled conditionally
+#cmakedefine MBEDTLS_DEBUG_C
 
 /**
  * \def MBEDTLS_DES_C

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -7,6 +7,7 @@
 set(CFLAGS "-fPIC -DSYSCALL_NO_INLINE")
 set(PATCHES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patches)
 set(MUSL_DIR ${CMAKE_CURRENT_BINARY_DIR}/musl)
+set(MUSL_INCLUDES ${OE_INCDIR}/openenclave/libc)
 
 include (ExternalProject)
 ExternalProject_Add(musl_includes
@@ -27,7 +28,7 @@ ExternalProject_Add(musl_includes
   CONFIGURE_COMMAND
     ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
     ./configure
-      --includedir=${OE_INCDIR}/openenclave/libc
+      --includedir=${MUSL_INCLUDES}
       CFLAGS=${CFLAGS}
       CC=${CMAKE_C_COMPILER}
       CXX=${CMAKE_CXX_COMPILER}
@@ -35,23 +36,23 @@ ExternalProject_Add(musl_includes
     ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
     make install-headers
     COMMAND ${CMAKE_COMMAND} -E copy
-      ${OE_INCDIR}/openenclave/libc/endian.h
-      ${OE_INCDIR}/openenclave/libc/__endian.h
+      ${MUSL_INCLUDES}/endian.h
+      ${MUSL_INCLUDES}/__endian.h
     COMMAND ${CMAKE_COMMAND} -E copy
       ${PATCHES_DIR}/endian.h
-      ${OE_INCDIR}/openenclave/libc/endian.h
+      ${MUSL_INCLUDES}/endian.h
 
     # Append deprecations.h to all C header files.
     COMMAND ${CMAKE_CURRENT_LIST_DIR}/append-deprecations
-      ${OE_INCDIR}/openenclave/libc
+      ${MUSL_INCLUDES}
 
     # Copy local deprecations.h to include/bits/deprecated.h.
     COMMAND ${CMAKE_COMMAND} -E copy
       ${CMAKE_CURRENT_LIST_DIR}/deprecations.h
-      ${OE_INCDIR}/openenclave/libc/bits/deprecations.h
+      ${MUSL_INCLUDES}/bits/deprecations.h
 
   BUILD_BYPRODUCTS
-    ${OE_INCDIR}/openenclave/libc ${CMAKE_CURRENT_BINARY_DIR}/musl
+    ${MUSL_INCLUDES} ${CMAKE_CURRENT_BINARY_DIR}/musl
 
   INSTALL_COMMAND "")
 
@@ -68,11 +69,10 @@ add_dependencies(oelibc_includes musl_includes)
 # include path.
 target_include_directories(oelibc_includes
   SYSTEM INTERFACE
-  $<BUILD_INTERFACE:${OE_INCDIR}/openenclave/libc>
+  $<BUILD_INTERFACE:${MUSL_INCLUDES}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libc>)
 
-install(TARGETS oelibc_includes EXPORT openenclave-targets
-  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+install(TARGETS oelibc_includes EXPORT openenclave-targets)
 
-install(DIRECTORY ${OE_INCDIR}/openenclave/libc
+install(DIRECTORY ${MUSL_INCLUDES}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)

--- a/cmake/package_settings.cmake
+++ b/cmake/package_settings.cmake
@@ -26,7 +26,7 @@ set(OE_LIBDIR ${OE_OUTPUT_DIR}/lib CACHE INTERNAL "Library collector")
 # Make directories for build systems (NMake) that don't automatically make them.
 file(MAKE_DIRECTORY ${OE_BINDIR} ${OE_DATADIR} ${OE_DOCDIR} ${OE_DOCDIR} ${OE_INCDIR} ${OE_LIBDIR})
 
-# Generate and install CMake export file for consumers using Cmake
+# Generate and install CMake export file for consumers using CMake
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ${PROJECT_SOURCE_DIR}/cmake/openenclave-config.cmake.in
@@ -41,6 +41,7 @@ install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake)
 install(
   EXPORT openenclave-targets
+  NAMESPACE openenclave::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/cmake
   FILE openenclave-targets.cmake)
 install(

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -39,4 +39,5 @@ target_link_libraries(oeenclave PUBLIC
 
 set_property(TARGET oeenclave PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/openenclave/enclave)
 
-install(TARGETS oeenclave ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+install(TARGETS oeenclave EXPORT openenclave-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -16,5 +16,5 @@ target_link_libraries(oelibcxx
 set_property(TARGET oelibcxx
   PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/enclave)
 
-install(TARGETS oelibcxx EXPORT openenclave
+install(TARGETS oelibcxx EXPORT openenclave-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)


### PR DESCRIPTION
This should mostly fix the CMake package (that is, the exported CMake targets). Please give it a try (that is, do a `make install` from this branch and attempt to use `lib/openenclave/cmake/openenclave-targets.cmake` from your install prefix).

I believe that I have at least fixed #468, and a couple other issues I identified when looking through the CMake package (some of which I knowingly caused recently, others which have probably been an issue for a long time).

I am not done fixing this, as "done" would imply working samples and a CI job and an auto-generated pkg-config file and the likes (that is, #887), but we're getting closer 😄 I would suggest we merge this and do sample etc. next.