### PR TITLE
Added functionality to run the pre-commit hook only against specific files

### DIFF
--- a/scripts/check-license
+++ b/scripts/check-license
@@ -18,24 +18,11 @@
 
 ##==============================================================================
 ##
-## Check command line arguments.
-##
-##==============================================================================
-
-if [[ $# -ne 0 ]]; then
-    echo "$0: too many parameters"
-    echo "Usage: $0"
-    exit 1
-fi
-
-##==============================================================================
-##
 ## expand_ignore_file():
 ##
 ##     Expand any wildcards in the .check-license.ignore file:
 ##
 ##==============================================================================
-
 # shellcheck disable=SC2155
 expand_ignore_file()
 {
@@ -83,11 +70,18 @@ ignorefile=$(expand_ignore_file)
 form_filelist()
 {
     local ignorefile=$1
+    shift
     local files=$(mktemp)
     local tmpfile=$(mktemp)
 
-    # Find all regular files:
-    find . -type f > "${files}"
+    if [[ $# -ne 0 ]]; then
+        for f in "$@"; do
+            find . -name "$f" -maxdepth 1 2>/dev/null >> "${files}"
+        done
+    else
+        # Find all regular files:
+        find . -type f > "${files}"
+    fi
 
     # Remove lines that match entries from ignore file:
     while IFS= read -r i
@@ -106,7 +100,12 @@ form_filelist()
     echo "${files}"
 }
 
-filelist=$(form_filelist "${ignorefile}")
+if [[ $# -ne 0 ]]; then
+    filelist=$(form_filelist "${ignorefile}" "$@")
+else
+    filelist=$(form_filelist "${ignorefile}")
+fi
+
 rm -rf "${ignorefile}"
 
 # Sanity check: make sure all files that require licenses exist

--- a/scripts/check-linters
+++ b/scripts/check-linters
@@ -13,7 +13,13 @@ if ! hash shellcheck 2>/dev/null; then
     exit 1
 fi
 
-while IFS= read -r i; do
+if [[ $# -ne 0 ]]; then
+    filelist="$*"
+else
+    filelist=$(git ls-files)
+fi
+
+for i in $filelist; do
     if [[ $i =~ ^3rdparty/ ]]; then
         continue;
     fi
@@ -25,7 +31,7 @@ while IFS= read -r i; do
     if ! shellcheck "$i"; then
         failed=1;
     fi
-done < <(git ls-files)
+done
 
 if [[ $failed -eq 1 ]]; then
     exit 1

--- a/scripts/check-precommit-reqs
+++ b/scripts/check-precommit-reqs
@@ -15,7 +15,7 @@ if [[ $# -ne 0 ]]; then
     files="$*"
 fi
 
-if ./scripts/format-code --whatif $([[ "$files" ]] && echo "--files=${files// /,}") | grep -q "@@"; then
+if ./scripts/format-code --whatif "$([[ "$files" ]] && echo "--files=${files// /,}")" | grep -q "@@"; then
     echo ""
     echo "Commit failed: please run ./scripts/format-code"
     echo ""
@@ -23,7 +23,7 @@ if ./scripts/format-code --whatif $([[ "$files" ]] && echo "--files=${files// /,
 fi
 
 # Check whether all sources have the license header:
-if ! ./scripts/check-license "$files"; then
+if ! ./scripts/check-license "$([[ "$files" ]] && echo "${files}")"; then
     echo ""
     echo "Commit failed: please add license headers to the above files"
     echo ""
@@ -31,7 +31,7 @@ if ! ./scripts/check-license "$files"; then
 fi
 
 # Check whether all scripts pass ShellCheck:
-if ! ./scripts/check-linters "$files"; then
+if ! ./scripts/check-linters "$([[ "$files" ]] && echo "${files}")"; then
     echo ""
     echo "Commit failed: please run ./scripts/check-linters"
     echo ""

--- a/scripts/check-precommit-reqs
+++ b/scripts/check-precommit-reqs
@@ -11,7 +11,11 @@
 ##==============================================================================
 
 ## Check whether source code has been formatted (diff outputs '@@'):
-if ./scripts/format-code --whatif | grep -q "@@"; then
+if [[ $# -ne 0 ]]; then
+    files="$*"
+fi
+
+if ./scripts/format-code --whatif $([[ "$files" ]] && echo "--files=${files// /,}") | grep -q "@@"; then
     echo ""
     echo "Commit failed: please run ./scripts/format-code"
     echo ""
@@ -19,7 +23,7 @@ if ./scripts/format-code --whatif | grep -q "@@"; then
 fi
 
 # Check whether all sources have the license header:
-if ! ./scripts/check-license; then
+if ! ./scripts/check-license "$files"; then
     echo ""
     echo "Commit failed: please add license headers to the above files"
     echo ""
@@ -27,7 +31,7 @@ if ! ./scripts/check-license; then
 fi
 
 # Check whether all scripts pass ShellCheck:
-if ! ./scripts/check-linters; then
+if ! ./scripts/check-linters "$files"; then
     echo ""
     echo "Commit failed: please run ./scripts/check-linters"
     echo ""

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -56,10 +56,14 @@ do
         userIncludeExts="${opt#*=}"
         ;;
 
+    --files=*)
+        files="${opt#*=}"
+        IFS=',' read -r -a files <<< "$files"
+        ;;
     *)
-      echo "$0: unknown option:  $opt"
-      exit 1
-      ;;
+        echo "$0: unknown option:  $opt"
+        exit 1
+        ;;
   esac
 done
 
@@ -76,7 +80,7 @@ OVERVIEW:
 
 Formats all C/C++ source files based on the .clang-format rules
 
-    $ format-code [-h] [-v] [-w] [--exclude-dirs="..."] [--include-exts="..."]
+    $ format-code [-h] [-v] [-w] [--exclude-dirs="..."] [--include-exts="..."] [--files=file1,file2]
 
 OPTIONS:
     -h, --help              Print this help message.
@@ -88,6 +92,8 @@ OPTIONS:
                             All subdirectories are relative to the current path.
     --include-exts          File extensions to include for formatting. If
                             unspecified, then *.h, *.c and *.cpp are included.
+    --files                 Only run the script against the specified files from
+                            the current directory.
 
 EXAMPLES:
 
@@ -101,6 +107,10 @@ can run from the tests folder:
 
     tests$ ../scripts/format-code --exclude-dirs="echo/host" \
       --include-exts="c cpp"
+
+To run only against a specified set of comma separated files in the current directory:
+
+    $ ./scripts/format-code -w --files=file1,file2
 
 EOF
     exit 0
@@ -221,7 +231,25 @@ if [[ ${whatif} -ne 1 ]]; then
     cfargs="${cfargs} -i"
 fi
 
-for file in $(eval "$findargs")
+if [[ $files ]]; then
+    file_list=""
+    list=$(eval "$findargs")
+    tempfile=$(mktemp)
+    echo $list | tr ' ' '\n' > $tempfile
+    
+    for f in ${files[@]}; do
+        new_file=$(grep -o "^\./${f}$" "${tempfile}")
+        if [[ $new_file ]]; then
+            file_list=$(echo $file_list $new_file)
+        fi
+    done
+
+    rm -rf "$tempfile"
+else
+    file_list=$(eval "$findargs")
+fi
+
+for file in $file_list
 do
     ((filecount+=1))
     cf="${cfargs} $file"

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -235,12 +235,12 @@ if [[ $files ]]; then
     file_list=""
     list=$(eval "$findargs")
     tempfile=$(mktemp)
-    echo $list | tr ' ' '\n' > $tempfile
+    echo "$list" | tr ' ' '\n' > $tempfile
     
-    for f in ${files[@]}; do
+    for f in "${files[@]}"; do
         new_file=$(grep -o "^\./${f}$" "${tempfile}")
         if [[ $new_file ]]; then
-            file_list=$(echo $file_list $new_file)
+            file_list=$(echo "$file_list" "$new_file")
         fi
     done
 


### PR DESCRIPTION
This PR resolves #766 by allowing the pre-commit hook only against specific files:

`./scripts/check-precommit-reqs newfile1.h newfile2.c`

To support this, functionality has been added to the 3 scripts called by `check-precommit-reqs`: `check-license`, `check-linters`, and `format-code`.
`check-license` and `check-linters` support running against specific files just like `check-precommit-reqs`.

Note: due to the nature of the implementation of the `format-code` script, I've made it accept files in the following way:

`./scripts/format-code --files=newfile1.h,newfile2.c`