### PR TITLE
Always export compile commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,11 @@ if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
   endif ()
 endif ()
 
+# Generates `compile_commands.json` used by some developers. Only
+# supported by Makefile and Ninja generators, but is otherwise
+# ignored.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Get Jenkins build number
 set(BUILD_NUMBER $ENV{BUILD_NUMBER})
 if (NOT BUILD_NUMBER)


### PR DESCRIPTION
I got tired of always specifying this on the command line. I can think of no reason not to enable it unconditionally. Here is the [documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html).