### PR TITLE
Compile with -Wextra warnings.

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -72,6 +72,11 @@ set_source_files_properties(
   PROPERTIES COMPILE_FLAGS "-Wno-conversion"
 )
 
+set_source_files_properties(
+  libcxx/src/system_error.cpp
+  PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter"
+)
+
 install(TARGETS libcxx EXPORT openenclave-targets
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
 

--- a/3rdparty/libcxxrt/CMakeLists.txt
+++ b/3rdparty/libcxxrt/CMakeLists.txt
@@ -17,17 +17,24 @@ add_library(libcxxrt OBJECT
 
 set_source_files_properties(
   libcxxrt/src/dynamic_cast.cc
-  PROPERTIES COMPILE_FLAGS "-Wno-sign-conversion"
+  PROPERTIES COMPILE_FLAGS "-Wno-sign-conversion -Wno-unused-parameter"
 )
 
 set_source_files_properties(
   libcxxrt/src/exception.cc
-  PROPERTIES COMPILE_FLAGS "-Wno-unused-variable -Wno-conversion")
+  PROPERTIES COMPILE_FLAGS "-Wno-unused-variable -Wno-conversion -Wno-unused-parameter")
 
 set_source_files_properties(
   libcxxrt/src/libelftc_dem_gnu3.c
-  PROPERTIES COMPILE_FLAGS "-Wno-conversion"
-)
+  PROPERTIES COMPILE_FLAGS "-Wno-conversion")
+
+set_source_files_properties(
+  libcxxrt/src/stdexcept.cc
+  PROPERTIES COMPILE_FLAGS "-Wno-extra")
+
+set_source_files_properties(
+  libcxxrt/src/typeinfo.cc
+  PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
 
 set_target_properties(libcxxrt PROPERTIES
   POSITION_INDEPENDENT_CODE ON)

--- a/3rdparty/libunwind/CMakeLists.txt
+++ b/3rdparty/libunwind/CMakeLists.txt
@@ -135,7 +135,8 @@ elseif (CMAKE_C_COMPILER_ID MATCHES Clang)
     -Wno-header-guard
     -Wno-uninitialized
     -Wno-unused-variable
-    -Wno-macro-redefined)
+    -Wno-macro-redefined
+    -Wno-unused-parameter)
 endif ()
 
 # Allow arithmetic on void*

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -76,7 +76,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
   # Enables all the warnings about constructions that some users consider questionable,
   # and that are easy to avoid. Treat at warnings-as-errors, which forces developers
   # to fix warnings as they arise, so they don't accumulate "to be fixed later".
-  add_compile_options(-Wall -Werror -Wpointer-arith -Wconversion)
+  add_compile_options(-Wall -Werror -Wpointer-arith -Wconversion -Wextra -Wno-missing-field-initializers)
 
   add_compile_options(-fno-strict-aliasing)
 

