### PR TITLE
Build enclaves on Windows using clang cross compilation (phase 1)

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -51,6 +51,11 @@ add_dependencies(libcxx libcxx_includes)
 set_target_properties(libcxx PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
 
+# Configure clangw before turning off warnings.
+if (USE_CLANGW)
+  build_using_clangw(libcxx)
+endif()
+
 target_compile_options(libcxx PRIVATE -Wno-error)
 
 target_compile_definitions(libcxx
@@ -74,4 +79,3 @@ install(TARGETS libcxx EXPORT openenclave-targets)
 
 install(DIRECTORY ${LIBCXX_INCLUDES}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty)
-

--- a/3rdparty/libcxxrt/CMakeLists.txt
+++ b/3rdparty/libcxxrt/CMakeLists.txt
@@ -18,6 +18,11 @@ add_library(libcxxrt OBJECT
 set_target_properties(libcxxrt PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
 
+# Configure clangw before turning off warnings.
+if (USE_CLANGW)
+  build_using_clangw(libcxxrt)
+endif()
+
 target_compile_options(libcxxrt PRIVATE -Wno-error)
 
 target_compile_definitions(libcxxrt PRIVATE -D_GNU_SOURCE)

--- a/3rdparty/libunwind/CMakeLists.txt
+++ b/3rdparty/libunwind/CMakeLists.txt
@@ -16,9 +16,7 @@ add_custom_command(
   # TODO: We are doing this ugly workaround since we don't support
   # thread local storage (__thread). Once the PR for Thread Local
   # Storage goes in (#1157), we can remove this.
-  COMMAND grep -v "^static __thread"
-    ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/src/x86_64/Gtrace.c >
-    ${CMAKE_CURRENT_BINARY_DIR}/Gtrace.inc
+  COMMAND bash -c "grep -v '^static __thread' ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/src/x86_64/Gtrace.c > ${CMAKE_CURRENT_BINARY_DIR}/Gtrace.inc"
   COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_SOURCE_DIR}/Gtrace.c
     ${CMAKE_CURRENT_BINARY_DIR}/Gtrace.c
@@ -109,6 +107,11 @@ add_library(libunwind OBJECT
   ${CMAKE_CURRENT_BINARY_DIR}/libunwind.h)
 
 set_target_properties(libunwind PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Configure clangw before turning off warnings.
+if (USE_CLANGW)
+  build_using_clangw(libcxx)
+endif()
 
 set_source_files_properties(Gstep.c PROPERTIES COMPILE_FLAGS "-Werror")
 set_source_files_properties(Gtrace.c PROPERTIES COMPILE_FLAGS "-Werror")

--- a/3rdparty/libunwind/CMakeLists.txt
+++ b/3rdparty/libunwind/CMakeLists.txt
@@ -16,7 +16,7 @@ add_custom_command(
   # TODO: We are doing this ugly workaround since we don't support
   # thread local storage (__thread). Once the PR for Thread Local
   # Storage goes in (#1157), we can remove this.
-  COMMAND bash -c "grep -v '^static __thread' ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/src/x86_64/Gtrace.c > ${CMAKE_CURRENT_BINARY_DIR}/Gtrace.inc"
+  COMMAND bash -c \"grep -v '^static __thread' ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/src/x86_64/Gtrace.c > ${CMAKE_CURRENT_BINARY_DIR}/Gtrace.inc\"
   COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_SOURCE_DIR}/Gtrace.c
     ${CMAKE_CURRENT_BINARY_DIR}/Gtrace.c

--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -3,6 +3,21 @@
 
 set(MBEDTLS_WRAP_CFLAGS "-nostdinc -I${OE_INCDIR}/openenclave/libc -fPIC -fno-builtin-udivti3 ${SPECTRE_MITIGATION_FLAGS}")
 
+if (USE_CLANGW)
+  set(MBEDTLS_WRAP_CFLAGS "-target x86_64-pc-linux ${MBEDTLS_WRAP_CFLAGS}")
+  # Setup clang wrapper toolchain
+  set(MBEDTLS_TOOLCHAIN "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/toolchain-clangw.cmake")
+
+  # Setup linker
+  find_program(LLVM_AR "llvm-ar.exe")
+  set(MBEDTLS_LINKER "-DCMAKE_AR=${LLVM_AR}")
+  set(MBEDTLS_COMPILER "")
+else()
+  set(MBEDTLS_TOOLCHAIN "")
+  set(MBEDTLS_LINKER "")
+  set(MBEDTLS_COMPILER "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}")
+endif()
+
 # Create a patched version of mbed TLS's `config.h` that the external
 # project depends on.
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
@@ -24,7 +39,9 @@ ExternalProject_Add(mbedtls-wrap
     ${CMAKE_CURRENT_BINARY_DIR}/config.h <SOURCE_DIR>/include/mbedtls/config.h
 
   CMAKE_ARGS
-    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    ${MBEDTLS_TOOLCHAIN}
+    ${MBEDTLS_LINKER}
+    ${MBEDTLS_COMPILER}
     -DCMAKE_C_FLAGS=${MBEDTLS_WRAP_CFLAGS}
     -DENABLE_PROGRAMS=OFF
     -DENABLE_TESTING=OFF

--- a/3rdparty/mbedtls/toolchain-clangw.cmake
+++ b/3rdparty/mbedtls/toolchain-clangw.cmake
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Toolchain file used for cross-compiling using clang.
+SET(CMAKE_SYSTEM_NAME Linux)
+
+include(CMakeForceCompiler)
+
+CMAKE_FORCE_C_COMPILER(clang Clang)
+CMAKE_FORCE_CXX_COMPILER(clang Clang)

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -7,6 +7,10 @@
 set(MUSL_CFLAGS "-fPIC -DSYSCALL_NO_INLINE")
 set(MUSL_CC ${CMAKE_C_COMPILER})
 set(MUSL_CXX ${CMAKE_CXX_COMPILER})
+set(PATCHES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patches)
+set(MUSL_DIR ${CMAKE_CURRENT_BINARY_DIR}/musl)
+set(MUSL_INCLUDES ${OE_INCDIR}/openenclave/libc)
+
 set(MUSL_APPEND_DEPRECATIONS
   "${CMAKE_CURRENT_LIST_DIR}/append-deprecations ${MUSL_INCLUDES}")
 if (USE_CLANGW)
@@ -15,9 +19,6 @@ if (USE_CLANGW)
   set(MUSL_CXX clang++)
   set(MUSL_APPEND_DEPRECATIONS "")
 endif ()
-set(PATCHES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patches)
-set(MUSL_DIR ${CMAKE_CURRENT_BINARY_DIR}/musl)
-set(MUSL_INCLUDES ${OE_INCDIR}/openenclave/libc)
 
 include (ExternalProject)
 ExternalProject_Add(musl_includes
@@ -67,7 +68,7 @@ ExternalProject_Add(musl_includes
       ${PATCHES_DIR}/endian.h
       ${MUSL_INCLUDES}/endian.h
     # Append deprecations.h to all C header files.
-    COMMAND ${MUSL_APPEND_DEPRECATIONS}
+    COMMAND bash -c "${MUSL_APPEND_DEPRECATIONS}"
     # Copy local deprecations.h to include/bits/deprecated.h.
     COMMAND ${CMAKE_COMMAND} -E copy
       ${CMAKE_CURRENT_LIST_DIR}/deprecations.h

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -4,7 +4,17 @@
 # Copy MUSL headers to collector dir and wrap
 # actual compilation and lib-generation happens in <ROOT>/libc/
 
-set(CFLAGS "-fPIC -DSYSCALL_NO_INLINE")
+set(MUSL_CFLAGS "-fPIC -DSYSCALL_NO_INLINE")
+set(MUSL_CC ${CMAKE_C_COMPILER})
+set(MUSL_CXX ${CMAKE_CXX_COMPILER})
+set(MUSL_APPEND_DEPRECATIONS
+  "${CMAKE_CURRENT_LIST_DIR}/append-deprecations ${MUSL_INCLUDES}")
+if (USE_CLANGW)
+  set(MUSL_CFLAGS "-target x86_64-pc-linux ${MUSL_CFLAGS}")
+  set(MUSL_CC clang)
+  set(MUSL_CXX clang++)
+  set(MUSL_APPEND_DEPRECATIONS "")
+endif ()
 set(PATCHES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patches)
 set(MUSL_DIR ${CMAKE_CURRENT_BINARY_DIR}/musl)
 set(MUSL_INCLUDES ${OE_INCDIR}/openenclave/libc)
@@ -14,7 +24,7 @@ ExternalProject_Add(musl_includes
   DOWNLOAD_COMMAND
     ${CMAKE_COMMAND} -E copy_directory
     ${CMAKE_CURRENT_LIST_DIR}/musl
-    ${CMAKE_CURRENT_BINARY_DIR}/musl
+    ${MUSL_DIR}
   PATCH_COMMAND
     COMMAND ${CMAKE_COMMAND} -E copy
       ${MUSL_DIR}/arch/x86_64/syscall_arch.h
@@ -26,34 +36,44 @@ ExternalProject_Add(musl_includes
       ${PATCHES_DIR}/pthread_arch.h
       ${MUSL_DIR}/arch/x86_64/pthread_arch.h
   CONFIGURE_COMMAND
-    ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
-    ./configure
+    ${CMAKE_COMMAND} -E chdir ${MUSL_DIR}
+    # TODO: Use `find_program` and ensure Bash is available.
+    bash -x ./configure
       --includedir=${MUSL_INCLUDES}
-      CFLAGS=${CFLAGS}
-      CC=${CMAKE_C_COMPILER}
-      CXX=${CMAKE_CXX_COMPILER}
+      CFLAGS=${MUSL_CFLAGS}
+      CC=${MUSL_CC}
+      CXX=${MUSL_CXX}
   BUILD_COMMAND
-    ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/musl
-    make install-headers
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${MUSL_DIR}/include
+        ${MUSL_INCLUDES}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${MUSL_DIR}/arch/generic/bits
+        ${MUSL_INCLUDES}/bits
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${MUSL_DIR}/arch/x86_64/bits
+        ${MUSL_INCLUDES}/bits
+    # base -c requires the command string to be in a single line
+    COMMAND bash -c "sed -f ${MUSL_DIR}/tools/mkalltypes.sed ${MUSL_DIR}/arch/x86_64/bits/alltypes.h.in ${MUSL_DIR}/include/alltypes.h.in > ${MUSL_INCLUDES}/bits/alltypes.h"
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${MUSL_DIR}/arch/x86_64/bits/syscall.h.in
+        ${MUSL_INCLUDES}/bits/syscall.h
+    # base -c requires the command string to be in a single line
+    COMMAND bash -c "sed -n -e s/__NR_/SYS_/p < ${MUSL_DIR}/arch/x86_64/bits/syscall.h.in >> ${MUSL_INCLUDES}/bits/syscall.h"
     COMMAND ${CMAKE_COMMAND} -E copy
       ${MUSL_INCLUDES}/endian.h
       ${MUSL_INCLUDES}/__endian.h
     COMMAND ${CMAKE_COMMAND} -E copy
       ${PATCHES_DIR}/endian.h
       ${MUSL_INCLUDES}/endian.h
-
     # Append deprecations.h to all C header files.
-    COMMAND ${CMAKE_CURRENT_LIST_DIR}/append-deprecations
-      ${MUSL_INCLUDES}
-
+    COMMAND ${MUSL_APPEND_DEPRECATIONS}
     # Copy local deprecations.h to include/bits/deprecated.h.
     COMMAND ${CMAKE_COMMAND} -E copy
       ${CMAKE_CURRENT_LIST_DIR}/deprecations.h
       ${MUSL_INCLUDES}/bits/deprecations.h
-
   BUILD_BYPRODUCTS
-    ${MUSL_INCLUDES} ${CMAKE_CURRENT_BINARY_DIR}/musl
-
+    ${MUSL_INCLUDES} ${MUSL_DIR}
   INSTALL_COMMAND "")
 
 add_library(oelibc_includes INTERFACE)

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -17,7 +17,7 @@ if (USE_CLANGW)
   set(MUSL_CFLAGS "-target x86_64-pc-linux ${MUSL_CFLAGS}")
   set(MUSL_CC clang)
   set(MUSL_CXX clang++)
-  set(MUSL_APPEND_DEPRECATIONS "")
+  set(MUSL_APPEND_DEPRECATIONS "echo 'Deprecations not applied on Windows'")
 endif ()
 
 include (ExternalProject)

--- a/3rdparty/musl/musl/src/stdio/pclose.c
+++ b/3rdparty/musl/musl/src/stdio/pclose.c
@@ -2,6 +2,10 @@
 #include <errno.h>
 #include <unistd.h>
 
+#ifdef _XOPEN_SOURCE
+hehe
+#endif
+
 int pclose(FILE *f)
 {
 	int status, r;

--- a/3rdparty/musl/musl/src/stdio/pclose.c
+++ b/3rdparty/musl/musl/src/stdio/pclose.c
@@ -2,10 +2,6 @@
 #include <errno.h>
 #include <unistd.h>
 
-#ifdef _XOPEN_SOURCE
-hehe
-#endif
-
 int pclose(FILE *f)
 {
 	int status, r;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,22 @@ if (NOT BUILD_NUMBER)
   set(BUILD_NUMBER "0")
 endif ()
 
+if (UNIX)
+  option(BUILD_ENCLAVES "Build Enclaves" ON)
+else()
+  # Building enclaves on windows is off by default
+  option(BUILD_ENCLAVES "Build ELF enclaves" OFF)
+endif()
+
+if (BUILD_ENCLAVES)
+  # Setup enclave building support on Windows.
+  if (WIN32)
+    add_subdirectory(windows/clangw)
+    include(build_using_clangw)
+    set(USE_CLANGW ON)
+  endif()
+endif()
+
 # See `cmake/compiler_settings.cmake` for all compiler settings
 include(compiler_settings)
 
@@ -94,13 +110,17 @@ add_subdirectory(tests)
 add_subdirectory(tools)
 
 if (UNIX)
-  add_subdirectory(3rdparty)
   add_subdirectory(debugger)
   add_subdirectory(docs/refman)
-  add_subdirectory(enclave)
-  add_subdirectory(enclave/core)
-  add_subdirectory(libc)
-  add_subdirectory(libcxx)
   add_subdirectory(pkgconfig)
   add_subdirectory(samples)
 endif ()
+
+# Add enclave directories
+if (BUILD_ENCLAVES)  
+  add_subdirectory(enclave/core)
+  add_subdirectory(3rdparty)
+  add_subdirectory(libc)
+  add_subdirectory(libcxx)
+  add_subdirectory(enclave)
+endif()

--- a/cmake/build_using_clangw.cmake
+++ b/cmake/build_using_clangw.cmake
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Build a given target using clang wrapper.
+# This function overrides variable in the caller scope.
+function(build_using_clangw OE_TARGET)
+    # Add dependency to the clang wrapper
+    add_dependencies(${OE_TARGET} clangw)
+
+    # Add compile options from compiler_settings.cmake
+    target_compile_options(${OE_TARGET} PRIVATE
+        -Wall -Werror -Wpointer-arith -Wconversion -Wextra -Wno-missing-field-initializers
+        -fno-strict-aliasing
+        -mxsave
+        -fno-builtin-malloc -fno-builtin-calloc)
+
+    # Setup library names variables
+    set(CMAKE_STATIC_LIBRARY_PREFIX "lib" PARENT_SCOPE)
+    set(CMAKE_STATIC_LIBRARY_SUFFIX ".a" PARENT_SCOPE)
+
+    # Setup library tool variables
+    set(CMAKE_C_CREATE_STATIC_LIBRARY "llvm-ar qc <TARGET> <OBJECTS>" PARENT_SCOPE)
+    set(CMAKE_CXX_CREATE_STATIC_LIBRARY "llvm-ar qc <TARGET> <OBJECTS>" PARENT_SCOPE)
+
+    # Setup linker variables.
+    find_program(LD_LLD "ld.lld.exe")
+    set(CMAKE_EXECUTABLE_SUFFIX "" PARENT_SCOPE)
+    set(CMAKE_C_STANDARD_LIBRARIES "" PARENT_SCOPE)
+    set(CMAKE_C_LINK_EXECUTABLE
+        "clang -target x86_64-pc-linux <OBJECTS> -o <TARGET>  <LINK_LIBRARIES> -fuse-ld=\"${LD_LLD}\""
+        PARENT_SCOPE)
+    set(CMAKE_CXX_STANDARD_LIBRARIES "" PARENT_SCOPE)
+    set(CMAKE_CXX_LINK_EXECUTABLE
+        "clang -target x86_64-pc-linux <OBJECTS> -o <TARGET>  <LINK_LIBRARIES> -fuse-ld=\"${LD_LLD}\""
+        PARENT_SCOPE)
+
+    # Setup comiler variables.
+    set(CMAKE_C_COMPILE_OBJECT
+        "\"${CMAKE_BINARY_DIR}/windows/clangw/clangw.exe\" -target x86_64-pc-linux <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>"
+        PARENT_SCOPE)
+
+    set(CMAKE_CXX_COMPILE_OBJECT
+        "\"${CMAKE_BINARY_DIR}/windows/clangw/clangw.exe\" -target x86_64-pc-linux <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>"
+        PARENT_SCOPE)
+
+    # Change ASM file extension.
+    # TODO: Do this very early so that this can be used instead of the
+    # hack where we set the language of these files to C every time.
+    #
+    # set(CMAKE_ASM_SOURCE_FILE_EXTENSIONS ".s,.S")
+    #
+    # TODO: Change output extension to .o for enclaves.
+    # The following does not work.
+    # set(CMAKE_C_OUTPUT_EXTENSION ".o")
+endfunction(build_using_clangw)

--- a/enclave/CMakeLists.txt
+++ b/enclave/CMakeLists.txt
@@ -41,3 +41,10 @@ set_property(TARGET oeenclave PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/ope
 
 install(TARGETS oeenclave EXPORT openenclave-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+
+if (USE_CLANGW)
+  # Mark assembler files for compilation using clang.
+  set_source_files_properties(start.S  PROPERTIES LANGUAGE C)
+  build_using_clangw(oeenclave)
+endif()
+

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-if (UNIX)
+if (UNIX OR USE_CLANGW)
 set(PLATFORM_SRC
     ../../common/rand.S
     linux/reloc.c
@@ -98,3 +98,12 @@ set_source_files_properties(jump.c PROPERTIES COMPILE_FLAGS -O2)
 
 set_property(TARGET oecore PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/openenclave/enclave)
 install (TARGETS oecore EXPORT openenclave-targets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+
+if (WIN32)
+    # Mark assembler files for compilation using clang.
+    set_source_files_properties(../../common/rand.S  PROPERTIES LANGUAGE C)
+    set_source_files_properties(enter.S PROPERTIES LANGUAGE C)
+    set_source_files_properties(exit.S PROPERTIES LANGUAGE C)
+    set_source_files_properties(getkey.S PROPERTIES LANGUAGE C)
+    build_using_clangw(oecore)
+endif()

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -25,11 +25,11 @@ add_library(oelibasm OBJECT
 # assembling, and clang-7 errors because we treat warnings as errors.
 # So we move the assembly code into a fake library, turn off the
 # error, and then inject the objects into the actual library.
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR USE_CLANGW)
     target_compile_options(oelibasm PRIVATE -Wno-error=unused-command-line-argument)
 endif ()
 
-if (UNIX)
+if (UNIX OR USE_CLANGW)
 set(PLATFORM_SRC
     ../common/rand.S
 )
@@ -667,6 +667,31 @@ add_library(oelibc STATIC
     ${MUSLSRC}/unistd/dup3.c
     ${PLATFORM_SRC})
 
+# build_using_clangw adds -Werror
+# There for it must come before specific warnings are disabled.
+if (USE_CLANGW)
+    # Treat .S files as C files to compile them
+    # TODO: Remove this hack.
+    set_source_files_properties(abort.S PROPERTIES LANGUAGE C)
+    set_source_files_properties(exp2l.S PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/math/x86_64/acosl.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/math/x86_64/asinl.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/math/x86_64/log1pl.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/math/x86_64/log2l.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/math/x86_64/logl.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/math/x86_64/exp2l.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/math/x86_64/sqrt.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/math/x86_64/sqrtl.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/math/x86_64/sqrtf.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/fenv/x86_64/fenv.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/setjmp/x86_64/longjmp.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(${MUSLSRC}/setjmp/x86_64/setjmp.s PROPERTIES LANGUAGE C)
+    set_source_files_properties(../common/rand.S PROPERTIES LANGUAGE C)
+
+    build_using_clangw(oelibasm)
+    build_using_clangw(oelibc)
+endif ()
+
 # NOTE: This is the minimum required for musl sources.
 set_property(TARGET oelibc PROPERTY C_STANDARD 99)
 
@@ -683,7 +708,7 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU)
 endif ()
 
 # Ignore warnings from musl sources. First, shared warnings:
-if (CMAKE_C_COMPILER_ID MATCHES GNU OR CMAKE_C_COMPILER_ID MATCHES Clang)
+if (CMAKE_C_COMPILER_ID MATCHES GNU OR CMAKE_C_COMPILER_ID MATCHES Clang OR USE_CLANGW)
   target_compile_options(oelibc PRIVATE
     -Wno-missing-braces
     -Wno-parentheses
@@ -702,7 +727,7 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU)
     -Wno-unused-function
     -Wno-unused-value
     -Wno-unused-variable)
-elseif (CMAKE_C_COMPILER_ID MATCHES Clang)
+elseif (CMAKE_C_COMPILER_ID MATCHES Clang OR USE_CLANGW)
   target_compile_options(oelibc PRIVATE
     -Wno-dangling-else
     -Wno-ignored-attributes
@@ -725,9 +750,9 @@ target_link_libraries(oelibc
   PRIVATE oelibasm)
 
 target_include_directories(oelibc PRIVATE
-  internal
   ${PROJECT_BINARY_DIR}/3rdparty/musl/musl/src/internal
-  ${PROJECT_BINARY_DIR}/3rdparty/musl/musl/arch/x86_64)
+  ${PROJECT_BINARY_DIR}/3rdparty/musl/musl/arch/x86_64  
+  )
 
 set_property(TARGET oelibc PROPERTY
   ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/openenclave/enclave)

--- a/libc/strerror.c
+++ b/libc/strerror.c
@@ -3,9 +3,9 @@
 
 #define __NEED_size_t
 #define __NEED_locale_t
+#include <bits/alltypes.h>
 #include <errno.h>
 #include <openenclave/enclave.h>
-#include <bits/alltypes.h>
 
 typedef struct _error_info
 {

--- a/libc/strerror.c
+++ b/libc/strerror.c
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#define __NEED_size_t
+#define __NEED_locale_t
 #include <errno.h>
 #include <openenclave/enclave.h>
+#include <bits/alltypes.h>
 
 typedef struct _error_info
 {

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -18,3 +18,7 @@ set_property(TARGET oelibcxx
 
 install(TARGETS oelibcxx EXPORT openenclave-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)
+
+if (USE_CLANGW)
+  build_using_clangw(oelibcxx)
+endif()

--- a/windows/clangw/CMakeLists.txt
+++ b/windows/clangw/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+add_executable(clangw clangw.cpp)

--- a/windows/clangw/README.md
+++ b/windows/clangw/README.md
@@ -1,0 +1,9 @@
+# clangw : Clang Compiler Wrapper for building enclaves
+
+clangw takes a mix of msvc and gcc/clang command-line agruments generated
+by cmake on windows, transforms them to their clang equivalents and
+then passes them along to clang.
+
+It is similar to clang-cl. However clang-cl cannot be used for 
+cross-compiling since it also does not understand options like -fPIC,
+-fvisibility=hidden etc.

--- a/windows/clangw/clangw.cpp
+++ b/windows/clangw/clangw.cpp
@@ -3,76 +3,77 @@
 
 #include <stdio.h>
 #include <fstream>
-#include <string>
 #include <streambuf>
+#include <string>
 
 /**
  * The following table list the command line options
  * generate by nmake/visual studio cmake generators,
  * and their corresponding clang mapping.
  */
-struct option_map {
+struct option_map
+{
     const char* from;
     const char* to;
 };
 
-static option_map _table[] = {
-    {"/nologo", ""},
-    {"/TP", ""},
-    {"/TP", ""},
-    {"/DWIN32", ""},
-    {"/D_WINDOWS", ""},
-    {"/W3", ""},
-    {"/GR", ""},
-    {"/EHsc", ""},
-    {"/MD", ""},
-    {"/MDd", ""},
-    {"/DNDEBUG", "-DNDEBUG"},
-    {"/Zi", "-g"},
-    {"/Ob0", ""},
-    {"/Ob1", ""},
-    {"/Ob2", ""},
-    {"/Od", ""},
-    {"/O2", ""},
-    {"/RTC1", ""},
-    {"/FS", ""},
-    {"-std:c++11", "-std=c++11"},
-    {"-std:c++14", "-std=c++14"},
-    {"-std:c++17", "-std=c++17"}
-};
+static option_map _table[] = {{"/nologo", ""},
+                              {"/TP", ""},
+                              {"/TP", ""},
+                              {"/DWIN32", ""},
+                              {"/D_WINDOWS", ""},
+                              {"/W3", ""},
+                              {"/GR", ""},
+                              {"/EHsc", ""},
+                              {"/MD", ""},
+                              {"/MDd", ""},
+                              {"/DNDEBUG", "-DNDEBUG"},
+                              {"/Zi", "-g"},
+                              {"/Ob0", ""},
+                              {"/Ob1", ""},
+                              {"/Ob2", ""},
+                              {"/Od", ""},
+                              {"/O2", ""},
+                              {"/RTC1", ""},
+                              {"/FS", ""},
+                              {"-std:c++11", "-std=c++11"},
+                              {"-std:c++14", "-std=c++14"},
+                              {"-std:c++17", "-std=c++17"}};
 
-static const size_t _table_size = sizeof(_table)/sizeof(_table[0]);
+static const size_t _table_size = sizeof(_table) / sizeof(_table[0]);
 
 /**
  * If an option is of the form:
  *     -D="..."
  * transform it to
  *     -D=\"...\"
- * since we are passing it back to the system command 
+ * since we are passing it back to the system command
  * to invoke clang
  */
 static std::string __escape_quotes(const std::string& option)
 {
     // Check if it is a -D option.
-    if (option.size() > 2 && option[0] == '-' && option[1] == 'D') {
-        // Search for the = character.        
+    if (option.size() > 2 && option[0] == '-' && option[1] == 'D')
+    {
+        // Search for the = character.
         size_t i = 2;
-        while(i < option.size() && option[i] != '=')
+        while (i < option.size() && option[i] != '=')
             ++i;
-        
+
         if (i == option.size())
         {
             // No = character found.
             return option;
         }
 
-        // Copy till -DNAME=                
-        std::string escaped_option = option.substr(0, i+1);
+        // Copy till -DNAME=
+        std::string escaped_option = option.substr(0, i + 1);
 
-        // Escape any double-quote character.        
+        // Escape any double-quote character.
         while (++i < option.size())
         {
-            if (option[i] == '"') {
+            if (option[i] == '"')
+            {
                 escaped_option.push_back('\\');
             }
             escaped_option.push_back(option[i]);
@@ -85,19 +86,20 @@ static std::string __escape_quotes(const std::string& option)
 int main(int argc, char** argv)
 {
     std::string cmd = "clang";
-    
+
     // Has /Zi or /O2 been specified?
     bool debug = false;
     bool optimize = false;
 
     // Transform all the arguments.
-    for (int i=1; i < argc; ++i)
+    for (int i = 1; i < argc; ++i)
     {
         std::string option = argv[i];
 
         // Look for a direct mapping
         bool match = false;
-        for(size_t j=0; j < _table_size; ++j) {
+        for (size_t j = 0; j < _table_size; ++j)
+        {
             if (option == _table[j].from)
             {
                 match = true;
@@ -111,7 +113,7 @@ int main(int argc, char** argv)
         cmd += " " + __escape_quotes(option);
     }
 
-    // Debug, Release and ReleaseWithDebug build-types 
+    // Debug, Release and ReleaseWithDebug build-types
     // are supported.
     if (optimize)
     {

--- a/windows/clangw/clangw.cpp
+++ b/windows/clangw/clangw.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <stdio.h>
+#include <fstream>
+#include <string>
+#include <streambuf>
+
+/**
+ * The following table list the command line options
+ * generate by nmake/visual studio cmake generators,
+ * and their corresponding clang mapping.
+ */
+struct option_map {
+    const char* from;
+    const char* to;
+};
+
+static option_map _table[] = {
+    {"/nologo", ""},
+    {"/TP", ""},
+    {"/TP", ""},
+    {"/DWIN32", ""},
+    {"/D_WINDOWS", ""},
+    {"/W3", ""},
+    {"/GR", ""},
+    {"/EHsc", ""},
+    {"/MD", ""},
+    {"/MDd", ""},
+    {"/DNDEBUG", "-DNDEBUG"},
+    {"/Zi", "-g"},
+    {"/Ob0", ""},
+    {"/Ob1", ""},
+    {"/Ob2", ""},
+    {"/Od", ""},
+    {"/O2", ""},
+    {"/RTC1", ""},
+    {"/FS", ""},
+    {"-std:c++11", "-std=c++11"},
+    {"-std:c++14", "-std=c++14"},
+    {"-std:c++17", "-std=c++17"}
+};
+
+static const size_t _table_size = sizeof(_table)/sizeof(_table[0]);
+
+/**
+ * If an option is of the form:
+ *     -D="..."
+ * transform it to
+ *     -D=\"...\"
+ * since we are passing it back to the system command 
+ * to invoke clang
+ */
+static std::string __escape_quotes(const std::string& option)
+{
+    // Check if it is a -D option.
+    if (option.size() > 2 && option[0] == '-' && option[1] == 'D') {
+        // Search for the = character.        
+        size_t i = 2;
+        while(i < option.size() && option[i] != '=')
+            ++i;
+        
+        if (i == option.size())
+        {
+            // No = character found.
+            return option;
+        }
+
+        // Copy till -DNAME=                
+        std::string escaped_option = option.substr(0, i+1);
+
+        // Escape any double-quote character.        
+        while (++i < option.size())
+        {
+            if (option[i] == '"') {
+                escaped_option.push_back('\\');
+            }
+            escaped_option.push_back(option[i]);
+        }
+        return escaped_option;
+    }
+    return option;
+}
+
+int main(int argc, char** argv)
+{
+    std::string cmd = "clang";
+    
+    // Has /Zi or /O2 been specified?
+    bool debug = false;
+    bool optimize = false;
+
+    // Transform all the arguments.
+    for (int i=1; i < argc; ++i)
+    {
+        std::string option = argv[i];
+
+        // Look for a direct mapping
+        bool match = false;
+        for(size_t j=0; j < _table_size; ++j) {
+            if (option == _table[j].from)
+            {
+                match = true;
+                debug = (option == "/Zi");
+                optimize = (option == "/O2");
+                option = _table[j].to;
+                break;
+            }
+        }
+
+        cmd += " " + __escape_quotes(option);
+    }
+
+    // Debug, Release and ReleaseWithDebug build-types 
+    // are supported.
+    if (optimize)
+    {
+        cmd += debug ? " -Og " : " - O2 ";
+    }
+
+    return system(cmd.c_str());
+}


### PR DESCRIPTION
All the enclave libraries are built in this changelist.
The tests will be built in phase 2.

1. Pass -DBUILD_ENCLAVES=1 on windows to turn on the feature.
2. Introduces clangw (clang-wrapper) to handle mix of msvc and gcc/clang options generated by cmake.
3. Uses ld.lld to link enclaves. llvm-ar to create libraries.
3. Launches git-bash as needed to do necessary configurations for some targets (especially 3rdparty).