### PR TITLE
Thread-Local Storage in Simulation mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - oe-gdb allows attaching to a host that is already running
 - Added Quote Enclave Identity validation into oe_verify_report implementation
 - Added OE SDK internal logging mechanism
-- Support for thread local variables (both GNU __thread and C++11 thread_local)
+- Support for thread local variables 
+   - Both GNU __thread and C++11 thread_local
+   - Both hardware and simulation mode 
+   - Local-Exec and Initial-Exec thread-local storage models
 
 ### Changed
 

--- a/debugger/pythonExtension/gdb_sgx_plugin.py
+++ b/debugger/pythonExtension/gdb_sgx_plugin.py
@@ -19,7 +19,7 @@ OE_ENCLAVE_MAGIC_VALUE = 0x20dc98463a5ad8b8
 
 # The following are the offset of the 'debug' and
 # 'simulate' flag fields which must lie one after the other.
-OE_ENCLAVE_FLAGS_OFFSET = 0x598
+OE_ENCLAVE_FLAGS_OFFSET = 0x798
 OE_ENCLAVE_FLAGS_LENGTH = 2
 OE_ENCLAVE_FLAGS_FORMAT = 'BB'
 OE_ENCLAVE_THREAD_BINDING_OFFSET = 0x28

--- a/host/enclave.h
+++ b/host/enclave.h
@@ -77,6 +77,10 @@ typedef struct _thread_binding
 
     /* Event signaling object for enclave threading implementation */
     EnclaveEvent event;
+
+    /* The host GS and FS values saved before making an ecall */
+    void* host_gs;
+    void* host_fs;
 } ThreadBinding;
 
 OE_STATIC_ASSERT(OE_OFFSETOF(ThreadBinding, tcs) == ThreadBinding_tcs);
@@ -145,7 +149,7 @@ OE_STATIC_ASSERT(OE_OFFSETOF(oe_enclave_t, addr) == 2 * sizeof(void*));
 // The fields up to binding correspond to 'ENCLAVE_HEADER'
 OE_STATIC_ASSERT(OE_OFFSETOF(oe_enclave_t, bindings) == 0x28);
 
-OE_STATIC_ASSERT(OE_OFFSETOF(oe_enclave_t, debug) == 0x598);
+OE_STATIC_ASSERT(OE_OFFSETOF(oe_enclave_t, debug) == 0x798);
 OE_STATIC_ASSERT(
     OE_OFFSETOF(oe_enclave_t, debug) + 1 ==
     OE_OFFSETOF(oe_enclave_t, simulate));

--- a/host/registers.c
+++ b/host/registers.c
@@ -33,3 +33,23 @@ void* oe_get_gs_register_base()
     return (void*)_readgsbase_u64();
 #endif
 }
+
+void oe_set_fs_register_base(const void* ptr)
+{
+#if defined(__linux__)
+    syscall(__NR_arch_prctl, ARCH_SET_FS, ptr);
+#elif defined(_WIN32)
+    _writefsbase_u64((uint64_t)ptr);
+#endif
+}
+
+void* oe_get_fs_register_base()
+{
+#if defined(__linux__)
+    void* ptr = NULL;
+    syscall(__NR_arch_prctl, ARCH_GET_FS, &ptr);
+    return ptr;
+#elif defined(_WIN32)
+    return (void*)_readfsbase_u64();
+#endif
+}

--- a/include/openenclave/internal/registers.h
+++ b/include/openenclave/internal/registers.h
@@ -13,6 +13,10 @@ void oe_set_gs_register_base(const void* ptr);
 
 void* oe_get_gs_register_base(void);
 
+void oe_set_fs_register_base(const void* ptr);
+
+void* oe_get_fs_register_base(void);
+
 OE_EXTERNC_END
 
 #endif /* _OE_ASM_H */

--- a/tests/thread_local/CMakeLists.txt
+++ b/tests/thread_local/CMakeLists.txt
@@ -12,12 +12,8 @@ add_enclave_test(tests/thread_local
      thread_local_host 
      thread_local_enc)
 
-set_tests_properties(tests/thread_local PROPERTIES SKIP_RETURN_CODE 2)
-
 # Test enclaves with exported thread-locals.
 add_enclave_test(tests/thread_local_exported
     thread_local_host 
 	thread_local_enc_exported
 	--exported-thread-locals)
-
-set_tests_properties(tests/thread_local_exported PROPERTIES SKIP_RETURN_CODE 2)	

--- a/tests/thread_local/host/host.cpp
+++ b/tests/thread_local/host/host.cpp
@@ -12,8 +12,6 @@
 #include <thread>
 #include "thread_local_u.h"
 
-#define SKIP_RETURN_CODE 2
-
 void run_enclave_thread(
     oe_enclave_t* enclave,
     int thread_num,
@@ -65,14 +63,6 @@ int main(int argc, const char* argv[])
     }
 
     const uint32_t flags = oe_get_create_flags();
-    if ((flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
-    {
-        printf(
-            "=== Skipped unsupported test in simulation mode "
-            "(thread-local)\n");
-        return SKIP_RETURN_CODE;
-    }
-
     if ((result = oe_create_thread_local_enclave(
              argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave)) != OE_OK)
         oe_put_err("oe_create_enclave(): result=%u", result);


### PR DESCRIPTION
In simulation mode, carefully set the GS and FS
registers upon entry/exit from an enclave.
These registers are set in SGX mode by EENTER and EEXIT
instructions, but in simulation mode, the host has
to do it carefully.
The FS register is key for libc, pthreads etc to work.
And therefore, FS register must be restored as early
as possible upon re-entry to the host.

Also fixed a bug where if an OCALL made an ECALL to
*another* enclave, the thread-binding was not being
restored correctly.