### PR TITLE
Added docker registry to be explicitly defined in Jenkinsfile.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -26,9 +26,11 @@ def simulationTest(String compiler, String unit, String suite ) {
             cleanWs()
             checkout scm
 
-            docker.image(OETOOLS_IMAGE).inside {
-                timeout(15) {
-                    sh "./scripts/test-build-config -p $unit -b $suite --compiler=$compiler"
+            docker.withRegistry('https://oejenkinscidockerregistry.azurecr.io', 'oejenkinscidockerregistry') {
+                docker.image(OETOOLS_IMAGE).inside {
+                    timeout(15) {
+                        sh "./scripts/test-build-config -p $unit -b $suite --compiler=$compiler"
+                    }
                 }
             }
         }
@@ -41,9 +43,11 @@ def nonSimulationTest() {
             cleanWs()
             checkout scm
 
-            docker.image(OETOOLS_IMAGE).inside('--privileged -v /dev/sgx:/dev/sgx') {
-                timeout(15) {
-                    sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d'
+            docker.withRegistry('https://oejenkinscidockerregistry.azurecr.io', 'oejenkinscidockerregistry') {
+                docker.image(OETOOLS_IMAGE).inside('--privileged -v /dev/sgx:/dev/sgx') {
+                    timeout(15) {
+                        sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d'
+                    }
                 }
             }
         }
@@ -56,9 +60,11 @@ def checkPreCommitRequirements() {
             cleanWs()
             checkout scm
 
-            docker.image(OETOOLS_IMAGE).inside {
-                timeout(2) {
-                    sh './scripts/check-precommit-reqs'
+            docker.withRegistry('https://oejenkinscidockerregistry.azurecr.io', 'oejenkinscidockerregistry') {
+                docker.image(OETOOLS_IMAGE).inside {
+                    timeout(2) {
+                        sh './scripts/check-precommit-reqs'
+                    }
                 }
             }
         }
@@ -103,10 +109,12 @@ def windowsDebugCrossPlatform() {
         node {
             cleanWs()
             checkout scm
-            docker.image(OETOOLS_IMAGE).inside {
-                timeout(15) {
-                    sh './scripts/test-build-config -p SGX1FLC -b Debug --compiler=clang-7'
-                    stash includes: 'build/tests/**', name: 'linuxdebug'
+            docker.withRegistry('https://oejenkinscidockerregistry.azurecr.io', 'oejenkinscidockerregistry') {
+                docker.image(OETOOLS_IMAGE).inside {
+                    timeout(15) {
+                        sh './scripts/test-build-config -p SGX1FLC -b Debug --compiler=clang-7'
+                        stash includes: 'build/tests/**', name: 'linuxdebug'
+                    }
                 }
             }
         }
@@ -127,10 +135,12 @@ def windowsReleaseCrossPlatform() {
         node {
             cleanWs()
             checkout scm
-            docker.image(OETOOLS_IMAGE).inside {
-                timeout(15) {
-                    sh './scripts/test-build-config -p SGX1FLC -b Release --compiler=clang-7'
-                    stash includes: 'build/tests/**', name: 'linuxrelease'
+            docker.withRegistry('https://oejenkinscidockerregistry.azurecr.io', 'oejenkinscidockerregistry') {
+                docker.image(OETOOLS_IMAGE).inside {
+                    timeout(15) {
+                        sh './scripts/test-build-config -p SGX1FLC -b Release --compiler=clang-7'
+                        stash includes: 'build/tests/**', name: 'linuxrelease'
+                    }
                 }
             }
         }


### PR DESCRIPTION
This ensures that new systems are provided the proper credentials to the docker repository when stages begin. The change to using a scripted Jenkinsfile somehow doesn't allow the Jenkins master node to propagate Docker registry credentials down to agents. This change will ensure that the credentials are passed down.