### PR TITLE
Revert "Disabled remote attestation tests temporarily."

### DIFF
--- a/samples/remote_attestation/Makefile
+++ b/samples/remote_attestation/Makefile
@@ -18,5 +18,4 @@ clean:
 	$(MAKE) -C host clean
 
 run:
-# TEST DISABLED TEMPORARILY UNTIL PCK SERVER ISSUE IS RESOLVED
-#	host/attestation_host ./enc1/enclave1.signed ./enc2/enclave2.signed
+	host/attestation_host ./enc1/enclave1.signed ./enc2/enclave2.signed

--- a/tests/report/CMakeLists.txt
+++ b/tests/report/CMakeLists.txt
@@ -8,12 +8,10 @@ if (BUILD_ENCLAVES)
 endif()
 
 # Run all tests. Also generate a report.
-# TEST DISABLED TEMPORARILY UNTIL PCK SERVER ISSUE IS RESOLVED
-#add_enclave_test(tests/report report_host report_enc)
-#set_tests_properties(tests/report PROPERTIES SKIP_RETURN_CODE 2)
+add_enclave_test(tests/report report_host report_enc)
+set_tests_properties(tests/report PROPERTIES SKIP_RETURN_CODE 2)
 
 # Attest generated report; but without creating any enclave.
-# TEST DISABLED TEMPORARILY UNTIL PCK SERVER ISSUE IS RESOLVED
-#add_enclave_test(tests/report_attestation_without_enclave report_host report_enc
-#    --attest-generated-report)
-#set_tests_properties(tests/report_attestation_without_enclave PROPERTIES SKIP_RETURN_CODE 2)
+add_enclave_test(tests/report_attestation_without_enclave report_host report_enc
+    --attest-generated-report)
+set_tests_properties(tests/report_attestation_without_enclave PROPERTIES SKIP_RETURN_CODE 2)


### PR DESCRIPTION
This reverts commit d0ef5ef6dbbebb436e7f3273296f97bc1be070b6, which disabled remote attestation tests. These tests will be re-enabled as soon as possible, once some service issues are fixed.

**NOTE: DO NOT MERGE THIS YET UNTIL THIS BOLDED TEXT IS REMOVED**