### PR TITLE
Added installation of oeegr8r include to install rule

### DIFF
--- a/tools/oeedger8r/CMakeLists.txt
+++ b/tools/oeedger8r/CMakeLists.txt
@@ -74,3 +74,4 @@ add_custom_target(oeedger8r ALL DEPENDS ${BINARY})
 
 # install rule
 install (PROGRAMS ${BINARY} DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../include/openenclave/edger8r DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)


### PR DESCRIPTION
addresses #1290

Currently we are not installing oeedgr8r includes into /opt/openenclave/include/openenclave/oeedgr8r. Samples and other builds using the oeedgr8r will build within the build tree, but not outside. 