### PR TITLE
Improve Ansible prereq setup for OE

### DIFF
--- a/docs/GettingStartedDocs/SimulatorGettingStarted.md
+++ b/docs/GettingStartedDocs/SimulatorGettingStarted.md
@@ -6,22 +6,27 @@
 
 ## Clone Open Enclave SDK repo from GitHub
 
-Use the following command to download the source code.
+Use the following command to download the source code and set the current directory to it.
 
 ```bash
 git clone https://github.com/Microsoft/openenclave.git
+cd openenclave
 ```
 
 This creates a source tree under the directory called openenclave.
 
 ## Install project prerequisites
 
-Ansible is required to install the project prerequisites. If not already installed, you can install it by running: `scripts/ansible/install-ansible.sh`
-The ansible-playbook [scripts/ansible/ansible-include_task.yml](/scripts/ansible/ansible-include_task.yml) was created to be able to run pre-defined ansible tasks on a target host. All the tasks required to install the prerequisites can be found in the following ansible task list : [scripts/ansible/tasks/ansible-install-prereqs.yml](/scripts/ansible/tasks/ansible-install-prereqs.yml) To make installing the prerequisites less tedious execute the following commands from the root of the source tree:
+Ansible is required to install the project prerequisites. You can install it by running:
+```bash
+sudo ./scripts/ansible/install-ansible.sh
+```
+
+The ansible-playbook [scripts/ansible/ansible-include_task.yml](/scripts/ansible/ansible-include_task.yml) was created to be able to run pre-defined ansible tasks on a target host. To make installing the prerequisites less tedious execute the following commands from the root of the source tree:
 
 ```bash
-cd openenclave
 ansible-playbook scripts/ansible/ansible-include_task.yml --extra-vars "target=localhost included_task=tasks/ansible-install-prereqs.yml"
+ansible-playbook scripts/ansible/ansible-include_task.yml --extra-vars "target=localhost included_task=tasks/ansible-install-openenclave-deps.yml"
 ```
 
 ## Build
@@ -39,6 +44,8 @@ Then run `cmake` to configure the build and generate the make files and build:
 cmake ..
 make
 ```
+
+If you want to compile in parallel you can use the -j argument for make (i.e. `make -j`).
 
 Refer to the [Advanced Build Information](AdvancedBuildInfo.md) documentation for further information.
 

--- a/scripts/ansible/install-ansible.sh
+++ b/scripts/ansible/install-ansible.sh
@@ -3,9 +3,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+set -o errexit
+
+DIR=$(dirname "$0")
+
 apt-get update
-apt-get install -y software-properties-common
-apt-add-repository ppa:ansible/ansible
-apt-get update
-apt-get install -y ansible
-apt-get clean
+apt-get install libssl-dev libffi-dev python3-pip -y
+pip3 install -U -r "$DIR/requirements.txt"

--- a/scripts/ansible/remove-ansible.sh
+++ b/scripts/ansible/remove-ansible.sh
@@ -3,6 +3,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-apt-get purge --auto-remove -y \
-    ansible \
-    software-properties-common
+set -o errexit
+
+DIR=$(dirname "$0")
+
+apt-get update
+apt-get install python3-pip -y
+pip3 uninstall -r "$DIR/requirements.txt" -y


### PR DESCRIPTION
* Update the `SimulatorGettingStarted.md` doc
* Use the existing `requirements.txt` file for Ansible when
  installing / removing the tool into `install-ansible.sh` or
  `remove-ansible.sh` bash scripts