### PR TITLE
Support for exported thread-locals.

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -95,6 +95,8 @@ const char* oe_result_str(oe_result_t result)
             return "OE_INVALID_UTC_DATE_TIME";
         case OE_INVALID_QE_IDENTITY_INFO:
             return "OE_INVALID_QE_IDENTITY_INFO";
+        case OE_UNSUPPORTED_ENCLAVE_IMAGE:
+            return "OE_UNSUPPORTED_ENCLAVE_IMAGE";
         case __OE_RESULT_MAX:
             break;
     }

--- a/enclave/core/linux/reloc.c
+++ b/enclave/core/linux/reloc.c
@@ -2,16 +2,9 @@
 // Licensed under the MIT License.
 
 #include <openenclave/enclave.h>
+#include <openenclave/internal/elf.h>
 #include <openenclave/internal/globals.h>
 #include "../init.h"
-
-/* Same layout as elf64_rela_t (see elf.h) */
-typedef struct _oe_reloc
-{
-    uint64_t offset;
-    uint64_t info;
-    int64_t addend;
-} oe_reloc_t;
 
 /*
 **==============================================================================
@@ -27,25 +20,28 @@ typedef struct _oe_reloc
 
 bool oe_apply_relocations(void)
 {
-    const oe_reloc_t* relocs = (const oe_reloc_t*)__oe_get_reloc_base();
-    size_t nrelocs = __oe_get_reloc_size() / sizeof(oe_reloc_t);
+    const elf64_rela_t* relocs = (const elf64_rela_t*)__oe_get_reloc_base();
+    size_t nrelocs = __oe_get_reloc_size() / sizeof(elf64_rela_t);
     const uint8_t* baseaddr = (const uint8_t*)__oe_get_enclave_base();
 
     for (size_t i = 0; i < nrelocs; i++)
     {
-        const oe_reloc_t* p = &relocs[i];
+        const elf64_rela_t* p = &relocs[i];
 
         /* If zero-padded bytes reached */
-        if (p->offset == 0)
+        if (p->r_offset == 0)
             break;
 
         /* Compute address of reference to be relocated */
-        uint64_t* dest = (uint64_t*)(baseaddr + p->offset);
+        uint64_t* dest = (uint64_t*)(baseaddr + p->r_offset);
 
-        (void)dest;
+        uint64_t reloc_type = ELF64_R_TYPE(p->r_info);
 
         /* Relocate the reference */
-        *dest = (uint64_t)(baseaddr + p->addend);
+        if (reloc_type == R_X86_64_RELATIVE)
+        {
+            *dest = (uint64_t)(baseaddr + p->r_addend);
+        }
     }
 
     return true;

--- a/enclave/core/linux/threadlocal.c
+++ b/enclave/core/linux/threadlocal.c
@@ -4,6 +4,7 @@
 #include "threadlocal.h"
 #include <openenclave/bits/safecrt.h>
 #include <openenclave/enclave.h>
+#include <openenclave/internal/elf.h>
 #include <openenclave/internal/enclavelibc.h>
 #include <openenclave/internal/globals.h>
 #include <openenclave/internal/raise.h>
@@ -124,7 +125,70 @@
  * calls to __tls_get_addr and to reduce thread-local variable access to simple
  * FS register offsets. To handle dynamically loaded modules we need to
  * implement __tls_get_addr.
