### PR TITLE
Update path in getting started doc using_oe_sdk

### DIFF
--- a/docs/GettingStartedDocs/using_oe_sdk.md
+++ b/docs/GettingStartedDocs/using_oe_sdk.md
@@ -27,7 +27,7 @@ For ease of development, we recommend adding:
 You can do this by sourcing the openenclaverc file that is distributed with the SDK:
 
 ```bash
-source /opt/openenclave/share/openenclave/openenclaverc
+source /opt/openenclave/share/openenclaverc
 ```
 
 ## Samples


### PR DESCRIPTION
Just tried to do a clean install of oe-sdk and noticed this path in the documentation isn't up to date with the package contents