### PR TITLE
Fix docker privileged flag

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -40,7 +40,7 @@ def ACCContainerTest(String label) {
             checkout scm
 
             def oetoolsContainer = docker.build("oetools-containertest", "-f .jenkins/Dockerfile .")
-            oetoolsContainer.inside('--privileged -v /dev/sgx:/dev/sgx') {
+            oetoolsContainer.inside('--device /dev/sgx:/dev/sgx') {
                 timeout(15) {
                     sh './scripts/test-build-config -p SGX1FLC -b RelWithDebInfo --disable_sim'
                 }


### PR DESCRIPTION
Replace the --privileged flag paired with the SGX device mount with --device flag for docker run, cleaner way that does not give too much access from container to host

Fixes #1366 for openenclave repo