- * For complete reference see: Elf Handling for Thread-Local Storage
+ * For complete reference see: Elf Handling for Thread-Local Storage.
+ *
+ * The thread-locals described above follow the "Local-Exec" tls model.
+ * They produce the most efficient opcodes for accessing thread-local variables.
+ *
+ * The thread-locals described below follow the "Initial-Exec" tls model.
+ * They are also very efficient, but require and extra memory dereference
+ * compared to the "Local-Exec" model.
+ *
+ * The other two models - "Local-Dynamic" and "Global-Dynamic" are currently
+ * not supported since they are more applicable to a multi-module enclaves
+ * scenario (i.e many shared libraries loaded into a single enclave.).
+ * Using those tls-model, via a combination of compiler and linker flags,
+ * would result in a link error since the __tls_get_addr function is not
+ * defined.
+ *
+ * ****************************************************************************
+ * Exported thread-locals and shared-libraries:
+ *
+ * When thread-local variables are exported (via visibility=default), then the
+ * linker does not optimize the access of a thread-local variable to a constant
+ * offset from the FS register. Instead, for each thread-local variable,
+ * another variable is introduced varname@tpoff that contains the offset for
+ * the thread local variable. The offset value for varname@tpoff is expected to
+ * be filled up by the dynamic linker/loader.
+ * Consider,
+ *         __attribute__((visibility=default)) __thread int x;
+ *         int foo() { return x; }
+ *
+ * This results in the following code to access x
+ *     foo:
+ *         ...
+ *         mov %FS:0, %rax            // Fetch the address of the FS segment
+ *         add x@tpoff(%rip), %rax    // Fetch offset for x from the
+ *                                    // relocation entry x@tpoff and add it to
+ *                                    // FS
+ *         mov (%rax), rax            // Fetch value of x
+ *
+ * Each @tpoff variable results in a relocation entry of the type
+ * R_X86_64_TPOFF64. The relocation entry contains enough information to fill
+ * the value of the @tpoff variable.
+ * R_X86_64_TPOFF64 relocation info contains the following fields:
+ *
+ *    r_offset = relative address of the corresponding tpoff variable
+ *    r_info.relocation_type = R_X86_64_TPOFF64
+ *    r_info.symbol = index of symbol in the .dynsym section.
+ *    r_addend = 0
+ *
+ * The value (st_value) of the symbol in the .dynsym section contains the offset
+ * to the thread-local variable from the *start* of the thread-local section.
+ * Thus:
+ *    &x = tls-start + symbol sh_value.
+ *
+ * Since the compiler emits code relative to the end of the section (i.e using
+ * FS), the tpoff is computed via the formula:
+ *     tpoff = FS - (tls-start + sh-value).
+ *
+ * Thus, performing relocations for thread-local variables involves setting the
+ * value of the corresponding tpoff variables to the offset from the FS register
+ * value.
+ *
+ * To avoid looking up symbols within the enclave (symbols are not available)
+ * the loader fetches the symbol's sh-value and stores it in the r_addend field
+ * (r_added field is otherwise zero for R_X86_64_TPOFF64).
  */
 static volatile uint64_t _tdata_rva = 0;
 static volatile uint64_t _tdata_size = 0;
@@ -132,6 +196,9 @@ static volatile uint64_t _tdata_align = 1;
 
 static volatile uint64_t _tbss_size = 0;
 static volatile uint64_t _tbss_align = 1;
+
+// Number of thread-local relocations.
+static volatile bool _thread_locals_relocated = false;
 
 /**
  * Get the address of the FS segment given a thread data object.
@@ -227,6 +294,39 @@ oe_result_t oe_thread_local_init(td_t* td)
 
         // Copy the template
         oe_memcpy_s(tls_start, _tdata_size, tdata, _tdata_size);
+
+        // Perform thread-local relocations.
+        if (!_thread_locals_relocated)
+        {
+            // Note: For an enclave, thread-local relocations always set the
+            // value of the tpoff variables to a computed constant value. Hence
+            // this is inherently thread-safe and also can be called multiple
+            // times.
+            const elf64_rela_t* relocs =
+                (const elf64_rela_t*)__oe_get_reloc_base();
+            size_t nrelocs = __oe_get_reloc_size() / sizeof(elf64_rela_t);
+            const uint8_t* baseaddr = (const uint8_t*)__oe_get_enclave_base();
+
+            for (size_t i = 0; i < nrelocs; i++)
+            {
+                const elf64_rela_t* p = &relocs[i];
+
+                // If zero-padded bytes reached
+                if (p->r_offset == 0)
+                    break;
+
+                if (ELF64_R_TYPE(p->r_info) == R_X86_64_TPOFF64)
+                {
+                    // Compute address of tpoff variable
+                    int64_t* tpoff = (int64_t*)(baseaddr + p->r_offset);
+
+                    // Set tpoff to the offset value relative to FS
+                    *tpoff = (tls_start + p->r_addend - fs);
+                }
+            }
+
+            _thread_locals_relocated = true;
+        }
     }
 
     result = OE_OK;
@@ -274,10 +374,13 @@ oe_result_t oe_thread_local_cleanup(td_t* td)
         td->num_tls_atexit_functions = 0;
     }
 
-    /* Clear tls section */
+    /* Clear tls section if it exists */
     uint8_t* fs = _get_fs_from_td(td);
     uint8_t* tls_start = _get_thread_local_data_start(td);
