### PR TITLE
Set `USE_LIBSGX` to ON by default, instead of OFF

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -89,15 +89,11 @@ def checkPreCommitRequirements() {
                     sh './scripts/check-ci'
                     // installed by our install-prereqs script.
 
-                    // We actually expect `ctest` to fail because it is an
-                    // older version that emits a failure if any tests are
-                    // skipped. In other stages, we explicitly install an
-                    // updated version of CMake.
                     dir('build') {
                         sh '''
-                        cmake ..
+                        cmake .. -DUSE_LIBSGX=OFF
                         make
-                        OE_SIMULATION=1 ctest --verbose --output-on-failure || true
+                        OE_SIMULATION=1 ctest --verbose --output-on-failure
                     '''
                         // Note that `make package` is not expected to work
                         // without extra configuration.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,9 +104,14 @@ include(package_settings)
 include(add_enclave)
 
 # User configurable options
-option(USE_LIBSGX "Build oehost using SGX library requiring FLC" OFF)
+if (UNIX)
+  option(USE_LIBSGX "Build oehost using SGX library requiring FLC" ON)
+elseif (WIN32)
+  option(USE_LIBSGX "Build oehost using SGX library requiring FLC" OFF)
+endif ()
+
 if (USE_LIBSGX AND WIN32)
-  message(FATAL_ERROR "USE_LIBSGX is not supported on Windows. Disable this when calling cmake with -DUSE_LIBSGX=OFF")
+  message(FATAL_ERROR "USE_LIBSGX is not yet supported on Windows.")
 endif ()
 
 # TODO: See #756: Fix this because it is incompatible with


### PR DESCRIPTION
Now that we will correctly error at configuration time if the libraries
are not found, it is safe to default this to ON instead of OFF, and this
is much more user friendly given the availability of ACC.