### PR TITLE
Enable building enclaves by default on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,8 @@ endif()
 
 if (OE_SGX)
   if (WIN32)
-    # Building enclaves on windows is off by default
-    option(BUILD_ENCLAVES "Build ELF enclaves" OFF)
+    # Building enclaves on windows is on by default but can be disabled for enclaves pre-compiled under linux
+    option(BUILD_ENCLAVES "Build ELF enclaves" ON)
   else()
     set(BUILD_ENCLAVES ON)
   endif()


### PR DESCRIPTION
changed default value of BUILD_ENCLAVES in CMake system to default to building enclaves

This PR fixes issue #1292