### PR TITLE
Fix cmake documentation to reflect USE_LIBSGX is now on by default

### DIFF
--- a/docs/GettingStartedDocs/SGX1FLCGettingStarted.md
+++ b/docs/GettingStartedDocs/SGX1FLCGettingStarted.md
@@ -58,7 +58,7 @@ cd build/
 Then run `cmake` to configure the build and generate the make files and build:
 
 ```bash
-cmake .. -DUSE_LIBSGX=1
+cmake ..
 make
 ```
 

--- a/docs/GettingStartedDocs/SGX1GettingStarted.md
+++ b/docs/GettingStartedDocs/SGX1GettingStarted.md
@@ -63,7 +63,7 @@ cd build/
 Then run `cmake` to configure the build and generate the make files and build:
 
 ```bash
-cmake ..
+cmake -DUSE_LIBSGX=OFF ..
 make
 ```
 

--- a/docs/GettingStartedDocs/SimulatorGettingStarted.md
+++ b/docs/GettingStartedDocs/SimulatorGettingStarted.md
@@ -36,7 +36,7 @@ cd build/
 Then run `cmake` to configure the build and generate the make files and build:
 
 ```bash
-cmake ..
+cmake -DUSE_LIBSGX=OFF ..
 make
 ```
 


### PR DESCRIPTION
Fix cmake documentation to reflect USE_LIBSGX is now on by default. It needs to be set to OFF for simulation and SGX1(without FLC)