### PR TITLE
Compile samples with debug symbols

### DIFF
--- a/samples/data-sealing/enc1/Makefile
+++ b/samples/data-sealing/enc1/Makefile
@@ -28,8 +28,8 @@ all:
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../datasealing.edl --trusted  --trusted-dir ../common
-	$(CXX) -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/dispatcher.cpp ../common/keys.cpp
-	$(CC) -c $(CFLAGS) $(CINCLUDES) ../common/datasealing_t.c
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/dispatcher.cpp ../common/keys.cpp
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) ../common/datasealing_t.c
 	$(CXX) -o enclave_a_v1 ecalls.o dispatcher.o keys.o datasealing_t.o $(LDFLAGS)
 
 sign:

--- a/samples/data-sealing/enc2/Makefile
+++ b/samples/data-sealing/enc2/Makefile
@@ -27,8 +27,8 @@ all:
 build:
 	cp ../enc1/private.pem .
 	@ echo "Compilers used: $(CC), $(CXX)"
-	$(CXX) -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/dispatcher.cpp ../common/keys.cpp
-	$(CC) -c $(CFLAGS) $(CINCLUDES) ../common/datasealing_t.c
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/dispatcher.cpp ../common/keys.cpp
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) ../common/datasealing_t.c
 	$(CXX) -o enclave_a_v2 ecalls.o dispatcher.o keys.o datasealing_t.o $(LDFLAGS)
 
 sign:

--- a/samples/data-sealing/enc3/Makefile
+++ b/samples/data-sealing/enc3/Makefile
@@ -27,8 +27,8 @@ all:
 
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
-	$(CXX) -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/dispatcher.cpp ../common/keys.cpp
-	$(CC) -c $(CFLAGS) $(CINCLUDES) ../common/datasealing_t.c
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/dispatcher.cpp ../common/keys.cpp
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) ../common/datasealing_t.c
 	$(CXX) -o enclave_b ecalls.o dispatcher.o keys.o datasealing_t.o $(LDFLAGS)	
 
 sign:

--- a/samples/data-sealing/host/Makefile
+++ b/samples/data-sealing/host/Makefile
@@ -26,8 +26,8 @@ all: build
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../datasealing.edl --untrusted
-	$(CXX) -c $(CXXFLAGS) $(INCLUDES) host.cpp
-	$(CC) -c $(CFLAGS) $(CINCLUDES) datasealing_u.c 
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) host.cpp
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) datasealing_u.c
 	$(CXX) -o data-sealing_host host.o datasealing_u.o $(LDFLAGS)
 
 clean:

--- a/samples/file-encryptor/enc/Makefile
+++ b/samples/file-encryptor/enc/Makefile
@@ -28,8 +28,8 @@ all:
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../fileencryptor.edl --trusted
-	$(CXX) -c $(CXXFLAGS) -std=c++11 ecalls.cpp encryptor.cpp keys.cpp
-	$(CC) -c $(CFLAGS) fileencryptor_t.c -o fileencryptor_t.o
+	$(CXX) -g -c $(CXXFLAGS) -std=c++11 ecalls.cpp encryptor.cpp keys.cpp
+	$(CC) -g -c $(CFLAGS) fileencryptor_t.c -o fileencryptor_t.o
 	$(CXX) -o file-encryptorenc ecalls.o encryptor.o keys.o fileencryptor_t.o $(LDFLAGS)
 
 sign:

--- a/samples/file-encryptor/host/Makefile
+++ b/samples/file-encryptor/host/Makefile
@@ -25,8 +25,8 @@ all: build
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../fileencryptor.edl --untrusted
-	$(CXX) -c $(CXXFLAGS) host.cpp
-	$(CC) -c $(CFLAGS) fileencryptor_u.c
+	$(CXX) -g -c $(CXXFLAGS) host.cpp
+	$(CC) -g -c $(CFLAGS) fileencryptor_u.c
 	$(CXX) -o file-encryptorhost host.o fileencryptor_u.o $(LDFLAGS)
 
 clean:

