### PR TITLE
Enable building within Visual Studio using Ninja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Open Enclave SDK works in Windows
+   - Build using Visual Studio 2017's CMake Support
+   - Build in x64 Native Prompt using Ninja
 - Function table/id based ecall/ocall dispatching
    - oeedger8r generates ecall tables and ocall tables
    - Dispatching based on function-id (index into table)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # Please read The Ultimate Guide to CMake:
 # https://rix0r.nl/blog/2015/08/13/cmake-guide/
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 # Read version from "VERSION" file.
 file(STRINGS "VERSION" OE_VERSION_WITH_V)

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -33,40 +33,40 @@
 
   "configurations": [
     {
-      "name": "x86-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "inheritEnvironments": [ "msvc_x86" ],
-      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "-v",
-      "ctestCommandArgs": ""
-    },
-    {
-      "name": "x86-Release",
-      "generator": "Ninja",
-      "configurationType": "RelWithDebInfo",
-      "inheritEnvironments": [ "msvc_x86" ],
-      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "-v",
-      "ctestCommandArgs": ""
-    },
-    {
       "name": "x64-Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "buildRoot": "${workspaceRoot}\\build\\Debug",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "",
+      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     },
     {
-      "name": "x64-Debug-tests",
+      "name": "x64-RelWithDebInfo",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${workspaceRoot}\\build\\RelWithDebInfo",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${workspaceRoot}\\build\\Release",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DBUILD_ENCLAVES=1",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-Cross-Platform-Debug-tests",
       "generator": "Visual Studio 15 2017 Win64",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
@@ -77,18 +77,7 @@
       "ctestCommandArgs": "-C Debug"
     },
     {
-      "name": "x64-Release",
-      "generator": "Ninja",
-      "configurationType": "RelWithDebInfo",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "-v",
-      "ctestCommandArgs": ""
-    },
-    {
-      "name": "x64-Release-tests",
+      "name": "x64-Cross-Platform-Release-tests",
       "generator": "Ninja",
       "configurationType": "RelWithDebInfo",
       "inheritEnvironments": [ "msvc_x64_x64" ],
@@ -137,6 +126,6 @@
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "linux-x64" ]
-    }
+    }    
   ]
 }

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,35 +1,27 @@
 {
-
   // Copyright (c) Microsoft Corporation. All rights reserved.
   // Licensed under the MIT License.
   //
-  // This file illustrates CMake settings to use for building and testing against
-  // WSL from Visual Studio 2017. It is based on the default CMakeSettings.json
-  // with the addition of two custom configurations: x64-Debug-tests and
-  // x64-Release-tests. These configurations allow a workflow for building a
-  // Windows OpenEnclave host app with a Linux enclave binary in 3 steps:
+  // This file illustrates CMake settings to use for building and testing
+  // Open Enclave SDK from Visual 2017. It is based on the default
+  // CMakeSettings.json.
+  // Prerequisites:
+  //  1. clang (preferable clang-7) must be installed on the machine
+  //     The following programs must be available in the path:
+  //         clang
+  //         llvm-ar
+  //         ld.lld
+  //  2. bash (Git's bash or WSL bash) must be available in the path.
   //
-  //  1. Build Windows host binaries using x64-Debug|Release configurations
-  //  2. Build Linux enclave binaries using Linux-Debug|Release configurations
-  //  3. Build Windows tests with Linux-built test enclaves from step 2 by
-  //     using x64-Debug|Release-tests configurations
-  //
-  // The test configurations specify the additional cmakeCommandArgs to enable
-  // retrieving the binaries built in WSL during the second step:
-  //
-  // ADD_WINDOWS_ENCLAVE_TESTS = 1
-  //   - This enables the CMake build option to only build Windows enclave tests
-  //
-  // LINUX_BIN_DIR = ${env.WSL_ROOTFS}/var/tmp/build/${workspaceHash}/build/Linux-Debug/tests
-  //   - This provides CMake with the Windows path to the WSL root file system
-  //   - You are expected to define the global environment variable WSL_ROOTFS,
-  //     which usually points to "C:\Users\username\AppData\Local\lxss\rootfs"
-  //   - The rest of the path should be defined exactly as in the Linux-Debug and
-  //     Linux-Release configurations respectively.
-  //
-  // These test configurations are otherwise identical to the x64-Debug and
-  // x64-Release configurations respectively. For more information on editing
-  // CMakeSettings.json, refer to https://go.microsoft.com//fwlink//?linkid=834763
+  // The following 3 configurations are available for building with
+  // Visual Studio 2017:
+  //    x64-Debug
+  //    x64-RelWithDebInfo
+  //    x64-Release
+  // Each configuration has its corresponding build folder under
+  //    ${workspaceRoot}/build/<configuration-name>
+  // For more information on editing CMakeSettings.json, refer to
+  // https://go.microsoft.com//fwlink//?linkid=834763
 
   "configurations": [
     {
@@ -37,7 +29,7 @@
       "generator": "Ninja",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${workspaceRoot}\\build\\Debug",
+      "buildRoot": "${workspaceRoot}\\build\\x64-Debug",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
       "cmakeCommandArgs": "-DBUILD_ENCLAVES=1",
       "buildCommandArgs": "-v",
@@ -48,7 +40,7 @@
       "generator": "Ninja",
       "configurationType": "RelWithDebInfo",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${workspaceRoot}\\build\\RelWithDebInfo",
+      "buildRoot": "${workspaceRoot}\\build\\x64-RelWithDebInfo",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
       "cmakeCommandArgs": "-DBUILD_ENCLAVES=1",
       "buildCommandArgs": "-v",
@@ -59,73 +51,11 @@
       "generator": "Ninja",
       "configurationType": "Release",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${workspaceRoot}\\build\\Release",
+      "buildRoot": "${workspaceRoot}\\build\\x64-Release",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
       "cmakeCommandArgs": "-DBUILD_ENCLAVES=1",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
-    },
-    {
-      "name": "x64-Cross-Platform-Debug-tests",
-      "generator": "Visual Studio 15 2017 Win64",
-      "configurationType": "Debug",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DADD_WINDOWS_ENCLAVE_TESTS=1 -DLINUX_BIN_DIR=${env.WSL_ROOTFS}/var/tmp/build/${workspaceHash}/build/Linux-Debug/tests ",
-      "buildCommandArgs": "-p:Configuration=Debug",
-      "ctestCommandArgs": "-C Debug"
-    },
-    {
-      "name": "x64-Cross-Platform-Release-tests",
-      "generator": "Ninja",
-      "configurationType": "RelWithDebInfo",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DADD_WINDOWS_ENCLAVE_TESTS=1 -DLINUX_BIN_DIR=${env.WSL_ROOTFS}/var/tmp/build/${workspaceHash}/build/Linux-Debug/tests ",
-      "buildCommandArgs": "-v",
-      "ctestCommandArgs": ""
-    },
-    {
-      "name": "Linux-Debug",
-      "generator": "Unix Makefiles",
-      "remoteMachineName": "${defaultRemoteMachineName}",
-      "configurationType": "Debug",
-      "remoteCMakeListsRoot": "/var/tmp/src/${workspaceHash}/${name}",
-      "cmakeExecutable": "/usr/local/bin/cmake",
-      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "remoteBuildRoot": "/var/tmp/build/${workspaceHash}/build/${name}",
-      "remoteInstallRoot": "/var/tmp/build/${workspaceHash}/install/${name}",
-      "remoteCopySources": true,
-      "remoteCopySourcesOutputVerbosity": "Normal",
-      "remoteCopySourcesConcurrentCopies": "10",
-      "remoteCopySourcesMethod": "sftp",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "linux-x64" ]
-    },
-    {
-      "name": "Linux-Release",
-      "generator": "Unix Makefiles",
-      "remoteMachineName": "${defaultRemoteMachineName}",
-      "configurationType": "Release",
-      "remoteCMakeListsRoot": "/var/tmp/src/${workspaceHash}/${name}",
-      "cmakeExecutable": "/usr/local/bin/cmake",
-      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
-      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "remoteBuildRoot": "/var/tmp/build/${workspaceHash}/build/${name}",
-      "remoteInstallRoot": "/var/tmp/build/${workspaceHash}/install/${name}",
-      "remoteCopySources": true,
-      "remoteCopySourcesOutputVerbosity": "Normal",
-      "remoteCopySourcesConcurrentCopies": "10",
-      "remoteCopySourcesMethod": "sftp",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "linux-x64" ]
-    }    
+    }
   ]
 }

