### PR TITLE
Fix _set_thread_binding in non TLS code-path.

### DIFF
--- a/host/calls.c
+++ b/host/calls.c
@@ -65,7 +65,7 @@ static void _set_thread_binding(ThreadBinding* binding)
     oe_once(&_thread_binding_once, _create_thread_binding_key);
     oe_thread_setspecific(_thread_binding_key, binding);
 #else
-    return (ThreadBinding*)oe_get_gs_register_base();
+    return oe_set_gs_register_base(binding);
 #endif
 }
 


### PR DESCRIPTION
Note: I am not sure why we need the USE_TLS_FOR_THREAD_BINDING
option in the firt place.
I have ran the tests to make sure that they pass in with and without
USE_TLS_FOR_THREAD_BINDING.
Fixes #1184