-    oe_memset_s(tls_start, (uint64_t)(fs - tls_start), 0, 0);
+    if (tls_start)
+    {
+        oe_memset_s(tls_start, (uint64_t)(fs - tls_start), 0, 0);
+    }
 
     return OE_OK;
 }

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -258,6 +258,11 @@ typedef enum _oe_result {
      */
     OE_INVALID_QE_IDENTITY_INFO,
 
+    /**
+     * The enclave image contains unsupported constructs.
+     */
+    OE_UNSUPPORTED_ENCLAVE_IMAGE,
+
     __OE_RESULT_MAX = OE_ENUM_MAX,
 } oe_result_t;
 /**< typedef enum _oe_result oe_result_t*/

--- a/include/openenclave/internal/elf.h
+++ b/include/openenclave/internal/elf.h
@@ -6,9 +6,6 @@
 
 #include <openenclave/bits/result.h>
 #include <openenclave/bits/types.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 #ifdef __cplusplus
 #define ELF_EXTERNC_BEGIN extern "C" {
@@ -139,6 +136,10 @@ ELF_EXTERNC_BEGIN
 
 /* elf64_rel.r_info */
 #define R_X86_64_RELATIVE 8
+
+/* Supported thread-local storage relocations */
+#define R_X86_64_TPOFF64 18 /* Offset in initial TLS block */
+
 #define ELF64_R_SYM(i) ((i) >> 32)
 #define ELF64_R_TYPE(i) ((i)&0xffffffffL)
 #define ELF64_R_INFO(s, t) (((s) << 32) + ((t)&0xffffffffL))
@@ -242,7 +243,10 @@ int elf64_load(const char* path, elf64_t* elf);
 
 int elf64_unload(elf64_t* elf);
 
-const void* elf64_get_symbol_table_section(const elf64_t* elf);
+int elf64_get_dynamic_symbol_table(
+    const elf64_t* elf,
+    const elf64_sym_t** symtab,
+    size_t* size);
 
 void elf64_dump_header(const elf64_ehdr_t* ehdr);
 

--- a/tests/thread_local/CMakeLists.txt
+++ b/tests/thread_local/CMakeLists.txt
@@ -7,8 +7,17 @@ if (UNIX)
 	add_subdirectory(enc)
 endif()
 
+# Test enclaves without exported thread-locals.
 add_enclave_test(tests/thread_local 
      thread_local_host 
      thread_local_enc)
 
 set_tests_properties(tests/thread_local PROPERTIES SKIP_RETURN_CODE 2)
+
+# Test enclaves with exported thread-locals.
+add_enclave_test(tests/thread_local_exported
+    thread_local_host 
+	thread_local_enc_exported
+	--exported-thread-locals)
+
+set_tests_properties(tests/thread_local_exported PROPERTIES SKIP_RETURN_CODE 2)	

--- a/tests/thread_local/README.md
+++ b/tests/thread_local/README.md
@@ -10,6 +10,7 @@ The following constructs are tested:
 5. Types with destructors
 6. extern thread_local variables with complex initializers.
 7. Reinitialization of tls via thread recreation.
+8. Test exported and non-exported thread-locals. These have different implementations.
 
 Disabled in simulation mode since simulation mode needs
 completely different implementation of tls variables.

--- a/tests/thread_local/enc/CMakeLists.txt
+++ b/tests/thread_local/enc/CMakeLists.txt
@@ -6,7 +6,16 @@ include(add_enclave_executable)
 
 oeedl_file(../thread_local.edl enclave gen)
 
