### PR TITLE
Fix comparison error

### DIFF
--- a/tests/memory/enc/basic.c
+++ b/tests/memory/enc/basic.c
@@ -93,12 +93,12 @@ void test_realloc(void)
 
     /* Ensure that realloc fails. With GCC 7, this throws a
        compilation error, which we ignore. */
-#if __GNUC__ > 7
+#if __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Walloc-size-larger-than="
 #endif
     void* ptr2 = realloc(ptr, ~((size_t)0));
-#if __GNUC__ > 7
+#if __GNUC__ >= 7
 #pragma GCC diagnostic pop
 #endif
     OE_TEST(ptr2 == NULL);


### PR DESCRIPTION
This has to be >=, obviously. It was missed in testing since originally
no version check was being performed, hence it passed locally, and then
a version check was added to make 16.04 CI pass. Unfortunately, we don't
yet have 18.04 GCC CI yet, so it was not caught and I must not have
manually tested it (we've been distracted by a massive CI outage).