### PR TITLE
Added new ansible playbooks for different scenarios.

### DIFF
--- a/scripts/ansible/ansible-dockerfile.yml
+++ b/scripts/ansible/ansible-dockerfile.yml
@@ -7,3 +7,4 @@
   - include_tasks: tasks/ansible-install-docker-packages.yml
   - include_tasks: tasks/ansible-install-prereqs.yml
   - include_tasks: tasks/ansible-install-openenclave-deps.yml
+  - include_tasks: tasks/ansible-install-sgx-packages.yml

--- a/scripts/ansible/deploy_jenkins.yml
+++ b/scripts/ansible/deploy_jenkins.yml
@@ -10,6 +10,7 @@
      - include_tasks: tasks/ansible-install-prereqs.yml
      - include_tasks: tasks/ansible-install-openenclave-deps.yml
      - include_tasks: tasks/ansible-install-sgx-driver.yml
+     - include_tasks: tasks/ansible-install-sgx-packages.yml
 
      - name: Install jre needed by Jenkins
        apt: name{{item}} state=present update_cache=yes

--- a/scripts/ansible/deploy_vanilla.yml
+++ b/scripts/ansible/deploy_vanilla.yml
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+- hosts: localhost
+  any_errors_fatal: true
+  tasks:
+     - include_tasks: tasks/ansible-install-prereqs.yml
+     - include_tasks: tasks/ansible-install-openenclave-deps.yml
+     - include_tasks: tasks/ansible-install-sgx-driver.yml
+     - include_tasks: tasks/ansible-install-sgx-packages.yml
+     - include_tasks: tasks/ansible-install-openenclave.yml

--- a/scripts/ansible/deploy_vanilla_to_prelibsgx_state.yml
+++ b/scripts/ansible/deploy_vanilla_to_prelibsgx_state.yml
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+- hosts: localhost
+  any_errors_fatal: true
+  tasks:
+     - include_tasks: tasks/ansible-install-prereqs.yml
+     - include_tasks: tasks/ansible-install-openenclave-deps.yml

--- a/scripts/ansible/tasks/ansible-install-openenclave-deps.yml
+++ b/scripts/ansible/tasks/ansible-install-openenclave-deps.yml
@@ -1,17 +1,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 ---
-- name: Add repo keys
+- name: Add LLVM and Microsoft APT repo keys
   apt_key: url={{item}} state=present
   with_items:
-    - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key
     - https://apt.llvm.org/llvm-snapshot.gpg.key
     - https://packages.microsoft.com/keys/microsoft.asc
 
-- name: Add repositories for openenclave
+- name: Add LLVM and Microsoft APT repositories
   apt_repository: repo={{item}} state=present update_cache=yes
   with_items:
-    - deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu xenial main
     - deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main
     - deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/prod xenial main
 
@@ -25,10 +23,6 @@
       gdb,
       g++,
       pkg-config,
-      libsgx-enclave-common,
-      libsgx-enclave-common-dev,
-      libsgx-dcap-ql,
-      libsgx-dcap-ql-dev,
       az-dcap-client
     ]
     state: present

--- a/scripts/ansible/tasks/ansible-install-sgx-packages.yml
+++ b/scripts/ansible/tasks/ansible-install-sgx-packages.yml
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+---
+- name: Add 01.org repo key
+  apt_key: url={{item}} state=present
+  with_items:
+    - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key
+
+- name: Add 01.org repository
+  apt_repository: repo={{item}} state=present update_cache=yes
+  with_items:
+    - deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu xenial main
+
+- name: Install libsgx packages
+  apt:
+    name: [
+      libsgx-enclave-common,
+      libsgx-enclave-common-dev,
+      libsgx-dcap-ql,
+      libsgx-dcap-ql-dev
+    ]
+    state: present
+    update_cache: yes


### PR DESCRIPTION
I've added two ansible playbooks in this PR:

1. One scenario for deploying everything for development on a vanilla ACC VM (which is similar to the Jenkins deploy playbook, but without docker and java and the users, but with the open-enclave package). (deploy_vanilla.yml)
2. One scenario for deploying everything as above, except for the intel packages/driver and the open-enclave package. (deploy_vanilla_to_prelibsgx_state.yml)

The first scenario may be picked up by the oe-engine provision scripts, depending on what @dmitsh thinks.
The second scenario will be used for integration testing.

This PR also splits one ansible task into two different tasks, so as to allow for installation of the prerequisites without installing the libsgx prerequisites.