+# Build enclave without exported thread-locals.
 add_executable(thread_local_enc enc.cpp externs.cpp ${gen})
 
 target_include_directories(thread_local_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(thread_local_enc oelibcxx oeenclave)
+
+# Build enclave with exported thread-locals.
+add_executable(thread_local_enc_exported enc.cpp externs.cpp ${gen})
+
+target_compile_definitions(thread_local_enc_exported PRIVATE -DEXPORT_THREAD_LOCALS=1)
+
+target_include_directories(thread_local_enc_exported PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(thread_local_enc_exported oelibcxx oeenclave)

--- a/tests/thread_local/enc/enc.cpp
+++ b/tests/thread_local/enc/enc.cpp
@@ -11,10 +11,11 @@
 #include <thread>
 
 #include "thread_local_t.h"
+#include "visibility.h"
 
 // These variables will be put in .tdata
-__thread volatile int __thread_int = 1;
-__thread volatile int g_x[10] = {8};
+VISIBILITY_SPEC __thread volatile int __thread_int = 1;
+VISIBILITY_SPEC __thread volatile int g_x[10] = {8};
 
 struct thread_local_struct
 {
@@ -35,13 +36,15 @@ struct thread_local_struct
 
 // These variables will be put in .tbss
 // Dynamic thread specific destructors for g_s and dist.
-extern thread_local std::random_device g_rd;
-extern thread_local std::mt19937 g_mt;
-extern thread_local std::uniform_real_distribution<double> g_dist;
-thread_local volatile thread_local_struct g_s(static_cast<int>(g_dist(g_mt)));
+VISIBILITY_SPEC extern thread_local std::random_device g_rd;
+VISIBILITY_SPEC extern thread_local std::mt19937 g_mt;
+VISIBILITY_SPEC extern thread_local std::uniform_real_distribution<double>
+    g_dist;
+VISIBILITY_SPEC thread_local volatile thread_local_struct g_s(
+    static_cast<int>(g_dist(g_mt)));
 
 // This variable will be put in .tdata
-thread_local int thread_local_int = 5;
+VISIBILITY_SPEC thread_local int thread_local_int = 5;
 
 // Helper function for debugging.
 // Gets the value of the FS segment.
@@ -142,6 +145,6 @@ OE_SET_ENCLAVE_SGX(
     0,    /* ProductID */
     0,    /* SecurityVersion */
     true, /* AllowDebug */
-    128,  /* HeapPageCount */
-    128,  /* StackPageCount */
-    2);   /* TCSCount */
+    64,   /* HeapPageCount */
+    16,   /* StackPageCount */
+    16);  /* TCSCount */

--- a/tests/thread_local/enc/externs.cpp
+++ b/tests/thread_local/enc/externs.cpp
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 #include <random>
+#include "visibility.h"
 
-thread_local std::random_device g_rd;
-thread_local std::mt19937 g_mt(g_rd());
-thread_local std::uniform_real_distribution<double> g_dist(1, 100);
+VISIBILITY_SPEC thread_local std::random_device g_rd;
+VISIBILITY_SPEC thread_local std::mt19937 g_mt(g_rd());
+VISIBILITY_SPEC thread_local std::uniform_real_distribution<double> g_dist(
+    1,
+    100);
 
 // The following behavior has been observed about this enclave:
 // In release mode, both .tdata and .tbss have the same alignment (2**4).

--- a/tests/thread_local/enc/visibility.h
+++ b/tests/thread_local/enc/visibility.h
@@ -1,0 +1,14 @@
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef _VISIBILITY_SPEC_H
+#define _VISIBILITY_SPEC_H
+
+#ifdef EXPORT_THREAD_LOCALS
+#define VISIBILITY_SPEC __attribute__((visibility("default")))
+#else
+#define VISIBILITY_SPEC __attribute__((visibility("hidden")))
+#endif
+
+#endif // _VISIBILITY_SPEC_H


### PR DESCRIPTION
1. Exported thread-locals require handling ELF_X86_64_TPOFF
relocations.

2. Raise error on unsupported relocations.

Implements: #1224 