### PR TITLE
Add Ubuntu 18.04 ACC tests to Jenkinsfile

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -13,10 +13,10 @@
 #
 # Once installed, build a docker image from .jenkins folder and
 # it will use this Dockerfile by default:
-#     openenclave$ sudo docker build --no-cache=true -t oetools-azure:<version> -f .jenkins/Dockerfile .
+#     openenclave$ sudo docker build --no-cache=true --build-arg ubuntu_version=<ubuntu_version> -t oetools-azure-<ubuntu_version>:<version> -f .jenkins/Dockerfile .
 #
-# For example, for version 1.x:
-#     openenclave$ sudo docker build --no-cache=true -t oetools-azure:1.x -f .jenkins/Dockerfile .
+# For example, for version 1.x with Ubuntu 18.04 :
+#     openenclave$ sudo docker build --no-cache=true --build-arg ubuntu_version=18.04 -t oetools-azure-18.04:1.x -f .jenkins/Dockerfile .
 #
 # Note that DNS forwarding in a VM can interfere with Docker
 # getting updates from Ubuntu apt-get repositories as part of the
@@ -31,8 +31,8 @@
 # Jenkins pulls the images it uses from the private oejenkinscidockerregistry
 # repository on Azure. To upload the image to that repository:
 #     $ sudo docker login oejenkinscidockerregistry.azurecr.io
-#     $ sudo docker tag oetools-azure:<version> oejenkinscidockerregistry.azurecr.io/oetools-azure:<version>
-#     $ sudo docker push oejenkinscidockerregistry.azurecr.io/oetools-azure:<version>
+#     $ sudo docker tag oetools-azure-<ubuntu_version>:<version> oejenkinscidockerregistry.azurecr.io/oetools-azure-<ubuntu_version>:<version>
+#     $ sudo docker push oejenkinscidockerregistry.azurecr.io/oetools-azure-<ubuntu_version>:<version>
 #     $ sudo docker logout
 #
 # You can check that the image has been successfully uploaded by checking
@@ -40,7 +40,9 @@
 # assuming you have proper permissions:
 # https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/e5839dfd-61f0-4b2f-b06f-de7fc47b5998/resourceGroups/OE-Jenkins-CI/providers/Microsoft.ContainerRegistry/registries/oejenkinscidockerregistry/overview
 
-FROM ubuntu:16.04
+ARG ubuntu_version=16.04
+
+FROM ubuntu:${ubuntu_version}
 
 ADD scripts/ansible /ansible
 

--- a/.jenkins/Dockerfile.scripts
+++ b/.jenkins/Dockerfile.scripts
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+ARG ubuntu_version=16.04
 
-FROM ubuntu:16.04
+FROM ubuntu:${ubuntu_version}
 
 COPY scripts/ansible /ansible
 

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -31,17 +31,17 @@ def ACCTest(String label, String compiler, String build_type) {
     }
 }
 
