### PR TITLE
Fixed broken Jenkins file - Added back -d switch to disable simulator mode for CI tests on hardware

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -16,7 +16,7 @@ def ACCTest(String label, String compiler, String unit, String suite) {
             checkout scm
 
             timeout(15) {
-                sh "./scripts/test-build-config -p $unit -b $suite --compiler=$compiler -d"
+                sh "./scripts/test-build-config -p $unit -b $suite --compiler=$compiler --disable_sim"
             }
 
         }
@@ -49,7 +49,7 @@ def ACCContainerTest(String label) {
             docker.withRegistry(OETOOLS_REPO, OETOOLS_REPO_CREDENTIAL_ID) {
                 docker.image(OETOOLS_IMAGE).inside('--privileged -v /dev/sgx:/dev/sgx') {
                     timeout(15) {
-                        sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d'
+                        sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo --disable_sim'
                     }
                 }
             }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -16,7 +16,7 @@ def ACCTest(String label, String compiler, String unit, String suite) {
             checkout scm
 
             timeout(15) {
-                sh "./scripts/test-build-config -p $unit -b $suite --compiler=$compiler"
+                sh "./scripts/test-build-config -p $unit -b $suite --compiler=$compiler -d"
             }
 
         }


### PR DESCRIPTION
Noticed that all the ACCTests on hardware were being run in simulator mode for the past month. Root-caused this to the -d switch to test-build-config to disable simulator mode being dropped in the Jenkins file with the following checkin:  
Change Jenkinsfile to scripted
https://github.com/Microsoft/openenclave/commit/c5e4cfa2abe108f10c88f4c558c0dc03f81c44a9#diff-9b83915ce4a53a5b3cc01b9f39d6a984

- Added the switch to disable simulator mode for the ACCTest function to enable all the tests to run in hardware mode instead of simulator mode.
- Converted -d switch to the long form version --disable_sim switch for clarity and prevention of accidental removal in the future. Did this for the ACCTest and ACCContainerTest functions.