### PR TITLE
Fix for correctly throwing std::bad_alloc

### DIFF
--- a/3rdparty/libcxxrt/README.md
+++ b/3rdparty/libcxxrt/README.md
@@ -1,0 +1,6 @@
+This README lists the set of changes made to the libcxxrt library.
+When upgrading the library, make sure to preserve the following changes.
+
+1. exception.cc: Use oe_thread_data_t's __cxx_thread_info instead of
+    calloc-ing it on demand. This prevents crashes when an std::bad_alloc
+	is thrown.

--- a/tests/stdcxx/enc/enc.cpp
+++ b/tests/stdcxx/enc/enc.cpp
@@ -193,6 +193,33 @@ int enc_test(bool* caught, bool* dynamic_cast_works, size_t* n_constructions)
 
     *n_constructions = num_constructions;
 
+    /* Test std::bad_alloc */
+    {
+        bool bad_alloc_caught = false;
+        std::vector<int*> ptrs;
+        while (true)
+        {
+            try
+            {
+                int* p = new int[64];
+                ptrs.push_back(p);
+            }
+            catch (std::bad_alloc)
+            {
+                bad_alloc_caught = true;
+                printf("std::bad_alloc caught\n");
+                break;
+            }
+        }
+        while (!ptrs.empty())
+        {
+            delete ptrs.back();
+            ptrs.pop_back();
+        }
+
+        OE_TEST(bad_alloc_caught == true);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
LLVM's exception.cc uses calloc to create the thread_info structure
to maintain the state. If the enclave has run out of memory and the
first exception being thrown is std::bad_alloc, then the calloc to
create thread_info would itself fail resulting in a SEGV when the
thread_info is later used. The fix is to use a predefined block
of memory reserved in the oe_thread_data_t structure.
Note: Intel SDK uses a similar strategy.

Locked down std::bad_alloc with a test.

Added README.md for catalog modifications to libcxxrt.