-def simulationTest(String platform_mode, String build_type) {
+def simulationTest(String version, String platform_mode, String build_type) {
     def use_libsgx = "OFF"
     if (platform_mode == "SGX1FLC") {
         use_libsgx = "ON"
     }
-    stage("Sim clang-7 ${platform_mode} ${build_type}") {
+    stage("Sim clang-7 Ubuntu${version} ${platform_mode} ${build_type}") {
         node {
             cleanWs()
             checkout scm
 
-            def oetoolsSim = docker.build("oetools-simulation", "-f .jenkins/Dockerfile .")
+            def oetoolsSim = docker.build("oetools-simulation-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile .")
             oetoolsSim.inside {
                 timeout(15) {
                     dir('build') {
@@ -59,13 +59,13 @@ def simulationTest(String platform_mode, String build_type) {
     }
 }
 
-def ACCContainerTest(String label) {
-    stage("${label} Container RelWithDebInfo") {
-        node("${label}") {
+def ACCContainerTest(String label, String version) {
+    stage("$label Container RelWithDebInfo") {
+        node("$label") {
             cleanWs()
             checkout scm
 
-            def oetoolsContainer = docker.build("oetools-containertest", "-f .jenkins/Dockerfile .")
+            def oetoolsContainer = docker.build("oetools-containertest-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile .")
             oetoolsContainer.inside('--device /dev/sgx:/dev/sgx') {
                 timeout(15) {
                     dir('build') {
@@ -83,13 +83,13 @@ def ACCContainerTest(String label) {
     }
 }
 
-def checkDevFlows() {
+def checkDevFlows(String version) {
     stage('Check dev flows') {
         node {
             cleanWs()
             checkout scm
 
-            def oetoolsCheck = docker.build("oetools-check", "-f .jenkins/Dockerfile .")
+            def oetoolsCheck = docker.build("oetools-check-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile .")
             oetoolsCheck.inside {
                 timeout(2) {
                     sh './scripts/check-ci'
@@ -103,7 +103,7 @@ def checkDevFlows() {
             cleanWs()
             checkout scm
 
-            def buildImage = docker.build("oetools-base", '-f .jenkins/Dockerfile.scripts .')
+            def buildImage = docker.build("oetools-base-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile.scripts .")
 
             buildImage.inside {
                 timeout(15) {
@@ -124,12 +124,12 @@ def checkDevFlows() {
     }
 }
 
-def win2016LinuxElfBuild(String build_type) {
-    stage("Linux SGX1 ${build_type}") {
+def win2016LinuxElfBuild(String version, String build_type) {
+    stage("Ubuntu ${version} SGX1 ${build_type}}") {
         node {
             cleanWs()
             checkout scm
-            def oetoolsWincp = docker.build("oetools-wincp", "-f .jenkins/Dockerfile .")
+            def oetoolsWincp = docker.build("oetools-wincp-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile .")
             oetoolsWincp.inside {
                 timeout(15) {
                     dir('build') {
@@ -140,7 +140,7 @@ def win2016LinuxElfBuild(String build_type) {
                             """
                         }
                     }
-                    stash includes: 'build/tests/**', name: "linux${build_type}"
+                    stash includes: 'build/tests/**', name: "linux${build_type}${version}"
                 }
             }
         }
@@ -149,7 +149,7 @@ def win2016LinuxElfBuild(String build_type) {
         node('SGXFLC-Windows') {
             cleanWs()
             checkout scm
-            unstash "linux${build_type}"
+            unstash "linux${build_type}${version}"
             PowerShellWrapper('mv build linuxbin')
             PowerShellWrapper("./scripts/test-build-config.ps1 -add_windows_enclave_tests -build_type ${build_type} -linux_bin_dir ${WORKSPACE}/linuxbin/tests")
        }
@@ -166,23 +166,38 @@ def win2016CrossCompile(String build_type) {
     }
 }
 
-parallel "Check Developer Experience" :          { checkDevFlows() },
-         "Sim clang-7 SGX1 Debug" :              { simulationTest('SGX1', 'Debug')},
-         "Sim clang-7 SGX1 Release" :            { simulationTest('SGX1', 'Release')},
-         "Sim clang-7 SGX1 RelWithDebInfo" :     { simulationTest('SGX1', 'RelWithDebInfo')},
-         "Sim clang-7 SGX1-FLC Debug" :          { simulationTest('SGX1FLC', 'Debug')},
-         "Sim clang-7 SGX1-FLC Release" :        { simulationTest('SGX1FLC', 'Release')},
-         "Sim clang-7 SGX1-FLC RelWithDebInfo" : { simulationTest('SGX1FLC', 'RelWithDebInfo')},
-         "ACC1604 clang-7 Debug" :               { ACCTest('ACC-1604', 'clang-7', 'Debug') },
-         "ACC1604 clang-7 Release" :             { ACCTest('ACC-1604', 'clang-7', 'Release') },
-         "ACC1604 clang-7 RelWithDebInfo" :      { ACCTest('ACC-1604', 'clang-7', 'RelWithDebinfo') },
-         "ACC1604 gcc Debug" :                   { ACCTest('ACC-1604', 'gcc', 'Debug') },
-         "ACC1604 gcc Release" :                 { ACCTest('ACC-1604', 'gcc', 'Release') },
-         "ACC1604 gcc RelWithDebInfo" :          { ACCTest('ACC-1604', 'gcc', 'RelWithDebInfo') },
-         "ACC1804 clang-7 Debug" :               { ACCTest('ACC-1804', 'clang-7', 'Debug') },
-         "ACC1804 clang-7 RelWithDebInfo" :      { ACCTest('ACC-1804', 'clang-7', 'RelWithDebinfo') },
-         "Win2016 Debug Cross Compile" :         { win2016CrossCompile("Debug") },
-         "Win2016 Release Cross Compile" :       { win2016CrossCompile("Release") },
-         "Win2016 Debug Linux-Elf-build" :       { win2016LinuxElfBuild("Debug") },
-         "Win2016 Release Linux-Elf-build" :     { win2016LinuxElfBuild("Release") },
-         "ACC1604 Container RelWithDebInfo" :    { ACCContainerTest('ACC-1604') }
+
+parallel "Check Developer Experience Ubuntu 16.04" :    { checkDevFlows('16.04') },
+         "Check Developer Experience Ubuntu 18.04" :    { checkDevFlows('18.04') },
+         "ACC1604 clang-7 Debug" :                      { ACCTest('ACC-1604', 'clang-7', 'Debug') },
+         "ACC1604 clang-7 Release" :                    { ACCTest('ACC-1604', 'clang-7', 'Release') },
+         "ACC1604 clang-7 RelWithDebInfo" :             { ACCTest('ACC-1604', 'clang-7', 'RelWithDebinfo') },
+         "ACC1604 gcc Debug" :                          { ACCTest('ACC-1604', 'gcc', 'Debug') },
+         "ACC1604 gcc Release" :                        { ACCTest('ACC-1604', 'gcc', 'Release') },
+         "ACC1604 gcc RelWithDebInfo" :                 { ACCTest('ACC-1604', 'gcc', 'RelWithDebInfo') },
+         "ACC1604 Container RelWithDebInfo" :           { ACCContainerTest('ACC-1604', '16.04') },
+         "ACC1804 clang-7 Debug" :                      { ACCTest('ACC-1804', 'clang-7', 'Debug') },
+         "ACC1804 clang-7 Release" :                    { ACCTest('ACC-1804', 'clang-7', 'Release') },
+         "ACC1804 clang-7 RelWithDebInfo" :             { ACCTest('ACC-1804', 'clang-7', 'RelWithDebinfo') },
+         "ACC1804 gcc Debug" :                          { ACCTest('ACC-1804', 'gcc', 'Debug') },
+         "ACC1804 gcc Release" :                        { ACCTest('ACC-1804', 'gcc', 'Release') },
+         "ACC1804 gcc RelWithDebInfo" :                 { ACCTest('ACC-1804', 'gcc', 'RelWithDebInfo') },
+         "ACC1804 Container RelWithDebInfo" :           { ACCContainerTest('ACC-1804', '18.04') },
+         "Sim 1604 clang-7 SGX1 Debug" :                { simulationTest('16.04', 'SGX1', 'Debug')},
+         "Sim 1604 clang-7 SGX1 Release" :              { simulationTest('16.04', 'SGX1', 'Release')},
+         "Sim 1604 clang-7 SGX1 RelWithDebInfo" :       { simulationTest('16.04', 'SGX1', 'RelWithDebInfo')},
+         "Sim 1604 clang-7 SGX1-FLC Debug" :            { simulationTest('16.04', 'SGX1FLC', 'Debug')},
+         "Sim 1604 clang-7 SGX1-FLC Release" :          { simulationTest('16.04', 'SGX1FLC', 'Release')},
+         "Sim 1604 clang-7 SGX1-FLC RelWithDebInfo" :   { simulationTest('16.04', 'SGX1FLC', 'RelWithDebInfo')},
+         "Sim 1804 clang-7 SGX1 Debug" :                { simulationTest('18.04', 'SGX1', 'Debug')},
+         "Sim 1804 clang-7 SGX1 Release" :              { simulationTest('18.04', 'SGX1', 'Release')},
+         "Sim 1804 clang-7 SGX1 RelWithDebInfo" :       { simulationTest('18.04', 'SGX1', 'RelWithDebInfo')},
+         "Sim 1804 clang-7 SGX1-FLC Debug" :            { simulationTest('18.04', 'SGX1FLC', 'Debug')},
+         "Sim 1804 clang-7 SGX1-FLC Release" :          { simulationTest('18.04', 'SGX1FLC', 'Release')},
+         "Sim 1804 clang-7 SGX1-FLC RelWithDebInfo" :   { simulationTest('18.04', 'SGX1FLC', 'RelWithDebInfo')},
+         "Win2016 Ubuntu1604 Debug Linux-Elf-build" :   { win2016LinuxElfBuild('16.04', 'Debug') },
+         "Win2016 Ubuntu1604 Release Linux-Elf-build" : { win2016LinuxElfBuild('16.04', 'Release') },
+         "Win2016 Ubuntu1804 Debug Linux-Elf-build" :   { win2016LinuxElfBuild('18.04', 'Debug') },
+         "Win2016 Ubuntu1804 Release Linux-Elf-build" : { win2016LinuxElfBuild('18.04', 'Release') },
+         "Win2016 Debug Cross Compile" :                { win2016CrossCompile('Debug') },
+         "Win2016 Release Cross Compile" :              { win2016CrossCompile('Release') }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -60,8 +60,8 @@ def simulationTest(String version, String platform_mode, String build_type) {
 }
 
 def ACCContainerTest(String label, String version) {
-    stage("$label Container RelWithDebInfo") {
-        node("$label") {
+    stage("${label} Container RelWithDebInfo") {
+        node("${label}") {
             cleanWs()
             checkout scm
 

--- a/samples/run
+++ b/samples/run
@@ -4,6 +4,7 @@
 # Licensed under the MIT License.
 
 if [ -f ../environment ]; then
+  # shellcheck disable=SC1091  
   source ../environment
 fi
 


### PR DESCRIPTION
Added Ubuntu 18.04 tests to be on par with Ubuntu 16.04 tests:

Added a new images oetools-azure-16.04:<tag>. and oetools-azure-18.04:<tag>
Updated Dockerfile instructions

Due to an issue with systemd, init.d not being present in Ubuntu 18.04 container , we are mounting /var/run/aesmd in ACC-Container test
https://github.com/intel/linux-sgx/blob/master/linux/installer/common/psw/install.sh#L57-L99

Re-wrote ansible tasks lists to accomodate Ubuntu 18.04 repositories and packages


Fixes #1252