### PR TITLE
Compile with -Wconversion but disable sign-conversion warnings.

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -66,6 +66,12 @@ target_include_directories(libcxx
   libcxx/src
   ../libcxxrt/libcxxrt/src)
 
+# Prevent warnings treated as error
+set_source_files_properties(
+  libcxx/src/locale.cpp
+  PROPERTIES COMPILE_FLAGS "-Wno-conversion"
+)
+
 install(TARGETS libcxx EXPORT openenclave-targets
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 

--- a/3rdparty/libcxxrt/CMakeLists.txt
+++ b/3rdparty/libcxxrt/CMakeLists.txt
@@ -15,8 +15,14 @@ add_library(libcxxrt OBJECT
   libcxxrt/src/auxhelper.cc
   libcxxrt/src/libelftc_dem_gnu3.c)
 
-set_source_files_properties(libcxxrt/src/exception.cc
-  PROPERTIES COMPILE_FLAGS -Wno-unused-variable)
+set_source_files_properties(
+  libcxxrt/src/exception.cc
+  PROPERTIES COMPILE_FLAGS "-Wno-unused-variable -Wno-conversion")
+
+set_source_files_properties(
+  libcxxrt/src/libelftc_dem_gnu3.c
+  PROPERTIES COMPILE_FLAGS "-Wno-conversion"
+)
 
 set_target_properties(libcxxrt PROPERTIES
   POSITION_INDEPENDENT_CODE ON)

--- a/3rdparty/libunwind/CMakeLists.txt
+++ b/3rdparty/libunwind/CMakeLists.txt
@@ -117,6 +117,7 @@ target_compile_options(libunwind PRIVATE
   -Wno-unused-function
   -Wno-unused-variable
   -Wno-cpp
+  -Wno-conversion
   -fno-builtin
   -include ${CMAKE_CURRENT_SOURCE_DIR}/stubs.h)
 

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -76,7 +76,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
   # Enables all the warnings about constructions that some users consider questionable,
   # and that are easy to avoid. Treat at warnings-as-errors, which forces developers
   # to fix warnings as they arise, so they don't accumulate "to be fixed later".
-  add_compile_options(-Wall -Werror -Wpointer-arith)
+  add_compile_options(-Wall -Werror -Wpointer-arith -Wconversion -Wno-sign-conversion)
 
   add_compile_options(-fno-strict-aliasing)
 

--- a/debugger/ptraceLib/oe_ptrace.c
+++ b/debugger/ptraceLib/oe_ptrace.c
@@ -347,7 +347,7 @@ pid_t waitpid(pid_t pid, int* status, int options)
     // Handle the traps.
     if (WIFSTOPPED(*status) && WSTOPSIG(*status) == SIGTRAP)
     {
-        int ret;
+        long ret;
         int64_t flags;
 
         // Cleanup the single step flag.

--- a/host/create.c
+++ b/host/create.c
@@ -467,7 +467,7 @@ static oe_result_t _initialize_enclave(oe_enclave_t* enclave)
         OE_CHECK(
             oe_ecall(
                 enclave, OE_ECALL_INIT_ENCLAVE, (uint64_t)&args, &arg_out));
-        OE_CHECK(arg_out);
+        OE_CHECK((oe_result_t)arg_out);
     }
 
     result = OE_OK;

--- a/host/sgxload.c
+++ b/host/sgxload.c
@@ -376,7 +376,7 @@ done:
 oe_result_t oe_sgx_initialize_load_context(
     oe_sgx_load_context_t* context,
     oe_sgx_load_type_t type,
-    uint32_t attributes)
+    uint64_t attributes)
 {
     oe_result_t result = OE_UNEXPECTED;
 

--- a/include/openenclave/internal/sgxcreate.h
+++ b/include/openenclave/internal/sgxcreate.h
@@ -40,7 +40,7 @@ struct _oe_sgx_load_context
     oe_sgx_load_state_t state;
 
     /* OE_FLAG bits to be applied to the enclave such as debug */
-    uint32_t attributes;
+    uint64_t attributes;
 
     /* Fields used when attributes contain OE_FLAG_SIMULATION */
     struct
@@ -62,7 +62,7 @@ struct _oe_sgx_load_context
 oe_result_t oe_sgx_initialize_load_context(
     oe_sgx_load_context_t* context,
     oe_sgx_load_type_t type,
-    uint32_t attributes);
+    uint64_t attributes);
 
 void oe_sgx_cleanup_load_context(oe_sgx_load_context_t* context);
 

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -675,7 +675,8 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU OR CMAKE_C_COMPILER_ID MATCHES Clang)
   target_compile_options(oelibc PRIVATE
     -Wno-missing-braces
     -Wno-parentheses
-    -Wno-unknown-pragmas)
+    -Wno-unknown-pragmas
+    -Wno-conversion)
 endif ()
 # Second: compiler-specific warnings:
 if (CMAKE_C_COMPILER_ID MATCHES GNU)

