### PR TITLE
Re-enabled Non-sim Container CI Tests.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -160,6 +160,5 @@ parallel "Check Pre-Commit Requirements" : { checkPreCommitRequirements() },
         "Coffeelake gcc SGX1-FLC Release" : { coffeelakeTest('gcc', 'SGX1FLC', 'Release') },
         "Coffeelake gcc SGX1-FLC RelWithDebInfo" : { coffeelakeTest('gcc', 'SGX1FLC', 'RelWithDebInfo') },
         "Windows Debug Cross-platform" : { windowsDebugCrossPlatform() },
-        "Windows Release Cross-platform" : { windowsReleaseCrossPlatform() }
-        // TODO: Re-enable this once it is no longer flaky.
-        // "Non-Simulation Container SGX1-FLC RelWithDebInfo" : { nonSimulationTest() }
+        "Windows Release Cross-platform" : { windowsReleaseCrossPlatform() },
+        "Non-Simulation Container SGX1-FLC RelWithDebInfo" : { nonSimulationTest() }


### PR DESCRIPTION
This test stage in Jenkins seems to work regularly again after several changes made it into master. Let's re-enable it, and if it fails again we should be able to investigate the cause due to logs being available now.