### PR TITLE
Fix mbed testcase file searching

### DIFF
--- a/tests/mbed/host/CMakeLists.txt
+++ b/tests/mbed/host/CMakeLists.txt
@@ -6,6 +6,7 @@ oeedl_file(../mbed.edl host gen)
 
 add_executable(libmbedtest_host host.c ocalls.c ${gen})
 
+target_compile_definitions(libmbedtest_host PRIVATE PROJECT_DIR="${CMAKE_SOURCE_DIR}/")
 target_compile_options(libmbedtest_host PRIVATE -Wno-error)
 
 target_include_directories(libmbedtest_host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/mbed/host/host.c
+++ b/tests/mbed/host/host.c
@@ -37,6 +37,9 @@ char* find_data_file(char* str, size_t size)
 void datafileloc(char* data_file_name, char* path)
 {
     char* tail = "3rdparty/mbedtls/mbedtls/tests/suites/";
+#ifdef PROJECT_DIR
+    strcpy(path, PROJECT_DIR);
+#else
     char* separator;
 
     if (getcwd(path, 1024) != NULL)
@@ -51,6 +54,7 @@ void datafileloc(char* data_file_name, char* path)
     }
 
     *separator = '\0'; /* separating string */
+#endif
     strcat(path, tail);
     strcat(path, data_file_name);
 


### PR DESCRIPTION
Mbed tests require test data file input.

Those files are in
<location_to_clone_repo>/3rdparty/mbedtls/mbedtls/tests/suites/

Add a compile define (PROJECT_DIR) which will be used
when adding test cases for mbed.

That define points to CMAKE_SOURCE_DIR.

Signed-off-by: Alin Gabriel Serdean aserdean@ovn.org
Fixes: #1145