--- a/tests/VectorException/enc/enc.c
+++ b/tests/VectorException/enc/enc.c
@@ -24,7 +24,7 @@ int DivideByZeroExceptionFunction(void)
     volatile float f = 0;
     volatile double d = 0;
 
-    f = 0.31;
+    f = 0.31f;
     d = 0.32;
 
     // Using inline assembly for idiv to prevent it being optimized out
@@ -125,14 +125,13 @@ static oe_vectored_exception_handler_t g_test_div_by_zero_handler;
 
 int VectorExceptionSetup()
 {
-    uint64_t ret = -1;
     oe_result_t result;
 
     // Add one exception handler.
     result = oe_add_vectored_exception_handler(false, TestDivideByZeroHandler);
     if (result != OE_OK)
     {
-        return ret;
+        return -1;
     }
 
     // Remove the exception handler.
@@ -145,7 +144,7 @@ int VectorExceptionSetup()
     result = oe_add_vectored_exception_handler(true, TestDivideByZeroHandler);
     if (result != OE_OK)
     {
-        return ret;
+        return -1;
     }
 
     // Remove the exception handler.
@@ -161,7 +160,7 @@ int VectorExceptionSetup()
             false, g_test_pass_through_handlers[i]);
         if (result != OE_OK)
         {
-            return ret;
+            return -1;
         }
     }
 
@@ -169,7 +168,7 @@ int VectorExceptionSetup()
     result = oe_add_vectored_exception_handler(false, TestDivideByZeroHandler);
     if (result == OE_OK)
     {
-        return ret;
+        return -1;
     }
 
     // Remove all registered handlers.
@@ -189,7 +188,7 @@ int VectorExceptionSetup()
             true, g_test_pass_through_handlers[i]);
         if (result != OE_OK)
         {
-            return ret;
+            return -1;
         }
     }
 
@@ -197,7 +196,7 @@ int VectorExceptionSetup()
     result = oe_add_vectored_exception_handler(true, TestDivideByZeroHandler);
     if (result == OE_OK)
     {
-        return ret;
+        return -1;
     }
 
     // Remove all registered handlers.
@@ -217,7 +216,7 @@ int VectorExceptionSetup()
             false, g_test_pass_through_handlers[i]);
         if (result != OE_OK)
         {
-            return ret;
+            return -1;
         }
     }
 
@@ -226,11 +225,10 @@ int VectorExceptionSetup()
     result = oe_add_vectored_exception_handler(false, TestDivideByZeroHandler);
     if (result != OE_OK)
     {
-        return ret;
+        return -1;
     }
 
-    ret = 0;
-    return ret;
+    return 0;
 }
 
 int VectorExceptionCleanup()

