### PR TITLE
Fix format-code script

### DIFF
--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -265,8 +265,7 @@ done:
               MEM_COMMIT | MEM_RESERVE,
               PAGE_EXECUTE_READWRITE)))
     {
-        OE_TRACE_ERROR(
-            "VirtualAlloc failed enclave_size=0x%lx", enclave_size);
+        OE_TRACE_ERROR("VirtualAlloc failed enclave_size=0x%lx", enclave_size);
         goto done;
     }
 
@@ -731,9 +730,7 @@ oe_result_t oe_sgx_load_enclave_data(
 
             if ((uint32_t)prot > OE_INT_MAX)
                 OE_RAISE_MSG(
-                    OE_FAILURE,
-                    "Unexpected page protections: %#x",
-                    prot);
+                    OE_FAILURE, "Unexpected page protections: %#x", prot);
 
 #if defined(__linux__)
             if (mprotect((void*)addr, OE_PAGE_SIZE, prot) != 0)

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -183,26 +183,26 @@ get_find_args()
     local defaultIncludeExts='h c cpp'
 
     if [[ -z ${userExcludeDirs} ]]; then
-        local excludeDirs=( "${defaultExcludeDirs}" )
+        local excludeDirs=( ${defaultExcludeDirs} )
     else
         log_verbose "Using user directory exclusions: ${userExcludeDirs}"
-        local excludeDirs=( "${userExcludeDirs}" )
+        local excludeDirs=( ${userExcludeDirs} )
     fi
 
     for exc in "${excludeDirs[@]}"
     do
-        findargs="${findargs} ! ( -path ./${exc} -prune )"
+        findargs="${findargs} ! \( -path ./${exc} -prune \)"
     done
 
     if [[ -z ${userIncludeExts} ]]; then
         # not local as this is used in get_file_list() too
-        includeExts=( "${defaultIncludeExts}" )
+        includeExts=( ${defaultIncludeExts} )
     else
         log_verbose "Using user extension inclusions: ${userIncludeExts}"
-        includeExts=( "${userIncludeExts}" )
+        includeExts=( ${userIncludeExts} )
     fi
 
-    findargs="${findargs} ("
+    findargs="${findargs} \("
     for ((i=0; i<${#includeExts[@]}; i++));
     do
         findargs="${findargs} -iname '*.${includeExts[$i]}'"
@@ -210,7 +210,7 @@ get_find_args()
             findargs="${findargs} -o"
         fi
     done
-    findargs="${findargs} )"
+    findargs="${findargs} \)"
 }
 
 get_find_args
@@ -236,10 +236,14 @@ fi
 get_file_list()
 {
     if [[ -z ${userFiles} ]]; then
-        mapfile -t file_list < <("$findargs")
+        mapfile -t file_list < <(eval "$findargs")
+        if [[ ${#file_list[@]} -eq 0 ]]; then
+            echo "No files were found to format!"
+            exit 1
+        fi
     else
         log_verbose "Using user files: ${userFiles}"
-        local user_file_list=( "${userFiles}" )
+        local user_file_list=( ${userFiles} )
         file_list=()
         for file in "${user_file_list[@]}"; do
             for ext in "${includeExts[@]}"; do

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -4,35 +4,33 @@
 # Licensed under the MIT License.
 
 set -o errexit
-set -o pipefail
 
 scripts=$(git rev-parse --show-toplevel)/scripts
 mapfile -t files < <(git diff --cached --name-only)
 
-info() {
+exit_() {
     echo "This hook can be skipped if needed with 'git commit --no-verify'"
     echo "See '.git/hooks/pre-commit', installed from 'scripts/pre-commit'"
+    exit 1
 }
-
-trap info EXIT
 
 # shellcheck disable=SC2154
 if "$scripts/format-code" --whatif --files="${files[*]}" | grep -q "@@"; then
     echo "Commit failed: please run './scripts/format-code' to fix the formatting"
-    exit 1
+    exit_
 fi
 
 if ! "$scripts/check-license" "${files[@]}"; then
     echo "Commit failed: please add license headers to the above files"
-    exit 1
+    exit_
 fi
 
 if ! "$scripts/check-linters" "${files[@]}"; then
     echo "Commit failed: please run './scripts/check-linters' and fix the warnings"
-    exit 1
+    exit_
 fi
 
 if ! git diff-index --check --cached HEAD --; then
     echo "Commit failed: please fix the conflict markers or whitespace errors"
-    exit 1
+    exit_
 fi

--- a/tests/libcxx/enc/enc.cpp
+++ b/tests/libcxx/enc/enc.cpp
@@ -268,7 +268,8 @@ int enc_test(char test_name[STRLEN])
                                         .join = _pthread_join_hook,
                                         .detach = _pthread_detach_hook};
     static const char* argv[] = {
-        "test", NULL,
+        "test",
+        NULL,
     };
     static const int argc = sizeof(argv) / sizeof(argv[0]);
 


### PR DESCRIPTION
My bad. I've reverted some changes made to shush ShellCheck on newer systems that inadvertently (and silently) broke `format-code`. It's now fixed and working both stand-alone as part of the pre-commit hook. Thanks for spotting this @CodeMonkeyLeet.