### PR TITLE
Added ntohl and ntohs object files to to the static C library.

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -445,6 +445,8 @@ add_library(oelibc STATIC
     ${MUSLSRC}/multibyte/wcstombs.c
     ${MUSLSRC}/multibyte/wctob.c
     ${MUSLSRC}/multibyte/wctomb.c
+    ${MUSLSRC}/network/ntohl.c
+    ${MUSLSRC}/network/ntohs.c
     ${MUSLSRC}/prng/drand48.c
     ${MUSLSRC}/prng/lcong48.c
     ${MUSLSRC}/prng/lrand48.c


### PR DESCRIPTION
The ntohl and ntohs functions exist on the header files, but the symbols do not exist on liboelibc.a.