--- a/tests/backtrace/enc/enc.cpp
+++ b/tests/backtrace/enc/enc.cpp
@@ -56,21 +56,21 @@ extern "C" OE_NEVER_INLINE void func1(size_t num_syms, const char** syms)
 #ifdef OE_USE_DEBUG_MALLOC
 static void _print_backtrace(
     void* const* buffer,
-    int size,
-    int num_expected_symbols,
+    size_t size,
+    size_t num_expected_symbols,
     const char* expected_symbols[])
 {
-    char** symbols = oe_backtrace_symbols(buffer, size);
+    char** symbols = oe_backtrace_symbols(buffer, static_cast<int>(size));
     OE_TEST(symbols != NULL);
 
     oe_host_printf("=== backtrace:\n");
 
-    for (int i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
         oe_host_printf("%s(): (%p)\n", symbols[i], buffer[i]);
 
     OE_TEST(size == num_expected_symbols);
 
-    for (int i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
         OE_TEST(strcmp(expected_symbols[i], symbols[i]) == 0);
 
     oe_host_printf("\n");

--- a/tests/bigmalloc/enc/enc.c
+++ b/tests/bigmalloc/enc/enc.c
@@ -29,11 +29,11 @@ oe_result_t test_malloc()
             goto done;
         }
 
-        heap_remaining = end - brk;
+        heap_remaining = (size_t)(end - brk);
     }
 
     /* Verify that at least 15.9 gigabytes of heap memory are available */
-    if (!(heap_remaining > (float)(15.9 * GIGABYTE)))
+    if (!(heap_remaining > (float)(15.9 * (double)GIGABYTE)))
     {
         return_value = OE_FAILURE;
         goto done;
@@ -41,7 +41,7 @@ oe_result_t test_malloc()
 
     /* Allocate 99% of remaining heap memory */
     {
-        const size_t allocation_size = (size_t)(0.99 * heap_remaining);
+        const size_t allocation_size = (size_t)(0.99 * (double)heap_remaining);
 
         if (!(ptr = (uint8_t*)dlmalloc(allocation_size)))
         {

--- a/tests/crypto/crl_tests.c
+++ b/tests/crypto/crl_tests.c
@@ -141,7 +141,12 @@ static void _test_get_dates(void)
     OE_TEST(last.day == _time.day);
     OE_TEST(last.hours == _time.hours);
     OE_TEST(last.minutes == _time.minutes);
-    OE_TEST(last.seconds == _time.seconds);
+    // TEMPORARY FIX: _time is the certificate file's timestamp
+    // whereas last.seconds is the actual issue time of the certificate.
+    // Sometimes they can be off by 1 depending upon when the file
+    // write operation completes.
+    OE_TEST(
+        last.seconds == _time.seconds || (last.seconds + 1U == _time.seconds));
 
     OE_TEST(next.year == _time.year + 1);
     OE_TEST(next.month == _time.month);

--- a/tests/crypto/enclave/host/host.c
+++ b/tests/crypto/enclave/host/host.c
@@ -31,7 +31,7 @@ OE_OCALL void f_read(void* syscall_args)
     int ret;
     syscall_args_t* args = (syscall_args_t*)syscall_args;
 
-    ret = read(args->fd, (char*)args->ptr, args->len);
+    ret = (int)read(args->fd, (char*)args->ptr, args->len);
     args->ret = ret;
 
     return;
@@ -41,7 +41,7 @@ OE_OCALL void f_readv(void* syscall_args)
 {
     syscall_args_t* args = (syscall_args_t*)syscall_args;
 
-    args->ret = readv(args->fd, (const struct iovec*)args->ptr, args->len);
+    args->ret = (int)readv(args->fd, (const struct iovec*)args->ptr, args->len);
 
     return;
 }

--- a/tests/ecall_ocall/enc/enc.cpp
+++ b/tests/ecall_ocall/enc/enc.cpp
@@ -151,7 +151,7 @@ OE_ECALL void EncCrossEnclaveCall(CrossEnclaveCallArg* arg)
     OE_TEST(oe_call_host("CrossEnclaveCall", arg) == OE_OK);
 
     // augment result with my result.
-    uint32_t my_result = my_input * Factor;
+    uint32_t my_result = static_cast<uint32_t>(my_input * Factor);
     arg->output += my_result;
     printf(
         "enclave %u: Factor=%lu, myResult = %u, arg.output=%u\n",

--- a/tests/ecall_ocall/host/host.cpp
+++ b/tests/ecall_ocall/host/host.cpp
@@ -43,7 +43,7 @@ struct EnclaveWrap
             oe_put_err("oe_create_enclave(): result=%u", result);
             throw std::runtime_error("oe_create_enclave() failed");
         }
-        m_id = m_enclaves.size();
+        m_id = static_cast<unsigned>(m_enclaves.size());
 
         args.result = OE_FAILURE;
         args.id = m_id;
@@ -87,7 +87,7 @@ struct EnclaveWrap
         return m_enclaves[m_id];
     }
 
-    static oe_enclave_t* Get(unsigned Id)
+    static oe_enclave_t* Get(uint64_t Id)
     {
         return m_enclaves[Id];
     }
@@ -336,7 +336,7 @@ static void TestCrossEnclaveCalls()
         0, // output value.
     };
 
-    uint32_t expected_output = 0;
+    size_t expected_output = 0;
     for (size_t i = 0; i < EnclaveWrap::Count(); ++i)
     {
         expected_output += (arg.input + i) * (i + 1);
@@ -345,7 +345,7 @@ static void TestCrossEnclaveCalls()
     OE_TEST(
         oe_call_enclave(EnclaveWrap::Get(0), "EncCrossEnclaveCall", &arg) ==
         OE_OK);
-    printf("arg.output=%u, expected_output=%u\n", arg.output, expected_output);
+    printf("arg.output=%u, expected_output=%lu\n", arg.output, expected_output);
     OE_TEST(arg.output == expected_output);
 
     printf("=== TestCrossEnclaveCalls passed\n");

--- a/tests/libc/host/host.cpp
+++ b/tests/libc/host/host.cpp
@@ -33,7 +33,7 @@ void Test(oe_enclave_t* enclave)
 
 OE_OCALL void ocall_exit(uint64_t arg)
 {
-    exit(arg);
+    exit(static_cast<int>(arg));
 }
 
 static int _get_opt(

--- a/tests/libcxx/host/host.cpp
+++ b/tests/libcxx/host/host.cpp
@@ -41,7 +41,7 @@ void Test(oe_enclave_t* enclave)
 
 OE_OCALL void ocall_exit(uint64_t arg)
 {
-    exit(arg);
+    exit(static_cast<int>(arg));
 }
 
 void* EnclaveThread(void* args)

--- a/tests/libcxxrt/host/host.cpp
+++ b/tests/libcxxrt/host/host.cpp
@@ -37,7 +37,7 @@ void Test(oe_enclave_t* enclave)
 
 void ocall_exit(uint64_t arg)
 {
-    exit(arg);
+    exit(static_cast<int>(arg));
 }
 
 static int _get_opt(

--- a/tests/libunwind/host/host.cpp
+++ b/tests/libunwind/host/host.cpp
@@ -32,9 +32,9 @@ void Test(oe_enclave_t* enclave, uint32_t pid)
     }
 }
 
-OE_OCALL void ExitOCall(void* arg)
+OE_OCALL void ExitOCall(uint64_t arg)
 {
-    exit((uint64_t)arg);
+    exit(static_cast<int>(arg));
 }
 
 static int _get_opt(

--- a/tests/memory/enc/basic.c
+++ b/tests/memory/enc/basic.c
@@ -13,7 +13,7 @@
 static void _set_buffer(int* buf, size_t start, size_t end)
 {
     for (size_t i = start; i < end; i++)
-        buf[i] = i;
+        buf[i] = (int)i;
 }
 
 static void _check_buffer(int* buf, size_t start, size_t end)

--- a/tests/memory/enc/stress.c
+++ b/tests/memory/enc/stress.c
@@ -25,7 +25,7 @@
 #define TEST_GET_VAL 6
 #define NUM_TESTS 7
 
-static inline size_t _randx(size_t x)
+static inline int _randx(int x)
 {
     /* Note that rand() % N is biased if RAND_MAX + 1 isn't divisible
      * by N. But, slight probability bias doesn't really matter in these
@@ -99,7 +99,7 @@ static void _handle_alloc(
             oe_abort();
     }
 
-    *index_ = index;
+    *index_ = (int)index;
     *max_size_ = max_size;
 }
 
@@ -119,18 +119,22 @@ static void _run_malloc_test(size_t size)
     int index = 0;
     size_t original_size = size;
 
+    // Make sure that the value can fit within a double since we use
+    // double arithmetic below.
+    OE_TEST(original_size == (double)original_size);
+
     for (int i = 0; i < ITERS; i++)
     {
         /* Malloc if our array is empty. Otherwise, pick a random
          * fuction to execute. */
-        size_t action = index == 0 ? TEST_MALLOC : _randx(NUM_TESTS);
+        int action = index == 0 ? TEST_MALLOC : _randx(NUM_TESTS);
 
         switch (action)
         {
             case TEST_MALLOC:
             case TEST_CALLOC:
             case TEST_REALLOC:
-                if (size < original_size * 0.15)
+                if (size < (size_t)((double)original_size * 0.15))
                 {
                     /* Getting low on memory. Free all memory and do malloc. */
                     _free_buffers(array, index);
@@ -172,7 +176,7 @@ static void _run_malloc_test(size_t size)
 
 void init_malloc_stress_test()
 {
-    srand(time(NULL));
+    srand((int)time(NULL));
 }
 
 void malloc_stress_test(int threads)

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -31,5 +31,15 @@ add_executable(edl_enc
     ${bar_t}
     )
 
+
+# The tests intentionally use floats etc in size context.
+# Disable warnings.
+if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
+    set_source_files_properties(
+        ${all_t}
+        PROPERTIES COMPILE_FLAGS "-Wno-float-conversion"
+    )
+endif()
+
 target_include_directories(edl_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(edl_enc oelibcxx oeenclave)

--- a/tests/oeedger8r/enc/testarray.cpp
+++ b/tests/oeedger8r/enc/testarray.cpp
@@ -13,16 +13,16 @@ template <typename T>
 static void init_arrays(T (&a1)[2], T (&a2)[2][2], T (&a3)[3][3], T (&a4)[4][4])
 {
     for (size_t i = 0; i < 2; ++i)
-        ((T*)a1)[i] = i + 1;
+        ((T*)a1)[i] = static_cast<T>(i + 1);
 
     for (size_t i = 0; i < 4; ++i)
-        ((T*)a2)[i] = i + 1;
+        ((T*)a2)[i] = static_cast<T>(i + 1);
 
     for (size_t i = 0; i < 9; ++i)
-        ((T*)a3)[i] = i + 1;
+        ((T*)a3)[i] = static_cast<T>(i + 1);
 
     for (size_t i = 0; i < 16; ++i)
-        ((T*)a4)[i] = i + 1;
+        ((T*)a4)[i] = static_cast<T>(i + 1);
 }
 
 template <typename T, typename F>
@@ -126,7 +126,7 @@ static void ecall_array_fun_impl(T a1[2], T a2[2][2], T a3[3][3], T a4[4][4])
         OE_TEST(oe_is_within_enclave(a3, sizeof(T) * 3 * 3));
         for (int i = 0; i < 9; ++i)
         {
-            ((T*)a3)[i] = i;
+            ((T*)a3)[i] = static_cast<T>(i);
         }
     }
 

--- a/tests/oeedger8r/enc/testbasic.cpp
+++ b/tests/oeedger8r/enc/testbasic.cpp
@@ -244,25 +244,25 @@ void ecall_basic_types(
     check_type<unsigned long long>(args.arg20);
 
     OE_TEST(arg1 == '?');
-    OE_TEST(arg2 = 3);
-    OE_TEST(arg3 = 4);
-    OE_TEST(arg4 = 3.1415f);
-    OE_TEST(arg5 = 1.0 / 3.0);
-    OE_TEST(arg6 = 8);
-    OE_TEST(arg7 = 9);
-    OE_TEST(arg8 = 10);
-    OE_TEST(arg9 = 11);
-    OE_TEST(arg10 = 12);
-    OE_TEST(arg11 = 13);
-    OE_TEST(arg12 = 14);
-    OE_TEST(arg13 = 15);
-    OE_TEST(arg14 = 16);
-    OE_TEST(arg15 = 17);
-    OE_TEST(arg16 = 18);
-    OE_TEST(arg17 = 255);
-    OE_TEST(arg18 = 19);
-    OE_TEST(arg19 = 20);
-    OE_TEST(arg20 = 21);
+    OE_TEST(arg2 == 3);
+    OE_TEST(arg3 == 4);
+    OE_TEST(arg4 == 3.1415f);
+    OE_TEST(arg5 == 1.0 / 3.0);
+    OE_TEST(arg6 == 8);
+    OE_TEST(arg7 == 9);
+    OE_TEST(arg8 == 10);
+    OE_TEST(arg9 == 11);
+    OE_TEST(arg10 == 12);
+    OE_TEST(arg11 == 13);
+    OE_TEST(arg12 == 14);
+    OE_TEST(arg13 == 15);
+    OE_TEST(arg14 == 16);
+    OE_TEST(arg15 == 17);
+    OE_TEST(arg16 == 18);
+    OE_TEST(arg17 == 255);
+    OE_TEST(arg18 == 19);
+    OE_TEST(arg19 == 20);
+    OE_TEST(arg20 == 21);
 }
 
 void ecall_basic_non_portable_types(

--- a/tests/oeedger8r/enc/testpointer.cpp
+++ b/tests/oeedger8r/enc/testpointer.cpp
@@ -20,7 +20,7 @@ static void test_ocall_pointer_fun(F ocall_pointer_fun)
     // 16 element arrays.
     T p4[16], p5[16], p6[16];
     for (size_t i = 0; i < 16; ++i)
-        p4[i] = p5[i] = p6[i] = i + 1;
+        p4[i] = p5[i] = p6[i] = static_cast<T>(i + 1);
 
     static_assert((80 / sizeof(T)) * sizeof(T) == 80, "invalid size");
     // arrays with size = 80 bytes.
@@ -28,23 +28,23 @@ static void test_ocall_pointer_fun(F ocall_pointer_fun)
     T p7[count], p8[count], p9[count];
 
     for (size_t i = 0; i < count; ++i)
-        p7[i] = p8[i] = p9[i] = i + 1;
+        p7[i] = p8[i] = p9[i] = static_cast<T>(i + 1);
 
     T p10[16];
     for (size_t i = 0; i < 16; ++i)
-        p10[i] = i + 1;
+        p10[i] = static_cast<T>(i + 1);
 
     static T p11[16];
     static T p12[16];
     static T p13[16];
     for (size_t i = 0; i < 16; ++i)
-        p11[i] = p12[i] = p13[i] = i + 1;
+        p11[i] = p12[i] = p13[i] = static_cast<T>(i + 1);
 
     static T p14[count];
     static T p15[count];
     static T p16[count];
     for (size_t i = 0; i < count; ++i)
-        p14[i] = p15[i] = p16[i] = i + 1;
+        p14[i] = p15[i] = p16[i] = static_cast<T>(i + 1);
 
     int pcount = 16;
     int psize = 80;
@@ -293,7 +293,7 @@ static T* ecall_pointer_fun_impl(
         const size_t count = 80 / sizeof(T);
         T exp[count];
         for (size_t i = 0; i < count; ++i)
-            exp[i] = i + 1;
+            exp[i] = static_cast<T>(i + 1);
 
         //
         if (p7)
@@ -351,7 +351,7 @@ static T* ecall_pointer_fun_impl(
         if (p13)
         {
             for (int i = 0; i < pcount; ++i)
-                p13[i] = pcount;
+                p13[i] = static_cast<T>(pcount);
         }
     }
 
@@ -361,7 +361,7 @@ static T* ecall_pointer_fun_impl(
         if (p14)
         {
             for (size_t i = 0; i < count; ++i)
-                OE_TEST(p14[i] == (T)(i + 1));
+                OE_TEST(p14[i] == static_cast<T>(i + 1));
 
             // change p11. Should not have any effect on host.
             memset(p14, 0, sizeof(T) * count);
@@ -379,7 +379,7 @@ static T* ecall_pointer_fun_impl(
         if (p16)
         {
             for (size_t i = 0; i < count; ++i)
-                p16[i] = psize;
+                p16[i] = static_cast<T>(psize);
         }
     }
 

--- a/tests/oeedger8r/enc/teststruct.cpp
+++ b/tests/oeedger8r/enc/teststruct.cpp
@@ -19,13 +19,13 @@ void test_struct_edl_ocalls()
 
     static MyStruct1 a2[5];
     for (size_t i = 0; i < 5; ++i)
-        a2[i].s0.x = a2[i].y = i;
+        a2[i].s0.x = a2[i].y = static_cast<int>(i);
 
     static MyStruct1 a3[5][5];
     for (size_t i = 0; i < 5; ++i)
     {
         for (size_t j = 0; j < 5; ++j)
-            a3[i][j].s0.x = a3[i][j].y = i * j;
+            a3[i][j].s0.x = a3[i][j].y = static_cast<int>(i * j);
     }
 
     MyStruct1 a4[1][1][1];

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -32,5 +32,14 @@ add_executable(edl_host
     ${bar_u}
 )
 
+# The tests intentionally use floats etc in size context.
+# Disable warnings.
+if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
+    set_source_files_properties(
+        ${all_u}
+        PROPERTIES COMPILE_FLAGS "-Wno-float-conversion"
+    )
+endif()
+
 target_include_directories(edl_host PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(edl_host oehostapp)

--- a/tests/oeedger8r/host/testbasic.cpp
+++ b/tests/oeedger8r/host/testbasic.cpp
@@ -248,25 +248,25 @@ void ocall_basic_types(
     check_type<unsigned long long>(args.arg20);
 
     OE_TEST(arg1 == '?');
-    OE_TEST(arg2 = 3);
-    OE_TEST(arg3 = 4);
-    OE_TEST(arg4 = 3.1415f);
-    OE_TEST(arg5 = 1.0 / 3.0);
-    OE_TEST(arg6 = 8);
-    OE_TEST(arg7 = 9);
-    OE_TEST(arg8 = 10);
-    OE_TEST(arg9 = 11);
-    OE_TEST(arg10 = 12);
-    OE_TEST(arg11 = 13);
-    OE_TEST(arg12 = 14);
-    OE_TEST(arg13 = 15);
-    OE_TEST(arg14 = 16);
-    OE_TEST(arg15 = 17);
-    OE_TEST(arg16 = 18);
-    OE_TEST(arg17 = 255);
-    OE_TEST(arg18 = 19);
-    OE_TEST(arg19 = 20);
-    OE_TEST(arg20 = 21);
+    OE_TEST(arg2 == 3);
+    OE_TEST(arg3 == 4);
+    OE_TEST(arg4 == 3.1415f);
+    OE_TEST(arg5 == 1.0 / 3.0);
+    OE_TEST(arg6 == 8);
+    OE_TEST(arg7 == 9);
+    OE_TEST(arg8 == 10);
+    OE_TEST(arg9 == 11);
+    OE_TEST(arg10 == 12);
+    OE_TEST(arg11 == 13);
+    OE_TEST(arg12 == 14);
+    OE_TEST(arg13 == 15);
+    OE_TEST(arg14 == 16);
+    OE_TEST(arg15 == 17);
+    OE_TEST(arg16 == 18);
+    OE_TEST(arg17 == 255);
+    OE_TEST(arg18 == 19);
+    OE_TEST(arg19 == 20);
+    OE_TEST(arg20 == 21);
 }
 
 void ocall_basic_non_portable_types(

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -187,7 +187,7 @@ TEST_FCN void TestLocalReport(void* args_)
     size_t report_data_size = 0;
     uint8_t report_data[OE_REPORT_DATA_SIZE];
     for (uint32_t i = 0; i < OE_REPORT_DATA_SIZE; ++i)
-        report_data[i] = i;
+        report_data[i] = static_cast<uint8_t>(i);
 #endif
 
     const uint8_t zeros[OE_REPORT_DATA_SIZE] = {0};
@@ -447,7 +447,7 @@ TEST_FCN void TestRemoteReport(void* args_)
     size_t report_data_size = 0;
     uint8_t report_data[OE_REPORT_DATA_SIZE];
     for (uint32_t i = 0; i < OE_REPORT_DATA_SIZE; ++i)
-        report_data[i] = i;
+        report_data[i] = static_cast<uint8_t>(i);
     const uint8_t zeros[OE_REPORT_DATA_SIZE] = {0};
 #endif
 
@@ -695,7 +695,7 @@ TEST_FCN void TestLocalVerifyReport(void* args_)
     uint8_t report_data[sizeof(sgx_report_data_t)];
     for (uint32_t i = 0; i < sizeof(report_data); ++i)
     {
-        report_data[i] = i;
+        report_data[i] = static_cast<uint8_t>(i);
     }
 
     GetSGXTargetInfo((sgx_target_info_t*)target_info);
@@ -757,7 +757,7 @@ TEST_FCN void TestRemoteVerifyReport(void* args_)
 
     for (uint32_t i = 0; i < sizeof(report_data); ++i)
     {
-        report_data[i] = i;
+        report_data[i] = static_cast<uint8_t>(i);
     }
 #endif
 

--- a/tests/safemath/main.cpp
+++ b/tests/safemath/main.cpp
@@ -137,13 +137,13 @@ struct UnsignedTest
         OE_TEST(add(a, b, &c) == OE_INTEGER_OVERFLOW);
 
         /* Check overflow doesn't occur <= limit. */
-        a = limit - 1;
+        a = static_cast<T>(limit - 1);
         b = 1;
         OE_TEST(add(a, b, &c) == OE_OK);
         OE_TEST(c == limit);
 
         a = 1;
-        b = limit - 1;
+        b = static_cast<T>(limit - 1);
         OE_TEST(add(a, b, &c) == OE_OK);
         OE_TEST(c == limit);
 
@@ -197,7 +197,7 @@ struct UnsignedTest
         b = limit;
         OE_TEST(sub(a, b, &c) == OE_INTEGER_OVERFLOW);
 
-        a = limit - 1;
+        a = static_cast<T>(limit - 1);
         b = limit;
         OE_TEST(sub(a, b, &c) == OE_INTEGER_OVERFLOW);
 
@@ -213,7 +213,7 @@ struct UnsignedTest
         OE_TEST(c == limit / 2 + 1);
 
         a = limit;
-        b = limit - 1;
+        b = static_cast<T>(limit - 1);
         OE_TEST(sub(a, b, &c) == OE_OK);
         OE_TEST(c == 1);
 
@@ -274,7 +274,7 @@ struct UnsignedTest
         OE_TEST(mul(a, b, &c) == OE_INTEGER_OVERFLOW);
 
         /* Check if overflow occurs past limit. */
-        a = limit / 2 + 1;
+        a = static_cast<T>(limit / 2 + 1);
         b = 2;
         OE_TEST(mul(a, b, &c) == OE_INTEGER_OVERFLOW);
 
@@ -391,7 +391,7 @@ struct SignedTest
         OE_TEST(add(a, b, &c) == OE_INTEGER_OVERFLOW);
 
         /* Check if overflow doesn't occur at or before limits. */
-        a = max_limit - 1;
+        a = static_cast<T>(max_limit - 1);
         b = 1;
         OE_TEST(add(a, b, &c) == OE_OK);
         OE_TEST(c == max_limit);
@@ -401,7 +401,7 @@ struct SignedTest
         OE_TEST(add(a, b, &c) == OE_OK);
         OE_TEST(c == max_limit - 1);
 
-        a = min_limit + 1;
+        a = static_cast<T>(min_limit + 1);
         b = -1;
         OE_TEST(add(a, b, &c) == OE_OK);
         OE_TEST(c == min_limit);
@@ -512,7 +512,7 @@ struct SignedTest
         OE_TEST(c == 0);
 
         a = min_limit;
-        b = -max_limit;
+        b = static_cast<T>(-max_limit);
         OE_TEST(sub(a, b, &c) == OE_OK);
         OE_TEST(c == -1);
 
@@ -526,7 +526,7 @@ struct SignedTest
         OE_TEST(sub(a, b, &c) == OE_INTEGER_OVERFLOW);
 
         /* Check overflow doesn't occur at <= limits. */
-        a = max_limit - 1;
+        a = static_cast<T>(max_limit - 1);
         b = -1;
         OE_TEST(sub(a, b, &c) == OE_OK);
         OE_TEST(c == max_limit);
@@ -536,7 +536,7 @@ struct SignedTest
         OE_TEST(sub(a, b, &c) == OE_OK);
         OE_TEST(c == max_limit - 1);
 
-        a = min_limit + 1;
+        a = static_cast<T>(min_limit + 1);
         b = 1;
         OE_TEST(sub(a, b, &c) == OE_OK);
         OE_TEST(c == min_limit);
@@ -695,32 +695,32 @@ struct SignedTest
         OE_TEST(mul(a, b, &c) == OE_OK);
         OE_TEST(c == max_limit - 1);
 
-        a = max_limit / 2 + 1;
+        a = static_cast<T>(max_limit / 2 + 1);
         b = 2;
         OE_TEST(mul(a, b, &c) == OE_INTEGER_OVERFLOW);
 
         /* When b is negative, check if overflow happens past limit. */
-        a = max_limit / 2 + 1;
+        a = static_cast<T>(max_limit / 2 + 1);
         b = -2;
         OE_TEST(mul(a, b, &c) == OE_OK);
         OE_TEST(c == min_limit);
 
-        a = max_limit / 2 + 2;
+        a = static_cast<T>(max_limit / 2 + 2);
         b = -2;
         OE_TEST(mul(a, b, &c) == OE_INTEGER_OVERFLOW);
 
         /* When a is negative, check if overflow happens past limit. */
         a = -2;
-        b = max_limit / 2 + 1;
+        b = static_cast<T>(max_limit / 2 + 1);
         OE_TEST(mul(a, b, &c) == OE_OK);
         OE_TEST(c == min_limit);
 
         a = -2;
-        b = max_limit / 2 + 2;
+        b = static_cast<T>(max_limit / 2 + 2);
         OE_TEST(mul(a, b, &c) == OE_INTEGER_OVERFLOW);
 
         /* When both are negative, check if overflow happens past limit. */
-        a = min_limit / 2 + 1;
+        a = static_cast<T>(min_limit / 2 + 1);
         b = -2;
         OE_TEST(mul(a, b, &c) == OE_OK);
         OE_TEST(c == max_limit - 1);

--- a/tests/thread_local/enc/enc.cpp
+++ b/tests/thread_local/enc/enc.cpp
@@ -38,7 +38,7 @@ struct thread_local_struct
 extern thread_local std::random_device g_rd;
 extern thread_local std::mt19937 g_mt;
 extern thread_local std::uniform_real_distribution<double> g_dist;
-thread_local volatile thread_local_struct g_s(g_dist(g_mt));
+thread_local volatile thread_local_struct g_s(static_cast<int>(g_dist(g_mt)));
 
 // This variable will be put in .tdata
 thread_local int thread_local_int = 5;


### PR DESCRIPTION
Sign conversion-warnings will be addressed in next pass.

Consistently used uint64_t for attributes.
Also fixed bugs in oeedger8r test. (Use of = instead of == ).