--- a/samples/helloworld/enc/Makefile
+++ b/samples/helloworld/enc/Makefile
@@ -25,8 +25,8 @@ all:
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../helloworld.edl --trusted
-	$(CC) -c $(CFLAGS) enc.c -o enc.o
-	$(CC) -c $(CFLAGS) helloworld_t.c -o helloworld_t.o
+	$(CC) -g -c $(CFLAGS) enc.c -o enc.o
+	$(CC) -g -c $(CFLAGS) helloworld_t.c -o helloworld_t.o
 	$(CC) -o helloworldenc helloworld_t.o enc.o $(LDFLAGS)
 
 sign:

--- a/samples/helloworld/host/Makefile
+++ b/samples/helloworld/host/Makefile
@@ -20,8 +20,8 @@ LDFLAGS=$(shell pkg-config oehost-$(COMPILER) --libs)
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../helloworld.edl --untrusted
-	$(CC) -c $(CFLAGS) host.c
-	$(CC) -c $(CFLAGS) helloworld_u.c
+	$(CC) -g -c $(CFLAGS) host.c
+	$(CC) -g -c $(CFLAGS) helloworld_u.c
 	$(CC) -o helloworldhost helloworld_u.o host.o $(LDFLAGS)
 
 clean:

--- a/samples/local_attestation/enc1/Makefile
+++ b/samples/local_attestation/enc1/Makefile
@@ -48,7 +48,7 @@ build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../localattestation.edl --trusted --trusted-dir ../common
 	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
-	$(CC) -c $(CFLAGS) $(CINCLUDES) ../common/localattestation_t.c	
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) ../common/localattestation_t.c
 	$(CXX) -o enclave1 attestation.o crypto.o ecalls.o dispatcher.o localattestation_t.o $(LDFLAGS)
 
 sign:

--- a/samples/local_attestation/enc2/Makefile
+++ b/samples/local_attestation/enc2/Makefile
@@ -48,7 +48,7 @@ build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../localattestation.edl --trusted --trusted-dir ../common
 	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
-	$(CC) -c $(CFLAGS) $(CINCLUDES) ../common/localattestation_t.c
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) ../common/localattestation_t.c
 	$(CXX) -o enclave2 attestation.o crypto.o ecalls.o dispatcher.o localattestation_t.o $(LDFLAGS)
 
 sign:

--- a/samples/local_attestation/host/Makefile
+++ b/samples/local_attestation/host/Makefile
@@ -25,8 +25,8 @@ all: build
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../localattestation.edl --untrusted
-	$(CC) -c $(CFLAGS) $(CINCLUDES) localattestation_u.c 
-	$(CXX) -c $(CXXFLAGS) $(INCLUDES) host.cpp
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) localattestation_u.c
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) host.cpp
 	$(CXX) -o attestation_host host.o localattestation_u.o $(LDFLAGS)
 
 clean:

--- a/samples/remote_attestation/enc1/Makefile
+++ b/samples/remote_attestation/enc1/Makefile
@@ -48,7 +48,7 @@ build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../remoteattestation.edl --trusted --trusted-dir ../common
 	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
-	$(CC) -c $(CFLAGS) $(CINCLUDES) ../common/remoteattestation_t.c
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) ../common/remoteattestation_t.c
 	$(CXX) -o enclave1 attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS)
 
 sign:

--- a/samples/remote_attestation/enc2/Makefile
+++ b/samples/remote_attestation/enc2/Makefile
@@ -47,7 +47,7 @@ genkey: public.pem
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
-	$(CC) -c $(CFLAGS) $(CINCLUDES) ../common/remoteattestation_t.c
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) ../common/remoteattestation_t.c
 	$(CXX) -o enclave2 attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS) 
 
 sign:

--- a/samples/remote_attestation/host/Makefile
+++ b/samples/remote_attestation/host/Makefile
@@ -25,8 +25,8 @@ all: build
 build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	oeedger8r ../remoteattestation.edl --untrusted
-	$(CC) -c $(CFLAGS) $(CINCLUDES) remoteattestation_u.c 
-	$(CXX) -c $(CXXFLAGS) $(INCLUDES) host.cpp
+	$(CC) -g -c $(CFLAGS) $(CINCLUDES) remoteattestation_u.c
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) host.cpp
 	$(CXX) -o attestation_host host.o remoteattestation_u.o $(LDFLAGS)
 
 clean:


### PR DESCRIPTION
Add '-g' option to all CC/CXX compiling calls.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>

Addresses: https://github.com/Microsoft/openenclave/issues/1139
