### PR TITLE
Disabled remote attestation tests temporarily.

### DIFF
--- a/samples/remote_attestation/Makefile
+++ b/samples/remote_attestation/Makefile
@@ -18,4 +18,5 @@ clean:
 	$(MAKE) -C host clean
 
 run:
-	host/attestation_host ./enc1/enclave1.signed ./enc2/enclave2.signed
+# TEST DISABLED TEMPORARILY UNTIL PCK SERVER ISSUE IS RESOLVED
+#	host/attestation_host ./enc1/enclave1.signed ./enc2/enclave2.signed

--- a/tests/report/CMakeLists.txt
+++ b/tests/report/CMakeLists.txt
@@ -8,10 +8,12 @@ if (BUILD_ENCLAVES)
 endif()
 
 # Run all tests. Also generate a report.
-add_enclave_test(tests/report report_host report_enc)
-set_tests_properties(tests/report PROPERTIES SKIP_RETURN_CODE 2)
+# TEST DISABLED TEMPORARILY UNTIL PCK SERVER ISSUE IS RESOLVED
+#add_enclave_test(tests/report report_host report_enc)
+#set_tests_properties(tests/report PROPERTIES SKIP_RETURN_CODE 2)
 
 # Attest generated report; but without creating any enclave.
-add_enclave_test(tests/report_attestation_without_enclave report_host report_enc
-    --attest-generated-report)
-set_tests_properties(tests/report_attestation_without_enclave PROPERTIES SKIP_RETURN_CODE 2)
+# TEST DISABLED TEMPORARILY UNTIL PCK SERVER ISSUE IS RESOLVED
+#add_enclave_test(tests/report_attestation_without_enclave report_host report_enc
+#    --attest-generated-report)
+#set_tests_properties(tests/report_attestation_without_enclave PROPERTIES SKIP_RETURN_CODE 2)


### PR DESCRIPTION
This PR disables some remote attestation tests, as they are failing due to an intermittent outage with the PCK service. That intermittent outage is currently being investigated/fixed.

**These tests need to be re-enabled as soon as possible.** 

The three tests that are disabled as part of this PR are:
```
tests/report
tests/report_attestation_without_enclave
samples
```