### PR TITLE
Fix edger8r target to be an imported executable

### DIFF
--- a/cmake/oeedl_file.cmake
+++ b/cmake/oeedl_file.cmake
@@ -57,20 +57,10 @@ function(oeedl_file EDL_FILE TYPE OUT_FILES_VAR)
 
 	set(h_file ${CMAKE_CURRENT_BINARY_DIR}/${idl_base}_${type_id}.h)
 
-	if (UNIX)
-		set(OEEDGER8R_COMMAND oeedger8r)
-	else()
-		set(OEEDGER8R_COMMAND oeedger8r.exe)
-	endif()
-
 	add_custom_command(
 		OUTPUT ${h_file} ${c_file}
-		# NOTE: Because `OEEDGER8R_COMMAND` is not a CMake
-		# executable, we need an explicit dependency on it in
-		# order to cause files to be regenerated if the
-		# oeedger8r is rebuilt.
-		DEPENDS ${EDL_FILE} oeedger8r ${OE_BINDIR}/${OEEDGER8R_COMMAND}
-		COMMAND ${OE_BINDIR}/${OEEDGER8R_COMMAND} ${type_opt} ${headers_only} ${dir_opt} ${CMAKE_CURRENT_BINARY_DIR} ${EDL_FILE} --search-path ${in_path} ${edl_search_path}
+		DEPENDS ${EDL_FILE}
+		COMMAND edger8r ${type_opt} ${headers_only} ${dir_opt} ${CMAKE_CURRENT_BINARY_DIR} ${EDL_FILE} --search-path ${in_path} ${edl_search_path}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		)
 

--- a/tools/oeedger8r/CMakeLists.txt
+++ b/tools/oeedger8r/CMakeLists.txt
@@ -1,12 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-if (WIN32)
-    set(BINARY ${OE_BINDIR}/oeedger8r.exe)
-else()
-    set(BINARY ${OE_BINDIR}/oeedger8r)
-endif()
-
 # NOTE: The custom commands below first copy the input files to the
 # build directory and then invoke the OCaml tools because those tools
 # do not emit to the current working directory, they always emit to
@@ -37,6 +31,7 @@ add_custom_command(
   DEPENDS intel/Parser.mly)
 
 # Compile
+set(BINARY oeedger8r${CMAKE_EXECUTABLE_SUFFIX})
 add_custom_command(
     OUTPUT ${BINARY}
     COMMAND ocamlopt -c -bin-annot -I . -o Ast.cmx          ${CMAKE_CURRENT_SOURCE_DIR}/intel/Ast.ml
@@ -66,10 +61,15 @@ add_custom_command(
             intel/Plugin.ml
             intel/Preprocessor.ml
             intel/SimpleStack.ml
-            intel/Util.ml
-)
+            intel/Util.ml)
 
-add_custom_target(oeedger8r ALL DEPENDS ${BINARY})
+# The names here are important because the output file must be named
+# `oeedger8r`, and our targets must not clash with that.
+add_executable(edger8r IMPORTED GLOBAL)
+set_target_properties(edger8r PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${BINARY})
+add_custom_target(oeedger8r_target DEPENDS ${BINARY})
+add_dependencies(edger8r oeedger8r_target)
 
-# install rule
-install (PROGRAMS ${BINARY} DESTINATION ${CMAKE_INSTALL_BINDIR})
+# Can't use `install(TARGETS)` on an imported executable, because it
+# causes CMake to crash with a segmentation fault.
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${BINARY} DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This makes it much easier to use in other aspects of CMake, such as
custom commands and tests.