### PR TITLE
Clean ccache usage and update it

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Adapted from https://crascit.com/2016/04/09/using-ccache-with-cmake/
+cmake_minimum_required(VERSION 3.4)
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  # Set CCACHE_CPP2 to true to decrease compile times when using ccache in
+  # combination with clang
+  # Support Unix Makefiles and Ninja
+  set(CMAKE_C_COMPILER_LAUNCHER export CCACHE_CPP2=true && "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER export CCACHE_CPP2=true && "${CCACHE_PROGRAM}")
+  message(STATUS "Using CCache")
+else()
+  message(STATUS "Not using CCache")
+endif()

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -43,16 +43,8 @@ if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
   message(FATAL_ERROR "Only 64-bit builds are supported!")
 endif ()
 
-# Use ccache if available.
-# TODO: See #759: Replace this with `CMAKE_<LANG>_COMPILER_LAUNCHER`.
-find_program(CCACHE_FOUND ccache)
-if (CCACHE_FOUND)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-  message("Using ccache")
-else ()
-  message("ccache not found")
-endif (CCACHE_FOUND)
+# Setup ccache
+include(ccache)
 
 # Check for compiler flags
 include(CheckCCompilerFlag)


### PR DESCRIPTION
Introduce a new file cmake/ccache.cmake which will deal with the ccache usage.

This is based on the article:
https://crascit.com/2016/04/09/using-ccache-with-cmake/

Fixes: https://github.com/Microsoft/openenclave/issues/759
Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>