### PR TITLE
CMake - Use top level directory in tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 include(oeedl_file)
+include(${PROJECT_SOURCE_DIR}/cmake/get_testcase_name.cmake)
 
 option(ENABLE_FULL_LIBCXX_TESTS "Build all libcxx tests and include in test list" OFF)
 

--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -1,9 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# add a test-case for each file listed in tests.supported
-include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/get_testcase_name.cmake)
-
 # read tests.supported, sanitize the cpp-file, and create the test-case
 if (ENABLE_FULL_LIBCXX_TESTS)
     file(STRINGS "tests.supported" alltests)

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 oeedl_file(../libcxx.edl enclave gen)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/get_testcase_name.cmake)
-
 # helper lib to contain file needed by some tests
 add_library(libcxxtest-support
     enc.cpp

--- a/tests/libcxxrt/CMakeLists.txt
+++ b/tests/libcxxrt/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# add a test-case for each file listed in tests.supported
-include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/get_testcase_name.cmake)
-
-
 add_subdirectory(host)
 
 if(BUILD_ENCLAVES)

--- a/tests/libcxxrt/enc/CMakeLists.txt
+++ b/tests/libcxxrt/enc/CMakeLists.txt
@@ -2,10 +2,6 @@
 # Licensed under the MIT License.
 
 
-# create a binary for each testcase listed in ../tests.supported
-
-include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/get_testcase_name.cmake)
-
 oeedl_file(../libcxxrt.edl enclave gen)
 
 # helper lib to contain file needed by some tests

--- a/tests/libunwind/CMakeLists.txt
+++ b/tests/libunwind/CMakeLists.txt
@@ -1,9 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# add a test-case for each file listed in tests.supported
-include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/get_testcase_name.cmake)
-
 # read tests.supported, sanitize the c-file, and create the test-case
 file(STRINGS "tests.supported" alltests)
 add_subdirectory(host)

--- a/tests/libunwind/enc/CMakeLists.txt
+++ b/tests/libunwind/enc/CMakeLists.txt
@@ -6,8 +6,6 @@
 # Disabling warning-as-errors for the specific warnings is painful across multiple different compilers.
 # It was agreed to, that it is best to just disable warnings-as-errors for these tests specifically.
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/get_testcase_name.cmake)
-
 oeedl_file(../libunwind.edl enclave gen)
 
 set(LIBUNWIND_TEST_DIR ${PROJECT_SOURCE_DIR}/3rdparty/libunwind/libunwind/tests)

--- a/tests/mbed/CMakeLists.txt
+++ b/tests/mbed/CMakeLists.txt
@@ -1,9 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# add a test-case for each file listed in tests.supported
-include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/get_testcase_name.cmake)
-
 # read tests.supported, sanitize the cpp-file, and create the test-case
 file(STRINGS "tests.supported" alltests)
 

--- a/tests/mbed/enc/CMakeLists.txt
+++ b/tests/mbed/enc/CMakeLists.txt
@@ -4,8 +4,6 @@
 # >> In one of the test "ssl" we are using a variable called new which is a function in C++
 #    causes improper behaviour at compile time leads us to use C instead of C++
 
-include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/get_testcase_name.cmake)
-
 oeedl_file(../mbed.edl enclave gen)
 
 # This function creates an enclave for a specific mbedTLS test.


### PR DESCRIPTION
CMake - Use top level directory in tests

Switch from the form '${CMAKE_CURRENT_LIST_DIR}/../../' to
'${PROJECT_SOURCE_DIR}/'.

This will make rearranging folders in the project easier and looks
cleaner.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
---
v2: switch from CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR as suggested
      by @andschwa; modify commit message