--- a/cmake/maybe_build_using_clangw.cmake
+++ b/cmake/maybe_build_using_clangw.cmake
@@ -33,6 +33,7 @@ function(maybe_build_using_clangw OE_TARGET)
 
     # Add dependency to the clang wrapper
     add_dependencies(${OE_TARGET} clangw)
+    add_dependencies(${OE_TARGET} llvm-arw)
 
     # Add compile options from compiler_settings.cmake
     target_compile_options(${OE_TARGET} PRIVATE
@@ -46,8 +47,12 @@ function(maybe_build_using_clangw OE_TARGET)
     set(CMAKE_STATIC_LIBRARY_SUFFIX ".a" PARENT_SCOPE)
 
     # Setup library tool variables
-    set(CMAKE_C_CREATE_STATIC_LIBRARY "llvm-ar qc <TARGET> <OBJECTS>" PARENT_SCOPE)
-    set(CMAKE_CXX_CREATE_STATIC_LIBRARY "llvm-ar qc <TARGET> <OBJECTS>" PARENT_SCOPE)
+    set(CMAKE_C_CREATE_STATIC_LIBRARY 
+        "\"${CMAKE_BINARY_DIR}/windows/clangw/llvm-arw.exe\" qc <TARGET> <OBJECTS>" 
+        PARENT_SCOPE)
+    set(CMAKE_CXX_CREATE_STATIC_LIBRARY 
+        "\"${CMAKE_BINARY_DIR}/windows/clangw/llvm-arw.exe\" qc <TARGET> <OBJECTS>" 
+        PARENT_SCOPE)
 
     # Setup linker variables.
     find_program(LD_LLD "ld.lld.exe")

--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -6,13 +6,7 @@ Introduction
 
 This document is a work in progress. It describes how to use experimental
 support in the Open Enclave SDK to build Windows host applications that can
-load enclaves built on Linux.
-
-You will need to be familiar with how to use the Open Enclave SDK on Linux,
-as you will need to set up a Linux build environment with which to build
-then enclave binaries. That information, along with a step-by-step tutorial
-on building an enclave application, is covered in [Getting Started with
-Open Enclave](GettingStarted.md) document.
+load ELF enclaves built using clang.
 
 Prerequisites
 -------------
@@ -24,29 +18,60 @@ Windows.
 - Windows 10 64-bit with Fall Creators Update (1709)
 - [Intel® SGX Platform Software for Windows (PSW)](
   https://software.intel.com/sites/default/files/managed/0f/c8/Intel-SGX-PSW-Release-Notes-for-Windows-OS.pdf)
+- [Microsoft Visual Studio 2017](https://www.visualstudio.com/downloads/)
+- [Git for Windows 64-bit](https://git-scm.com/download/win)
+- [clang (preferably version 7.0 or above)](http://releases.llvm.org/download.html)  
+- [OCaml on Windows 64-bit](https://fdopen.github.io/opam-repository-mingw/installation/) (Note that this will install a Mingw environment for OCaml.)
+
+
+Intel® SGX Platform Software for Windows (PSW) 
+---------------------------------
 
 The PSW should be installed automatically on Windows 10 with the Fall Creators
 Update installed. You can verify that is the case on the command line as
 follows:
 
+```cmd
+sc query aesmservice
 ```
-C:\> sc query aesmservice
+
+The state of the service should be "running" (4). Follow Intel's documentation for troubleshooting.
+
+Microsoft Visual Studio 2017
+---------------------------------
+Install the latest version of [Microsoft Visual Studio 2017](https://www.visualstudio.com/downloads/).
+Visual Studio 2017's cmake support is required for building the Open Enclave SDK.
+For more information about cmake support, refer to
+https://blogs.msdn.microsoft.com/vcblog/2016/10/05/cmake-support-in-visual-studio/
+
+
+Git for Windows 64-bit
+---------------------------------
+Install Git and add Git's bash to the path.
+Typically, Git's bash is located in C:\Program Files\Git\bin.
+Currently the Open Enclave SDK build system uses bash scripts to configure
+and process few 3rd-party libraries. 
+
+Open a command prompt and ensure that bash is available in the path:
+```cmd
+C:\>where bash
+C:\Program Files\Git\bin\bash.exe
 ```
 
-The state of the service should be "running" (4). See the Troubleshooting
-section on how to manually install the PSW if it is not installed.
+Clang
+---------------------------------
+Install the latest version of Clang and add the LLVM folder (typically C:\Program Files\LLVM\bin)
+to the path. Open Enclave SDK uses clang to build the enclave binaries.
 
-In addition, you will need to set up a development environment to build both the
-Linux and Windows binaries:
-
-- [Windows Subsystem for Linux (WSL)](
-  https://docs.microsoft.com/en-us/windows/wsl/install-win10)
-- [Microsoft Visual Studio 2017](https://www.visualstudio.com/downloads/)
-  - [Windows 10 SDK (10.0.16299)](
-    https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk)
-- [Git for Windows 64-bit](https://git-scm.com/download/win)
-- [CMake 3.13.1+](https://cmake.org/download/)
-- [OCaml on Windows 64-bit](https://fdopen.github.io/opam-repository-mingw/installation/) (Note that this will install a Cygwin environment for OCaml.)
+Open up a command prompt and ensure that clang is available in the path:
+```cmd
+C:\> where clang
+C:\Program Files\LLVM\bin\clang.exe
+C:\> where llvm-ar
+C:\Program Files\LLVM\bin\llvm-ar.exe
+C:\> where ld.lld
+C:\Program Files\LLVM\bin\ld.lld.exe
+```
 
 Configuring OCaml for Windows
 ---------------------------------
@@ -79,22 +104,6 @@ This creates a source tree under the directory called openenclave.
 Building
 --------
 
-### Building on Linux
-Host applications can be built on Windows but enclaves cannot, so enclaves
-must be built on Linux and then copied to Windows for testing. The [instructions
-for setting up a Linux development environment](GettingStarted.md) are
-applicable to WSL as well.
-
-To summarize, assuming your local Open Enclave repo is at C:\openenclave, it can
-be built in the WSL shell using:
-```
-$ cd /mnt/c/openenclave
-$ mkdir build
-$ cd build
-$ cmake ..
-$ make
-```
-
 ### Building on Windows using Visual Studio 2017
 [Visual Studio 2017 has integrated support for loading CMake projects](
 https://blogs.msdn.microsoft.com/vcblog/2016/10/05/cmake-support-in-visual-studio/):
@@ -105,9 +114,8 @@ https://blogs.msdn.microsoft.com/vcblog/2016/10/05/cmake-support-in-visual-studi
 3. The CMake menu option should appear when it detects a valid CMake project is
    loaded. VS2017 will then recursively walk the repo directory structure and
    generate a cache for the project to display Intellisense.
-4. Open Enclave is only supported for 64-bit, so change the build flavor to
-   `x64-Debug`. You may need to cancel cache generation and start it again after
-   changing the build flavor.
+4. Open Enclave is only supported for 64-bit, by default the `x64-Debug` configuration is 
+   selected.
 5. Once cache generation is complete, you can build the project via the CMake >
    Build All menu option.
 
@@ -118,128 +126,64 @@ You can change the build settings by with the CMake > Change CMake Settings menu
 option. This opens the [CMakeSettings.json](https://blogs.msdn.microsoft.com/vcblog/2017/08/14/cmake-support-in-visual-studio-customizing-your-environment/)
 file which you can edit and change settings such as the target build location.
 
-By default, VS2017 will build to a dynamically generated folder name:
+By default, Open Enclave SDK will be built in the following location:
 ```
-${env.USERPROFILE}\CMakeBuilds\\${workspaceHash}\\build\\${name}
+${workspaceRoot}\build\<configuration-name>
 ```
 For example:
 ```
-C:\Users\username\CMakeBuilds\ca6d6e50-e70d-c836-ac64-910bf7e68090\build\x64-Debug
+C:\openenclave\build\x64-Debug
 ```
 
 ### Building on Windows using Developer Command Prompt
 
-1. From the Start menu, launch the [Developer Command Prompt](
+1. Launch the [x64 Native Tools Command Prompt for VS 2017](
 https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs)
-2. At the command prompt, use cmake and nmake to build the project:
+Normally this is accessible under the `Visual Studio 2017` folder in the Start Menu.
+2. At the x64 Native Tools command prompt, use cmake and nmake to build the project:
+   ```cmd
+   cd C:\openenclave
+   mkdir build\x64-Debug
+   cd build\x64-Debug
+   cmake -G Ninja -DBUILD_ENCLAVES=1 ../..
+   ninja
    ```
-   C:\> cd C:\openenclave
-   C:\openenclave> mkdir build
-   C:\openenclave> cd build
-   C:\openenclave> cmake -G "NMake Makefiles" ..
-   C:\openenclave> nmake
-   ```
-
-Alternatively, you can also try to generate a Visual Studio project using CMake
-and build the resulting project instead. Again from a Developer Command Prompt:
-
-```
-C:\> cmake -G "Visual Studio 14 2015 Win64" -DENABLE_REFMAN=OFF C:\openenclave
-C:\> msbuild ALL_BUILD.vcxproj
-```
 
 Testing
 -------
 
 ### Running ctests in Visual Studio 2017
-For now, integrated CMake support in VS2017 will only support running tests that
-do not have an enclave dependency:
 
 How to build the CMake project using Visual Studio 2017
 --------------------------------------------------------
 1. Open CMake project in Visual Studio from menu File > Open > CMake...
 	and select top level CMakeLists.txt file which is present in openenclave folder.
-2. Select Linux-Debug configuration and make sure cache is updated and then
-	select menu CMake > Build only > All(Targets) to build all the projects.
+2. Select menu CMake > Tests > Run Open Enclave SDK CTests.
 
-	VS2017 does not copy script files to the target WSL environment with the correct
-	execute permissions, so they will need to be manually granted after the initial
-	build failure.
-
-	1. Find the CMake target Linux path from the Output window, for example:
-	Build files have been written to: /var/tmp/build/ca6d6e50-e70d-c836-ac64-910bf7e68090/build/Linux-Debug
-
-	2. In a WSL console:
-	$ cd /var/tmp/src/{workspaceHash}/{Linux-Debug|Linux-Release}
-	$ sudo chmod +755 3rdparty/mbedtls/mbedtls/tests/scripts/generate_code.pl
-
-	$ cd /var/tmp/build/{workspaceHash}/build/{Linux-Debug|Linux-Release}
-	$ sudo chmod +755 3rdparty/musl/CMakeFiles/oelibc_includes.dir/build.make
-	$ sudo chmod +755 3rdparty/musl/musl/configure
-	$ sudo chmod +755 3rdparty/musl/musl/tools/install.sh
-	$ sudo chmod +755 3rdparty/libunwind/libunwind/autogen.sh
-
-3. Switch to x64-Debug-test configuration and wait for the cache to update and
-	select menu CMake > BuildAll.
-4. Now to run CTest, select menu CMake > Tests > Run openenclave tests.
-
-NOTE : Currently this Tests menu item is not directly available in
-	Visual Studio 2017 (15.6.6), some workaround is added in tests/CMakeLists.txt
-	file suggested by Microsoft.
-
-The Output window should indicate that `tests/mem` and `tests/str` were run.
 
 ### Running ctests on the command line
-For tests that have an enclave dependency, you will need to manually copy the
-enclave from the Linux build location into the same folder as the host app in
-the Windows build folder. For example, to run `tests/ecall`:
+At the x64 Native Tools command prompt do: 
 
-```
-C:\> copy C:\openenclave\build\tests\ecall\enc\ecallenc.signed
-      C:\Users\username\CMakeBuilds\build\x64-Debug\tests\ecall\host
-C:\> cd C:\Users\username\CMakeBuilds\build\x64-Debug\tests\ecall\host
-C:\> ecallhost ecallenc.signed
+```cmd
+ctest
 ```
 
-For the moment, only `tests/echo` and `tests/ecall` can be built and run on
-Windows.
-
+Simulation mode
+```cmd
+set OE_SIMULATION=1
+ctest
+```
 
 Known Issues
 ------------
-
-* Enclaves cannot be run under WSL outside of simulation mode.
-
-* Ctests fail when run under WSL even when OE_SIMULATION=1. This can be avoided by
-  running the ctests in a Linux VM.
-
-Troubleshooting
----------------
-
-### Manual install of Intel SGX PSW
-
-1. Verify that you have Windows 10 Fall Creators Update or higher installed:
-   ```
-   C:\> winver
-   ```
-   The version should be 1709 or higher. If it is not, go to Settings > Update
-   & Security > Windows Update and check for updates.
-
-2. Get the latest releases of the Intel SGX drivers from Windows Update Catalog:
-   1. Download and extract the contents of the latest [ACPI\INT0E0C package](
-     http://download.windowsupdate.com/d/msdownload/update/driver/drvs/2018/01/af564f2c-2bc5-43be-a863-437a5a0008cb_61e7ba0c2e17c87caf4d5d3cdf1f35f6be462b38.cab)
-   2. Download and extract the contents of the latest [VEN_INT&DEV_0E0C package](
-     http://download.windowsupdate.com/d/msdownload/update/driver/drvs/2018/01/6f61d533-e985-49dd-94c7-eeab74c216b7_3f45627e8b3be2f53db09b4b209cca7ec598cc4c.cab)
-
-3. Install the packages to the local driver store using [pnputil.exe](
-   https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/pnputil):
-   ```
-   C:\> Pnputil.exe /add-driver <extracted path>\sgx_psw.inf
-   C:\> Pnputil.exe /add-driver <extracted path>\sgx_base.inf /install
-   ```
-
-4. Check that the PSW successfully installed
-   ```
-   sc query aesmservice
-   ```
-   The service state should be "running" (4)
+* Samples have not yet been ported to Windows
+* Not all tests currently run on Windows. See See tests/CMakeLists for a list of supported tests.  
+* The following tests are known to fail under simulation mode
+  - tests/ecall (SEGFAULT)
+  - tests/ecall_ocall (SEGFAULT)
+  - tests/file (SEGFAULT)
+  - tests/oethread (SEGFAULT)
+  - tests/pthread (SEGFAULT)
+  - tests/threadcxx (SEGFAULT)
+  - tests/thread_local (SEGFAULT)
+  - tests/thread_local_exported (SEGFAULT)

--- a/windows/clangw/CMakeLists.txt
+++ b/windows/clangw/CMakeLists.txt
@@ -2,3 +2,4 @@
 # Licensed under the MIT License.
 
 add_executable(clangw clangw.cpp)
+add_executable(llvm-arw llvm-arw.cpp)

--- a/windows/clangw/README.md
+++ b/windows/clangw/README.md
@@ -10,6 +10,6 @@ cross-compiling since it also does not understand options like -fPIC,
 
 # llvm-arw: Wrapper for llvm-ar
 Ninja generator uses response files when the command line is long.
-However it uses / directory separator within the response files, which
-llvm-ar does not handle. llvm-arw transforms all / to \ in both command line
-as well as in repsponse files specified in the command-line.
+However it uses \ directory separator within the response files, which
+llvm-ar does not handle. llvm-arw transforms all \ to / in both command line
+as well as in response files specified in the command line.

--- a/windows/clangw/README.md
+++ b/windows/clangw/README.md
@@ -7,3 +7,9 @@ then passes them along to clang.
 It is similar to clang-cl. However clang-cl cannot be used for 
 cross-compiling since it also does not understand options like -fPIC,
 -fvisibility=hidden etc.
+
+# llvm-arw: Wrapper for llvm-ar
+Ninja generator uses response files when the command line is long.
+However it uses / directory separator within the response files, which
+llvm-ar does not handle. llvm-arw transforms all / to \ in both command line
+as well as in repsponse files specified in the command-line.

--- a/windows/clangw/clangw.cpp
+++ b/windows/clangw/clangw.cpp
@@ -38,7 +38,8 @@ static option_map _table[] = {{"/nologo", ""},
                               {"/FS", ""},
                               {"-std:c++11", "-std=c++11"},
                               {"-std:c++14", "-std=c++14"},
-                              {"-std:c++17", "-std=c++17"}};
+                              {"-std:c++17", "-std=c++17"},
+                              {"/showIncludes", ""}};
 
 static const size_t _table_size = sizeof(_table) / sizeof(_table[0]);
 

--- a/windows/clangw/llvm-arw.cpp
+++ b/windows/clangw/llvm-arw.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 #include <stdio.h>
 #include <stdlib.h>
+#include <algorithm>
 #include <string>
 
 int main(int argc, char** argv)
@@ -12,11 +12,8 @@ int main(int argc, char** argv)
     for (int i = 1; i < argc; ++i)
     {
         std::string arg = argv[i];
-        for (size_t c = 0; c < arg.size(); ++c)
-        {
-            if (arg[c] == '\\')
-                arg[c] = '/';
-        }
+        std::replace(arg.begin(), arg.end(), '\\', '/');
+
         // If a response file is specified, transform slashes
         // within the response file.
         if (arg[0] == '@')

--- a/windows/clangw/llvm-arw.cpp
+++ b/windows/clangw/llvm-arw.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+
+int main(int argc, char** argv)
+{
+    // Loop through each argument and transform \ to /.
+    std::string cmd = "llvm-ar";
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        for (size_t c = 0; c < arg.size(); ++c)
+        {
+            if (arg[c] == '\\')
+                arg[c] = '/';
+        }
+        // If a response file is specified, transform slashes
+        // within the response file.
+        if (arg[0] == '@')
+        {
+            // Fix up directory separators in the response file
+            std::string fixup = "bash -c \"sed -i 's/\\\\\\\\/\\//g' ";
+            fixup += arg.substr(1) + "\"";
+            printf("cmd = %s\n", fixup.c_str());
+            system(fixup.c_str());
+        }
+        cmd += " ";
+        cmd += arg;
+    }
+    // Call llvm-ar
+    return system(cmd.c_str());
+}


### PR DESCRIPTION
1. llvm-arw wraps llvm-ar in order to handle / characters
within response files. Ninja generator uses response files
for long command-lines.
2. Add x64-Debug, x64-Release and x64-RelWithDebInfo Visual Studio
  configurations. Any of these can be used to build OE SDK from
  within Visual Studio via Open Folder. All supported
  tests can also be run via CMake->Tests->Run
3. Removed invalid x86  configuration since we support only 64 bit builds.
4. Map /showIncludes to null in clangw
5. Bump down required CMake version to 3.12 since that is the version
  that Visual Studio supports. Visual Studio has it's own cmake
  binary and does not use any other installed cmake.