--- a/common/quote.c
+++ b/common/quote.c
@@ -165,6 +165,11 @@ oe_result_t VerifyQuoteImpl(
     oe_ec_public_key_t expected_root_public_key = {0};
     bool key_equal = false;
 
+    OE_UNUSED(pck_crl);
+    OE_UNUSED(pck_crl_size);
+    OE_UNUSED(tcb_info_json);
+    OE_UNUSED(tcb_info_json_size);
+
     OE_CHECK(
         _parse_quote(
             quote,

--- a/common/revocation.c
+++ b/common/revocation.c
@@ -175,6 +175,8 @@ oe_result_t oe_enforce_revocation(
     oe_datetime_t crl_this_update_date = {0};
     oe_datetime_t crl_next_update_date = {0};
 
+    OE_UNUSED(pck_cert_chain);
+
     if (intermediate_cert == NULL || leaf_cert == NULL)
         OE_RAISE(OE_INVALID_PARAMETER);
 

--- a/common/safecrt.c
+++ b/common/safecrt.c
@@ -97,6 +97,8 @@ OE_INLINE oe_result_t _oe_validate_string(char* str, size_t size)
 
 OE_INLINE void _oe_fill_string(char* str, size_t size)
 {
+    OE_UNUSED(str);
+    OE_UNUSED(size);
 #ifndef NDEBUG
     // Fill memory with pattern.
     memset(str, 0xFD, size);

--- a/common/sgxcertextensions.c
+++ b/common/sgxcertextensions.c
@@ -373,6 +373,7 @@ static oe_result_t _read_boolean_extension(
     oe_result_t result = OE_INVALID_SGX_CERTIFICATE_EXTENSIONS;
     uint8_t* data = NULL;
     size_t data_length = 0;
+    OE_UNUSED(tag);
 
     OE_CHECK(
         _read_extension(itr, end, oid, SGX_BOOLEAN_TAG, &data, &data_length));

--- a/common/tcbinfo.c
+++ b/common/tcbinfo.c
@@ -342,6 +342,8 @@ static oe_result_t _read_tcb_level(
     const uint8_t* status = NULL;
     size_t status_length = 0;
 
+    OE_UNUSED(parsed_info);
+
     OE_CHECK(_read('{', itr, end));
 
     OE_TRACE_INFO("Reading tcb\n");

--- a/enclave/cert.c
+++ b/enclave/cert.c
@@ -406,6 +406,8 @@ static bool _find_extension(
     void* args_)
 {
     FindExtensionArgs* args = (FindExtensionArgs*)args_;
+    OE_UNUSED(index);
+    OE_UNUSED(critical);
 
     if (oe_strcmp(oid, args->oid) == 0)
     {

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -59,7 +59,13 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU)
     target_compile_options(oecore PRIVATE -Wjump-misses-init)
 endif ()
 
-set_source_files_properties(malloc.c PROPERTIES COMPILE_FLAGS -Wno-conversion)
+# Unfortunately dlmalloc uses GNU extension that allows arithmetic
+# null pointers.
+set_source_files_properties(
+    malloc.c 
+    PROPERTIES COMPILE_FLAGS "-Wno-conversion -Wno-null-pointer-arithmetic")
+
+set_source_files_properties(keys.c PROPERTIES COMPILE_FLAGS -Wno-type-limits)
 
 target_compile_options(oecore PUBLIC
     -m64

--- a/enclave/core/atexit.c
+++ b/enclave/core/atexit.c
@@ -69,6 +69,7 @@ static oe_atexit_entry_t* _new_atexit_entry(void (*func)(void*), void* arg)
 int __cxa_atexit(void (*func)(void*), void* arg, void* dso_handle)
 {
     oe_atexit_entry_t* entry;
+    OE_UNUSED(dso_handle);
 
     if (!(entry = _new_atexit_entry(func, arg)))
         return -1;

--- a/enclave/core/backtrace.c
+++ b/enclave/core/backtrace.c
@@ -35,6 +35,8 @@ const void* _check_address(const void* ptr)
  */
 int oe_backtrace(void** buffer, int size)
 {
+    OE_UNUSED(buffer);
+    OE_UNUSED(size);
 #ifdef OE_USE_DEBUG_MALLOC
     // Fetch the frame-pointer of the current function.
     // The current function oe_backtrace is not expected to be inlined.
@@ -132,7 +134,7 @@ oe_result_t oe_print_backtrace(void)
 
     oe_host_printf("=== backtrace:\n");
 
-    for (size_t i = 0; i < size; i++)
+    for (int i = 0; i < size; i++)
         oe_host_printf("%s(): %p\n", syms[i], buffer[i]);
 
     oe_host_printf("\n");

--- a/enclave/core/debugmalloc.c
+++ b/enclave/core/debugmalloc.c
@@ -258,7 +258,7 @@ static void _malloc_dump(size_t size, void* addrs[], int num_addrs)
 
     oe_host_printf("%llu bytes\n", OE_LLX(size));
 
-    for (size_t i = 0; i < num_addrs; i++)
+    for (int i = 0; i < num_addrs; i++)
         oe_host_printf("%s(): %p\n", syms[i], addrs[i]);
 
     oe_host_printf("\n");

--- a/enclave/core/exception.c
+++ b/enclave/core/exception.c
@@ -316,6 +316,7 @@ void oe_virtual_exception_dispatcher(
     uint64_t* arg_out)
 {
     SSA_Info ssa_info = {0};
+    OE_UNUSED(arg_in);
 
     // Verify if the first SSA has valid exception info.
     if (_get_enclave_thread_first_ssa_info(td, &ssa_info) != 0)

--- a/enclave/core/globals.c
+++ b/enclave/core/globals.c
@@ -182,7 +182,7 @@ const void* __oe_get_reloc_end()
     return (const uint8_t*)__oe_get_reloc_base() + __oe_get_reloc_size();
 }
 
-const size_t __oe_get_reloc_size()
+size_t __oe_get_reloc_size()
 {
 #if defined(__linux__)
     return _reloc_size;
@@ -211,7 +211,7 @@ const void* __oe_get_ecall_end()
     return (const uint8_t*)__oe_get_ecall_base() + __oe_get_ecall_size();
 }
 
-const size_t __oe_get_ecall_size()
+size_t __oe_get_ecall_size()
 {
     return oe_enclave_properties_sgx.image_info.ecall_size;
 }
@@ -231,7 +231,7 @@ const void* __oe_get_heap_base()
     return base + oe_enclave_properties_sgx.image_info.heap_rva;
 }
 
-const size_t __oe_get_heap_size()
+size_t __oe_get_heap_size()
 {
     return oe_enclave_properties_sgx.header.size_settings.num_heap_pages *
            OE_PAGE_SIZE;

--- a/enclave/core/hostcalls.c
+++ b/enclave/core/hostcalls.c
@@ -156,7 +156,7 @@ int oe_host_vfprintf(int device, const char* fmt, oe_va_list ap_)
     }
 
     /* If string was truncated, retry with correctly sized buffer */
-    if (n >= sizeof(buf))
+    if (n >= (int)sizeof(buf))
     {
         if (!(p = oe_stack_alloc((uint32_t)n + 1)))
             return -1;

--- a/enclave/core/malloc.c
+++ b/enclave/core/malloc.c
@@ -175,6 +175,7 @@ static int _dlmalloc_stats_fprintf(FILE* stream, const char* format, ...)
     int ret = 0;
     oe_va_list ap;
 
+    OE_UNUSED(stream);
     oe_va_start(ap, format);
 
     if (oe_strcmp(format, "max system bytes = %10lu\n") == 0)

--- a/enclave/core/sbrk.c
+++ b/enclave/core/sbrk.c
@@ -13,12 +13,12 @@ void* oe_sbrk(ptrdiff_t increment)
 
     oe_spin_lock(&_lock);
     {
-        size_t remaining;
+        ptrdiff_t remaining;
 
         if (!_heap_next)
             _heap_next = (unsigned char*)__oe_get_heap_base();
 
-        remaining = (size_t)((unsigned char*)__oe_get_heap_end() - _heap_next);
+        remaining = (unsigned char*)__oe_get_heap_end() - _heap_next;
 
         if (increment <= remaining)
         {

--- a/enclave/core/tracee.c
+++ b/enclave/core/tracee.c
@@ -19,15 +19,11 @@ const char* get_filename_from_path(const char* path)
 {
     if (path)
     {
-        for (size_t i = oe_strlen(path) - 1; i >= 0; i--)
+        for (size_t i = oe_strlen(path); i > 0; i--)
         {
-            if ((path[i] == '/') || (path[i] == '\\'))
+            if ((path[i - 1] == '/') || (path[i - 1] == '\\'))
             {
-                return &path[i + 1];
-            }
-            else if (i == 0)
-            {
-                break;
+                return &path[i];
             }
         }
     }
@@ -188,7 +184,7 @@ oe_result_t oe_log(log_level_t level, const char* fmt, ...)
     oe_va_start(ap, fmt);
     n = oe_vsnprintf(
         &args->message[bytes_written],
-        (size_t)(OE_LOG_MESSAGE_LEN_MAX - bytes_written),
+        OE_LOG_MESSAGE_LEN_MAX - (size_t)bytes_written,
         fmt,
         ap);
     oe_va_end(ap);

--- a/enclave/report.c
+++ b/enclave/report.c
@@ -181,6 +181,8 @@ void oe_handle_verify_report(uint64_t arg_in, uint64_t* arg_out)
     oe_verify_report_args_t arg;
     uint8_t* buffer = NULL;
 
+    OE_UNUSED(arg_out);
+
     OE_CHECK(_safe_copy_verify_report_args(arg_in, &arg, &buffer));
 
     OE_CHECK(oe_verify_report(arg.report, arg.report_size, NULL));

--- a/host/crypto/openssl/cert.c
+++ b/host/crypto/openssl/cert.c
@@ -970,7 +970,7 @@ oe_result_t oe_cert_find_extension(
                 OE_RAISE(OE_FAILURE);
 
             /* If the caller's buffer is too small, raise error */
-            if (str->length > *size)
+            if ((size_t)str->length > *size)
             {
                 *size = (size_t)str->length;
                 OE_RAISE(OE_BUFFER_TOO_SMALL);

--- a/host/crypto/openssl/ec.c
+++ b/host/crypto/openssl/ec.c
@@ -505,7 +505,7 @@ oe_result_t oe_ecdsa_signature_write_der(
         OE_RAISE(OE_FAILURE);
 
     /* Copy binary signature to output buffer */
-    if (signature && sig_len <= *signature_size)
+    if (signature && ((size_t)sig_len <= *signature_size))
     {
         uint8_t* p = signature;
 
@@ -517,7 +517,7 @@ oe_result_t oe_ecdsa_signature_write_der(
     }
 
     /* Check whether buffer is too small */
-    if (sig_len > *signature_size)
+    if ((size_t)sig_len > *signature_size)
     {
         *signature_size = (size_t)sig_len;
         OE_RAISE(OE_BUFFER_TOO_SMALL);

--- a/host/linux/aesm.c
+++ b/host/linux/aesm.c
@@ -289,7 +289,7 @@ static int _read(int sock, void* data, size_t size)
 {
     ssize_t n;
 
-    if ((n = read(sock, data, size)) != size)
+    if ((n = read(sock, data, size)) != (ssize_t)size)
         return -1;
 
     return 0;
@@ -299,7 +299,7 @@ static int _write(int sock, const void* data, size_t size)
 {
     ssize_t n;
 
-    if ((n = write(sock, data, size)) != size)
+    if ((n = write(sock, data, size)) != (ssize_t)size)
         return -1;
 
     return 0;

--- a/host/linux/windows.c
+++ b/host/linux/windows.c
@@ -59,6 +59,10 @@ BOOL VirtualProtect(
     DWORD flNewProtect,
     PDWORD lpflOldProtect)
 {
+    OE_UNUSED(lpAddress);
+    OE_UNUSED(dwSize);
+    OE_UNUSED(flNewProtect);
+    OE_UNUSED(lpflOldProtect);
     /* Nothing to do. */
     return true;
 }

--- a/host/loadelf.c
+++ b/host/loadelf.c
@@ -826,6 +826,7 @@ static oe_result_t _sgx_load_enclave_properties(
     oe_sgx_enclave_properties_t* properties)
 {
     oe_result_t result = OE_UNEXPECTED;
+    OE_UNUSED(section_name);
 
     /* Copy from the image at oeinfo_rva. */
     OE_CHECK(
@@ -847,6 +848,7 @@ static oe_result_t _sgx_update_enclave_properties(
     const oe_sgx_enclave_properties_t* properties)
 {
     oe_result_t result = OE_UNEXPECTED;
+    OE_UNUSED(section_name);
 
     /* Copy to both the image and ELF file*/
     OE_CHECK(

--- a/host/loadpe.c
+++ b/host/loadpe.c
@@ -71,6 +71,7 @@ static oe_result_t _sgx_load_enclave_properties(
     const char* sectionName, // unused
     oe_sgx_enclave_properties_t* properties)
 {
+    OE_UNUSED(sectionName);
     assert(image);
     assert(image->oeinfo_rva);
     assert(properties);
@@ -85,6 +86,7 @@ static oe_result_t _sgx_update_enclave_properties(
     const char* sectionName, // unused
     const oe_sgx_enclave_properties_t* properties)
 {
+    OE_UNUSED(sectionName);
     assert(image);
     assert(image->oeinfo_rva);
     assert(properties);

--- a/host/ocalls.c
+++ b/host/ocalls.c
@@ -94,7 +94,7 @@ void HandleThreadWait(oe_enclave_t* enclave, uint64_t arg_in)
             // Spurious-wakes are ignored by going back to FUTEX_WAIT.
             // Since FUTEX_WAIT uses atomic instructions to load event->value,
             // it is safe to use a non-atomic operation here.
-        } while (event->value == -1);
+        } while (event->value == (uint32_t)-1);
     }
 
 #elif defined(_WIN32)
@@ -286,6 +286,7 @@ void oe_handle_backtrace_symbols(oe_enclave_t* enclave, uint64_t arg)
 void oe_handle_log(oe_enclave_t* enclave, uint64_t arg)
 {
     oe_log_args_t* args = (oe_log_args_t*)arg;
+    OE_UNUSED(enclave);
     if (args)
     {
         log_message(true, args);

--- a/host/sgxload.c
+++ b/host/sgxload.c
@@ -298,6 +298,7 @@ static oe_result_t _sgx_free_enclave_memory(
     else /* FLC simulation mode needs to munmap. */
 #endif
     {
+        OE_UNUSED(is_simulation);
         munmap(addr, size);
     }
 

--- a/host/sgxmeasure.c
+++ b/host/sgxmeasure.c
@@ -34,6 +34,7 @@ static void _measure_eextend(
 {
     uint64_t pgoff = 0;
     const uint64_t CHUNK_SIZE = 256;
+    OE_UNUSED(flags);
 
     /* Write this page one chunk at a time */
     for (pgoff = 0; pgoff < OE_PAGE_SIZE; pgoff += CHUNK_SIZE)

--- a/include/openenclave/internal/globals.h
+++ b/include/openenclave/internal/globals.h
@@ -17,17 +17,17 @@ size_t __oe_get_enclave_size(void);
 /* Reloc */
 const void* __oe_get_reloc_base(void);
 const void* __oe_get_reloc_end(void);
-const size_t __oe_get_reloc_size(void);
+size_t __oe_get_reloc_size(void);
 
 /* ECall */
 const void* __oe_get_ecall_base(void);
 const void* __oe_get_ecall_end(void);
-const size_t __oe_get_ecall_size(void);
+size_t __oe_get_ecall_size(void);
 
 /* Heap */
 const void* __oe_get_heap_base(void);
 const void* __oe_get_heap_end(void);
-const size_t __oe_get_heap_size(void);
+size_t __oe_get_heap_size(void);
 
 /* The enclave handle passed by host during initialization */
 extern oe_enclave_t* oe_enclave;

--- a/include/openenclave/internal/str.h
+++ b/include/openenclave/internal/str.h
@@ -280,7 +280,7 @@ MEM_INLINE int str_printf(str_t* str, const char* format, ...)
     va_end(ap);
 
     /* If buffer was not big enough and using dynamic memory */
-    if (r + 1 > str_cap(str))
+    if ((size_t)r + 1 > str_cap(str))
     {
         /* Expand memory allocation to required size */
         if (str_reserve(str, (size_t)r + 1) != 0)

--- a/include/openenclave/internal/trace.h
+++ b/include/openenclave/internal/trace.h
@@ -18,8 +18,8 @@ typedef enum _log_level_ {
 } log_level_t;
 
 /* Maximum log length */
-#define OE_LOG_MESSAGE_LEN_MAX 2048
-#define MAX_FILENAME_LEN 256
+#define OE_LOG_MESSAGE_LEN_MAX 2048U
+#define MAX_FILENAME_LEN 256U
 
 typedef struct _oe_log_filter
 {

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -688,7 +688,9 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU OR CMAKE_C_COMPILER_ID MATCHES Clang)
     -Wno-missing-braces
     -Wno-parentheses
     -Wno-unknown-pragmas
-    -Wno-conversion)
+    -Wno-conversion
+    -Wno-unused-parameter
+    -Wno-sign-compare)
 endif ()
 # Second: compiler-specific warnings:
 if (CMAKE_C_COMPILER_ID MATCHES GNU)

--- a/libc/__printf_chk.c
+++ b/libc/__printf_chk.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <openenclave/enclave.h>
 #include <stdarg.h>
 #include <stdio.h>
 
@@ -11,6 +12,8 @@
 int __printf_chk(int flag, const char* format, ...)
 {
     va_list ap;
+
+    OE_UNUSED(flag);
 
     va_start(ap, format);
     int ret = vfprintf(stdout, format, ap);

--- a/libc/dladdr.c
+++ b/libc/dladdr.c
@@ -4,10 +4,13 @@
 #define _GNU_SOURCE
 #include <assert.h>
 #include <dlfcn.h>
+#include <openenclave/enclave.h>
 #include <stdlib.h>
 
 int dladdr(const void* addr, Dl_info* info)
 {
+    OE_UNUSED(addr);
+    OE_UNUSED(info);
     assert("dladdr(): panic" == NULL);
     return -1;
 }

--- a/libc/libunwind_stubs.c
+++ b/libc/libunwind_stubs.c
@@ -4,6 +4,7 @@
 #define _GNU_SOURCE
 #define USE_DL_PREFIX
 #include <assert.h>
+#include <openenclave/enclave.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -52,6 +53,9 @@ int __libunwind_munmap(void* addr, size_t length)
 
 int __libunwind_msync(void* addr, size_t length, int flags)
 {
+    OE_UNUSED(addr);
+    OE_UNUSED(length);
+    OE_UNUSED(flags);
     return 0;
 }
 

--- a/libc/locale.c
+++ b/libc/locale.c
@@ -3,6 +3,7 @@
 
 #include <libc.h>
 #include <locale.h>
+#include <openenclave/enclave.h>
 #include <string.h>
 
 /* ATTN: should these assert? */
@@ -39,6 +40,7 @@ static const struct __locale_struct c_locale = {0};
 
 locale_t uselocale(locale_t newloc)
 {
+    OE_UNUSED(newloc);
     return 0;
 }
 
@@ -49,16 +51,20 @@ struct lconv* localeconv(void)
 
 void freelocale(locale_t loc)
 {
+    OE_UNUSED(loc);
 }
 
 char* setlocale(int category, const char* locale)
 {
+    OE_UNUSED(category);
+    OE_UNUSED(locale);
     return NULL;
 }
 
 locale_t newlocale(int mask, const char* locale, locale_t loc)
 {
     int builtin;
+    OE_UNUSED(mask);
 
     /* Currently we will support basic C/POSIX locale */
     builtin = (locale[0] == 'C' && !locale[1]) || !strcmp(locale, "POSIX");

--- a/libc/pthread.c
+++ b/libc/pthread.c
@@ -164,6 +164,7 @@ int pthread_once(pthread_once_t* once, void (*func)(void))
 
 int pthread_spin_init(pthread_spinlock_t* spinlock, int pshared)
 {
+    OE_UNUSED(pshared);
     return _to_errno(oe_spin_init((oe_spinlock_t*)spinlock));
 }
 
@@ -192,21 +193,26 @@ int pthread_spin_destroy(pthread_spinlock_t* spinlock)
 
 int pthread_mutexattr_init(pthread_mutexattr_t* attr)
 {
+    OE_UNUSED(attr);
     return 0;
 }
 
 int pthread_mutexattr_settype(pthread_mutexattr_t* attr, int type)
 {
+    OE_UNUSED(attr);
+    OE_UNUSED(type);
     return 0;
 }
 
 int pthread_mutexattr_destroy(pthread_mutexattr_t* attr)
 {
+    OE_UNUSED(attr);
     return 0;
 }
 
 int pthread_mutex_init(pthread_mutex_t* m, const pthread_mutexattr_t* attr)
 {
+    OE_UNUSED(attr);
     return _to_errno(oe_mutex_init((oe_mutex_t*)m));
 }
 
@@ -242,6 +248,7 @@ int pthread_rwlock_init(
     pthread_rwlock_t* rwlock,
     const pthread_rwlockattr_t* attr)
 {
+    OE_UNUSED(attr);
     return _to_errno(oe_rwlock_init((oe_rwlock_t*)rwlock));
 }
 
@@ -275,6 +282,7 @@ int pthread_rwlock_destroy(pthread_rwlock_t* rwlock)
 
 int pthread_cond_init(pthread_cond_t* cond, const pthread_condattr_t* attr)
 {
+    OE_UNUSED(attr);
     return _to_errno(oe_cond_init((oe_cond_t*)cond));
 }
 
@@ -288,6 +296,9 @@ int pthread_cond_timedwait(
     pthread_mutex_t* mutex,
     const struct timespec* ts)
 {
+    OE_UNUSED(cond);
+    OE_UNUSED(mutex);
+    OE_UNUSED(ts);
     assert("pthread_cond_timedwait(): panic" == NULL);
     return -1;
 }

--- a/libc/stdlib.c
+++ b/libc/stdlib.c
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 #include <locale.h>
+#include <openenclave/enclave.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 long long int strtoll_l(const char* nptr, char** endptr, int base, locale_t loc)
 {
+    OE_UNUSED(loc);
     return strtoll(nptr, endptr, base);
 }
 
@@ -16,5 +18,6 @@ unsigned long long strtoull_l(
     int base,
     locale_t loc)
 {
+    OE_UNUSED(loc);
     return strtoull(nptr, endptr, base);
 }

--- a/libc/strerror.c
+++ b/libc/strerror.c
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 #include <errno.h>
+#include <openenclave/enclave.h>
 
 typedef struct _error_info
 {
-    unsigned int errnum;
+    int errnum;
     const char* message;
 } error_info_t;
 
@@ -18,6 +19,7 @@ static size_t _num_errors = sizeof(_errors) / sizeof(_errors[0]);
 
 char* strerror_l(int errnum, locale_t loc)
 {
+    OE_UNUSED(loc);
     for (size_t i = 0; i < _num_errors; i++)
     {
         if (errnum == _errors[i].errnum)

--- a/libc/syscalls.c
+++ b/libc/syscalls.c
@@ -39,9 +39,13 @@ _syscall_open(long n, long x1, long x2, long x3, long x4, long x5, long x6)
     int flags = (int)x2;
     int mode = (int)x3;
 
-    (void)filename;
-    (void)flags;
-    (void)mode;
+    OE_UNUSED(n);
+    OE_UNUSED(x4);
+    OE_UNUSED(x5);
+    OE_UNUSED(x6);
+    OE_UNUSED(filename);
+    OE_UNUSED(flags);
+    OE_UNUSED(mode);
 
     if (flags == O_WRONLY)
         return STDOUT_FILENO;
@@ -52,12 +56,14 @@ _syscall_open(long n, long x1, long x2, long x3, long x4, long x5, long x6)
 static long _syscall_close(long n, ...)
 {
     /* required by mbedtls */
+    OE_UNUSED(n);
     return 0;
 }
 
 static long _syscall_mmap(long n, ...)
 {
     /* Always fail */
+    OE_UNUSED(n);
     return EPERM;
 }
 
@@ -66,6 +72,7 @@ static long _syscall_readv(long n, ...)
     /* required by mbedtls */
 
     /* return zero-bytes read */
+    OE_UNUSED(n);
     return 0;
 }
 
@@ -73,6 +80,13 @@ static long
 _syscall_ioctl(long n, long x1, long x2, long x3, long x4, long x5, long x6)
 {
     int fd = (int)x1;
+
+    OE_UNUSED(n);
+    OE_UNUSED(x2);
+    OE_UNUSED(x3);
+    OE_UNUSED(x4);
+    OE_UNUSED(x5);
+    OE_UNUSED(x6);
 
     /* only allow ioctl() on these descriptors */
     if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO)
@@ -89,6 +103,11 @@ _syscall_writev(long n, long x1, long x2, long x3, long x4, long x5, long x6)
     unsigned long iovcnt = (unsigned long)x3;
     long ret = 0;
     int device;
+
+    OE_UNUSED(n);
+    OE_UNUSED(x4);
+    OE_UNUSED(x5);
+    OE_UNUSED(x6);
 
     /* Allow writing only to stdout and stderr */
     switch (fd)
@@ -125,6 +144,8 @@ static long _syscall_clock_gettime(long n, long x1, long x2)
     int ret = -1;
     uint64_t msec;
 
+    OE_UNUSED(n);
+
     if (!tp)
         goto done;
 
@@ -155,6 +176,8 @@ static long _syscall_gettimeofday(long n, long x1, long x2)
     int ret = -1;
     uint64_t msec;
 
+    OE_UNUSED(n);
+
     if (tv)
         oe_memset(tv, 0, sizeof(struct timeval));
 
@@ -182,6 +205,8 @@ static long _syscall_nanosleep(long n, long x1, long x2)
     struct timespec* rem = (struct timespec*)x2;
     size_t ret = -1;
     uint64_t milliseconds = 0;
+
+    OE_UNUSED(n);
 
     if (rem)
         oe_memset(rem, 0, sizeof(*rem));

--- a/libc/sysconf.c
+++ b/libc/sysconf.c
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 #include <errno.h>
+#include <openenclave/enclave.h>
 #include <unistd.h>
 
 long sysconf(int name)
 {
+    OE_UNUSED(name);
     errno = EINVAL;
     return -1;
 }

--- a/libc/time.c
+++ b/libc/time.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <assert.h>
+#include <openenclave/enclave.h>
 #include <stdlib.h>
 #include <sys/time.h>
 #include <time.h>
@@ -11,6 +12,10 @@ const char __gmt[] = "GMT";
 
 size_t strftime(char* s, size_t max, const char* format, const struct tm* tm)
 {
+    OE_UNUSED(s);
+    OE_UNUSED(max);
+    OE_UNUSED(format);
+    OE_UNUSED(tm);
     assert("strftime(): panic" == NULL);
     return 0;
 }
@@ -22,6 +27,11 @@ size_t strftime_l(
     const struct tm* tm,
     locale_t loc)
 {
+    OE_UNUSED(s);
+    OE_UNUSED(max);
+    OE_UNUSED(format);
+    OE_UNUSED(tm);
+    OE_UNUSED(loc);
     assert("strftime_l(): panic" == NULL);
     return 0;
 }

--- a/tests/VectorException/enc/enc.c
+++ b/tests/VectorException/enc/enc.c
@@ -68,6 +68,7 @@ uint64_t TestDivideByZeroHandler(oe_exception_record_t* exception_record)
     uint64_t __exception_handler_name_(                          \
         oe_exception_record_t* exception_record)                 \
     {                                                            \
+        OE_UNUSED(exception_record);                             \
         return OE_EXCEPTION_CONTINUE_SEARCH;                     \
     }
 

--- a/tests/aesm/main.cpp
+++ b/tests/aesm/main.cpp
@@ -14,7 +14,7 @@
 
 #define SKIP_RETURN_CODE 2
 
-int main(int argc, const char* argv[])
+int main()
 {
     const uint32_t flags = oe_get_create_flags();
     if ((flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
@@ -37,12 +37,12 @@ int main(int argc, const char* argv[])
     aesm_t* aesm;
     if (!(aesm = aesm_connect()))
     {
-        fprintf(stderr, "%s: failed to connect\n", argv[0]);
+        fprintf(stderr, "aesm: failed to connect\n");
         exit(1);
     }
     aesm_disconnect(aesm);
 #endif
 
-    printf("=== passed all tests (%s)\n", argv[0]);
+    printf("=== passed all tests (aesm)\n");
     return 0;
 }

--- a/tests/backtrace/enc/enc.cpp
+++ b/tests/backtrace/enc/enc.cpp
@@ -29,6 +29,9 @@ extern "C" OE_NEVER_INLINE void func4(size_t num_syms, const char** syms)
 {
     Backtrace b;
 
+    OE_UNUSED(num_syms);
+    OE_UNUSED(syms);
+
     b.size = oe_backtrace(b.buffer, OE_COUNTOF(b.buffer));
 
     /* Check for truncation */
@@ -85,6 +88,9 @@ extern "C" bool test(size_t num_syms, const char** syms)
 
     Backtrace b;
     GetBacktrace(&b);
+
+    OE_UNUSED(num_syms);
+    OE_UNUSED(syms);
 
 /* Backtrace does not work in non-debug builds */
 #ifdef OE_USE_DEBUG_MALLOC

--- a/tests/bigmalloc/host/host.c
+++ b/tests/bigmalloc/host/host.c
@@ -28,6 +28,8 @@ uint64_t get_free_system_memory(void)
 
 int main(int argc, const char* argv[])
 {
+    OE_UNUSED(argc);
+    OE_UNUSED(argv);
 #if !defined(OE_USE_LIBSGX)
 
     oe_result_t result;

--- a/tests/crypto/enclave/enc/enc.c
+++ b/tests/crypto/enclave/enc/enc.c
@@ -47,6 +47,10 @@ static oe_result_t _syscall_hook(
 {
     oe_result_t result = OE_UNEXPECTED;
 
+    OE_UNUSED(arg4);
+    OE_UNUSED(arg5);
+    OE_UNUSED(arg6);
+
     if (ret)
         *ret = -1;
 

--- a/tests/crypto/host/main.c
+++ b/tests/crypto/host/main.c
@@ -20,6 +20,7 @@ const char* arg0;
 
 int main(int argc, const char* argv[])
 {
+    OE_UNUSED(argc);
     arg0 = argv[0];
 
     /* Run the tests */

--- a/tests/crypto/read_file.c
+++ b/tests/crypto/read_file.c
@@ -150,6 +150,8 @@ oe_result_t read_mod(char* filename, uint8_t* mod, size_t* mod_size)
 oe_result_t read_mixed_chain(char* chain, char* chain1, char* chain2)
 {
     char chain_temp[max_cert_chain_size * 2];
+    OE_UNUSED(chain);
+
     strcat(chain_temp, chain1);
     strcat(chain_temp, chain2);
     chain = chain_temp;

--- a/tests/crypto_crls_cert_chains/common/tests.cpp
+++ b/tests/crypto_crls_cert_chains/common/tests.cpp
@@ -102,6 +102,7 @@ void test_cert_chain_negative(
     const char* leaf2)
 {
     oe_cert_chain_t chain = {0};
+    OE_UNUSED(leaf2);
 
     // Missing cert in chain.
     OE_TEST(

--- a/tests/libcxx/enc/enc.cpp
+++ b/tests/libcxx/enc/enc.cpp
@@ -44,7 +44,7 @@ extern "C" void exit(int status)
 
 typedef void (*Handler)(int signal);
 
-Handler signal(int signal, Handler)
+Handler signal(int, Handler)
 {
     /* Ignore! */
     return NULL;
@@ -52,6 +52,7 @@ Handler signal(int signal, Handler)
 
 extern "C" int close(int fd)
 {
+    OE_UNUSED(fd);
     OE_TEST("close() panic" == NULL);
     return 0;
 }
@@ -74,6 +75,8 @@ static int _pthread_create_hook(
     void* (*start_routine)(void*),
     void* arg)
 {
+    OE_UNUSED(attr);
+
     *enc_thread = 0;
     _acquire_lock(&_enc_lock);
     _thread_functions.push_back(

--- a/tests/libcxx/host/host.cpp
+++ b/tests/libcxx/host/host.cpp
@@ -120,6 +120,8 @@ OE_OCALL void host_join_pthread(void* args, oe_enclave_t* enclave)
     int join_ret = -1;
     void* value_ptr;
 
+    OE_UNUSED(enclave);
+
     // Find the host_thread_id from the enclave_host_id_map using the enc_key
 
     // Using atomic locks to protect the enclave_host_id_map
@@ -165,6 +167,8 @@ OE_OCALL void host_detach_pthread(void* args, oe_enclave_t* enclave)
 {
     pthread_t host_thread_id = 0;
     ThreadArgs* thrd_detach_args = (ThreadArgs*)args;
+
+    OE_UNUSED(enclave);
 
     printf(
         "host_detach_pthread():enclave key=%lu\n", thrd_detach_args->enc_key);

--- a/tests/mbed/enc/enc.c
+++ b/tests/mbed/enc/enc.c
@@ -81,6 +81,9 @@ static oe_result_t _syscall_hook(
     long* ret)
 {
     oe_result_t result = OE_UNEXPECTED;
+    OE_UNUSED(arg4);
+    OE_UNUSED(arg5);
+    OE_UNUSED(arg6);
 
     if (ret)
         *ret = -1;
@@ -166,14 +169,14 @@ static oe_result_t _syscall_hook(
             const struct iovec* iov = (const struct iovec*)arg2;
             unsigned long iovcnt = (unsigned long)arg3;
             // Calculating  buffer length
-            for (int i = 0; i < iovcnt; i++)
+            for (size_t i = 0; i < iovcnt; i++)
             {
                 total_buff_len = total_buff_len + iov[i].iov_len;
             }
             // Considering string terminating character
             total_buff_len += 1;
             str_full = (char*)calloc(total_buff_len, sizeof(char));
-            for (int i = 0; i < iovcnt; i++)
+            for (size_t i = 0; i < iovcnt; i++)
             {
                 strncat(str_full, iov[i].iov_base, iov[i].iov_len);
             }
@@ -255,6 +258,8 @@ int test(const char* in_testname, char** out_testname, struct mbed_args* args)
 
 void oe_handle_verify_report(uint64_t arg_in, uint64_t* arg_out)
 {
+    OE_UNUSED(arg_in);
+    OE_UNUSED(arg_out);
     assert("oe_handle_verify_report()" == NULL);
     abort();
 }

--- a/tests/mem/main.c
+++ b/tests/mem/main.c
@@ -79,7 +79,7 @@ void TestMem(mem_t* m)
     printf("=== passed TestMem()\n");
 }
 
-int main(int argc, const char* argv[])
+int main()
 {
     /* TestMem dynamic */
     {

--- a/tests/memory/enc/basic.c
+++ b/tests/memory/enc/basic.c
@@ -19,7 +19,7 @@ static void _set_buffer(int* buf, size_t start, size_t end)
 static void _check_buffer(int* buf, size_t start, size_t end)
 {
     for (size_t i = start; i < end; i++)
-        OE_TEST(buf[i] == i);
+        OE_TEST(buf[i] == (int)i);
 }
 
 void test_malloc(void)

--- a/tests/memory/enc/boundaries.c
+++ b/tests/memory/enc/boundaries.c
@@ -43,10 +43,10 @@ void test_between_enclave_boundaries(
     unsigned char* heapbuf = host_heap.buf;
 
     /* Verify host stack and heap pointers work. */
-    for (int i = 0; i < host_stack.size; i++)
+    for (size_t i = 0; i < host_stack.size; i++)
         OE_TEST(stackbuf[i] == 1);
 
-    for (int i = 0; i < host_heap.size; i++)
+    for (size_t i = 0; i < host_heap.size; i++)
         OE_TEST(heapbuf[i] == 2);
 
     /* Send two pointers. One from malloc (enclave memory) and
@@ -76,7 +76,7 @@ void try_input_enclave_pointer(buffer enclave_memory)
     OE_TEST(oe_is_within_enclave(enclave_memory.buf, enclave_memory.size));
 
     /* Verify enclave memory is unchanged. */
-    for (int i = 0; i < enclave_memory.size; i++)
+    for (size_t i = 0; i < enclave_memory.size; i++)
         OE_TEST(enclave_memory.buf[i] == 3);
 }
 

--- a/tests/mixed_c_cpp/enc/enc.cpp
+++ b/tests/mixed_c_cpp/enc/enc.cpp
@@ -7,6 +7,7 @@
 
 void foo_cpp(int a)
 {
+    OE_UNUSED(a);
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/tests/mixed_c_cpp/enc/foo.c
+++ b/tests/mixed_c_cpp/enc/foo.c
@@ -11,4 +11,5 @@
 
 void foo_c(int a)
 {
+    OE_UNUSED(a);
 }

--- a/tests/ocall/enc/enc.cpp
+++ b/tests/ocall/enc/enc.cpp
@@ -23,6 +23,7 @@ OE_ECALL void Test2(void* args_)
 OE_ECALL void Test4(void* args)
 {
     unsigned char buf[32];
+    OE_UNUSED(args);
 
     /* Call into host with enclave memory */
     oe_memset(buf, 0xAA, sizeof(buf));
@@ -128,6 +129,7 @@ OE_ECALL void TestMyOCall(void* args_)
 OE_ECALL void TestOCallEdgeCases(void* args_)
 {
     oe_result_t result;
+    OE_UNUSED(args_);
 
     /* Null OCALL. */
     result = oe_call_host(NULL, NULL);
@@ -161,6 +163,7 @@ OE_ECALL void test_callback(void* arg)
 OE_ECALL void TestReentrancy(void* args)
 {
     oe_result_t result;
+    OE_UNUSED(args);
 
     result = oe_call_host("TestReentrancy", NULL);
     OE_TEST(result == OE_OK);

--- a/tests/ocall/host/host.cpp
+++ b/tests/ocall/host/host.cpp
@@ -14,6 +14,7 @@ static bool _func1_called = false;
 
 OE_OCALL void Func1(void* args)
 {
+    OE_UNUSED(args);
     _func1_called = true;
 }
 
@@ -29,7 +30,7 @@ static bool _func2_ok = false;
 
 OE_OCALL void Func2(void* args)
 {
-    // unsigned char* buf = (unsigned char*)args;
+    OE_UNUSED(args);
     _func2_ok = true;
 }
 
@@ -37,6 +38,7 @@ static bool _func_a_called = false;
 
 OE_OCALL void A(void* args)
 {
+    OE_UNUSED(args);
     _func_a_called = true;
 }
 
@@ -44,6 +46,7 @@ OE_OCALL void A(void* args)
 OE_OCALL void callback(void* arg, oe_enclave_t* enclave)
 {
     test_callback_args_t* args = (test_callback_args_t*)arg;
+    OE_UNUSED(enclave);
 
     if (args)
         args->out = args->in;

--- a/tests/oeedger8r/edltestutils.h
+++ b/tests/oeedger8r/edltestutils.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <openenclave/bits/defs.h>
 #include <stdint.h>
 #include <wchar.h>
 #include <limits>
@@ -27,6 +28,7 @@ struct unused
 {
     unused(int i = 0)
     {
+        OE_UNUSED(i);
     }
 };
 
@@ -39,6 +41,7 @@ struct unused
     template <typename S>                                        \
     void assert_no_field_##fname(unused<sizeof(S::fname)> u = 0) \
     {                                                            \
+        OE_UNUSED(u);                                            \
     }                                                            \
     template <typename S>                                        \
     void assert_no_field_##fname()                               \

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -39,6 +39,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
         ${all_t}
         PROPERTIES COMPILE_FLAGS "-Wno-conversion"
     )
+    set_source_files_properties(
+        testpointer.cpp
+        teststring.cpp
+        PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter"
+    )      
 endif()
 
 target_include_directories(edl_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -39,6 +39,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
         ${all_u}
         PROPERTIES COMPILE_FLAGS "-Wno-conversion"
     )
+    set_source_files_properties(
+        testpointer.cpp
+        teststring.cpp
+        PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter"
+    )    
 endif()
 
 target_include_directories(edl_host PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/tests/qeidentity/enc/enc.cpp
+++ b/tests/qeidentity/enc/enc.cpp
@@ -20,6 +20,8 @@ oe_result_t test_verify_qe_identity_info(
     return oe_parse_qe_identity_info_json(
         (const uint8_t*)info_json, strlen(info_json) + 1, parsed_info);
 #else
+    OE_UNUSED(info_json);
+    OE_UNUSED(parsed_info);
     return OE_OK;
 #endif
 }

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -450,6 +450,7 @@ TEST_FCN void TestRemoteReport(void* args_)
         report_data[i] = static_cast<uint8_t>(i);
     const uint8_t zeros[OE_REPORT_DATA_SIZE] = {0};
 #endif
+    OE_UNUSED(args_);
 
     uint8_t report_buffer[OE_MAX_REPORT_SIZE];
     size_t report_size = sizeof(report_buffer);
@@ -597,6 +598,8 @@ TEST_FCN void TestRemoteReport(void* args_)
 
 TEST_FCN void TestParseReportNegative(void* args_)
 {
+    OE_UNUSED(args_);
+
     uint8_t report_buffer[OE_MAX_REPORT_SIZE] = {0};
     oe_report_t parsed_report = {0};
 
@@ -685,6 +688,8 @@ static void GetSGXTargetInfo(sgx_target_info_t* sgx_target_info)
 
 TEST_FCN void TestLocalVerifyReport(void* args_)
 {
+    OE_UNUSED(args_);
+
     uint8_t target_info[sizeof(sgx_target_info_t)];
     size_t target_info_size = sizeof(target_info);
 
@@ -748,6 +753,8 @@ TEST_FCN void TestLocalVerifyReport(void* args_)
 
 TEST_FCN void TestRemoteVerifyReport(void* args_)
 {
+    OE_UNUSED(args_);
+
     uint8_t report_buffer[OE_MAX_REPORT_SIZE] = {0};
     size_t report_size = sizeof(report_buffer);
 

--- a/tests/report/enc/enc.cpp
+++ b/tests/report/enc/enc.cpp
@@ -25,6 +25,9 @@ oe_result_t test_verify_tcb_info(
         platform_tcb_level,
         parsed_tcb_info);
 #else
+    OE_UNUSED(tcb_info);
+    OE_UNUSED(platform_tcb_level);
+    OE_UNUSED(parsed_tcb_info);
     return OE_OK;
 #endif
 }
@@ -73,6 +76,8 @@ void test_minimum_issue_date(oe_datetime_t now)
         OE_INVALID_REVOCATION_INFO);
 
     printf("test_minimum_issue_date passed.\n");
+#else
+    OE_UNUSED(now);
 #endif
 }
 

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -36,6 +36,8 @@ void generate_and_save_report(oe_enclave_t* enclave)
     FILE* file = fopen("./data/generated_report.bytes", "wb");
     fwrite(report, 1, report_size, file);
     fclose(file);
+#else
+    OE_UNUSED(enclave);
 #endif
 }
 

--- a/tests/safemath/main.cpp
+++ b/tests/safemath/main.cpp
@@ -817,7 +817,7 @@ void _test_signed()
     s64.Run();
 }
 
-int main(int argc, const char* argv[])
+int main()
 {
     /* For 8-bit math, we can quickly exhaust all combinations. */
     _test_8_bit();

--- a/tests/str/main.c
+++ b/tests/str/main.c
@@ -196,7 +196,7 @@ void TestStr(str_t* s)
     printf("=== passed TestStr()\n");
 }
 
-int main(int argc, const char* argv[])
+int main()
 {
     /* TestStr dynamic */
     {

--- a/tests/thread/oethread_enc/cond_tests.cpp
+++ b/tests/thread/oethread_enc/cond_tests.cpp
@@ -21,6 +21,8 @@ static volatile bool exit_thread = false;
 
 OE_ECALL void CBTestWaiterThreadImpl(void* args)
 {
+    OE_UNUSED(args);
+
     oe_mutex_lock(&mutex);
 
     while (!exit_thread)
@@ -42,6 +44,8 @@ OE_ECALL void CBTestWaiterThreadImpl(void* args)
 
 OE_ECALL void CBTestSignalThreadImpl(void* args)
 {
+    OE_UNUSED(args);
+
     // Iterate for enough number of times to
     // detect any sporadic behavior.
     // Note: The original issue that the accompanying fix

--- a/tests/thread/oethread_enc/enc.cpp
+++ b/tests/thread/oethread_enc/enc.cpp
@@ -128,6 +128,8 @@ static oe_cond_t exclusive = OE_COND_INITIALIZER;
 
 OE_ECALL void WaitForExclusiveAccess(void* args_)
 {
+    OE_UNUSED(args_);
+
     oe_mutex_lock(&ex_mutex);
 
     // Wait for other threads to finish
@@ -147,6 +149,8 @@ OE_ECALL void WaitForExclusiveAccess(void* args_)
 
 OE_ECALL void RelinquishExclusiveAccess(void* args_)
 {
+    OE_UNUSED(args_);
+
     oe_mutex_lock(&ex_mutex);
 
     // Mark thread as done

--- a/tests/threadcxx/enc/cond_tests.cpp
+++ b/tests/threadcxx/enc/cond_tests.cpp
@@ -24,6 +24,8 @@ static volatile bool exit_thread = false;
 
 OE_ECALL void CBTestWaiterThreadImplCxx(void* args)
 {
+    OE_UNUSED(args);
+
     std::unique_lock<std::mutex> lck(mutex);
 
     while (!exit_thread)
@@ -43,6 +45,8 @@ OE_ECALL void CBTestWaiterThreadImplCxx(void* args)
 
 OE_ECALL void CBTestSignalThreadImplCxx(void* args)
 {
+    OE_UNUSED(args);
+
     // Iterate for enough number of times to
     // detect any sporadic behavior.
     // Note: The original issue that the accompanying fix

--- a/tests/threadcxx/enc/enc.cpp
+++ b/tests/threadcxx/enc/enc.cpp
@@ -158,6 +158,8 @@ static std::condition_variable exclusive;
 
 OE_ECALL void WaitForExclusiveAccessCxx(void* args_)
 {
+    OE_UNUSED(args_);
+
     std::stringstream ss;
     std::unique_lock<std::mutex> lock(ex_mutex);
 
@@ -177,6 +179,8 @@ OE_ECALL void WaitForExclusiveAccessCxx(void* args_)
 
 OE_ECALL void RelinquishExclusiveAccessCxx(void* args_)
 {
+    OE_UNUSED(args_);
+
     std::stringstream ss;
 
     std::lock_guard<std::mutex> lg_lock(ex_mutex);

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -734,7 +734,8 @@ let oe_gen_ocall_host_wrapper (os:out_channel) (fd:Ast.func_decl) =
   fprintf os "        size_t* output_bytes_written)\n";
   (* Variable declarations *)
   fprintf os "{\n";
-  fprintf os "    oe_result_t _result = OE_FAILURE;\n\n";
+  fprintf os "    oe_result_t _result = OE_FAILURE;\n";
+  fprintf os "    OE_UNUSED(input_buffer_size);\n\n";
   fprintf os "    /* Prepare parameters */\n";
   fprintf os "    %s_args_t* pargs_in = (%s_args_t*) input_buffer;\n" fd.Ast.fname fd.Ast.fname;
   fprintf os "    %s_args_t* pargs_out = (%s_args_t*) output_buffer;\n\n" fd.Ast.fname fd.Ast.fname;
@@ -906,7 +907,10 @@ let gen_t_c (ec: enclave_content) (ep: edger8r_params) =
   if ec.ufunc_decls <> [] then (
     fprintf os "\n/* ocall wrappers */\n\n";
     List.iter (fun d -> oe_gen_ocall_enclave_wrapper os d.Ast.uf_fdecl)  ec.ufunc_decls);
-  fprintf os "\nOE_ECALL void _dummy_old_style_ecall_to_keep_loader_happy(void* arg){}\n\n";
+  fprintf os "\nOE_ECALL void _dummy_old_style_ecall_to_keep_loader_happy(void* arg)\n";
+  fprintf os "{\n";
+  fprintf os "    OE_UNUSED(arg);\n";
+  fprintf os "}\n\n";
   fprintf os "OE_EXTERNC_END\n";
   close_out os 
 

--- a/tools/oesign/main.c
+++ b/tools/oesign/main.c
@@ -418,6 +418,7 @@ void _merge_config_file_options(
     const ConfigFileOptions* options)
 {
     bool initialized = false;
+    OE_UNUSED(path);
 
     /* Determine whether the properties are already initialized */
     if (properties->header.size == sizeof(oe_sgx_enclave_properties_t))


### PR DESCRIPTION
This option enables some extra warning flags that are not
enabled by -Wall. Missing field initializers warning is disabled
since we use {0} syntax to initialize structs.