### PR TITLE
Port pre-commit scripts to Windows

### DIFF
--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -24,6 +24,8 @@ Windows.
 - [Git for Windows 64-bit](https://git-scm.com/download/win)
 - [clang (preferably version 7.0 or above)](http://releases.llvm.org/download.html)  
 - [OCaml for Windows 64-bit](https://www.ocamlpro.com/pub/ocpwin/ocpwin-builds/ocpwin64/20160113/) (Please download and install the mingw64 exe for OCaml)
+- [LLVM for Windows 64-bit](http://releases.llvm.org/7.0.1/LLVM-7.0.1-win64.exe)
+- [shellcheck for Windows](https://storage.googleapis.com/shellcheck/shellcheck-stable.zip)
 
 Intel® SGX Platform Software for Windows (PSW)
 ---------------------------------

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -159,6 +159,7 @@ check_clang-format()
             echo "clang-format is not installed. Please run scripts/install-prereqs first."
             exit 1
         fi
+        cf="clang-format"
     fi
 
     local required_cfver='7.0.1'

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -148,10 +148,11 @@ check_version()
 ##==============================================================================
 check_clang-format()
 {
-    # First check explicitly for the 3.8 executable.
+    # First check explicitly for the clang-format-7 executable.
     cf=$(command -v clang-format-7 2> /dev/null)
 
     if [[ -x ${cf} ]]; then
+        cf="clang-format-7"
         return
     else
         cf=$(command -v clang-format 2> /dev/null)


### PR DESCRIPTION
This PR fixes #1285 and introduces the following changes:

- Update the Getting Started Guide for Windows with LLVM and shellcheck prerequisites
- Use the clang-format binary from PATH, so the script is compatible with both Linux and Windows