### PR TITLE
Add edger8r behavior tests for existing warnings

### DIFF
--- a/tests/oeedger8r/CMakeLists.txt
+++ b/tests/oeedger8r/CMakeLists.txt
@@ -8,3 +8,5 @@ if (BUILD_ENCLAVES)
 endif()
 
 add_enclave_test(tests/oeedger8r edl_host edl_enc)
+
+add_subdirectory(behavior)

--- a/tests/oeedger8r/behavior/CMakeLists.txt
+++ b/tests/oeedger8r/behavior/CMakeLists.txt
@@ -9,3 +9,17 @@ set(EDGER8R_ARGS --header-only --search-path ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME edger8r_private_trusted_warning COMMAND edger8r ${EDGER8R_ARGS} private_trusted.edl)
 set_tests_properties(edger8r_private_trusted_warning PROPERTIES
   PASS_REGULAR_EXPRESSION "error: Function 'private': 'private' specifier is not supported by oeedger8r")
+
+add_test(NAME edger8r_allow_list_warning COMMAND edger8r ${EDGER8R_ARGS} allow_list.edl)
+set_tests_properties(edger8r_allow_list_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Warning: Function 'ocall_allow': Reentrant ocalls are not supported by Open Enclave. Allow list ignored.")
+
+# NOTE: These are two separate tests because the edger8r exits as soon
+# as the first instance is found.
+add_test(NAME edger8r_switchless_trusted_warning COMMAND edger8r ${EDGER8R_ARGS} switchless_trusted.edl)
+set_tests_properties(edger8r_switchless_trusted_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "error: Function 'switchless': switchless ecalls and ocalls are not yet supported by Open Enclave SDK.")
+
+add_test(NAME edger8r_switchless_untrusted_warning COMMAND edger8r ${EDGER8R_ARGS} switchless_untrusted.edl)
+set_tests_properties(edger8r_switchless_untrusted_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "error: Function 'switchless': switchless ecalls and ocalls are not yet supported by Open Enclave SDK.")

--- a/tests/oeedger8r/behavior/CMakeLists.txt
+++ b/tests/oeedger8r/behavior/CMakeLists.txt
@@ -23,3 +23,38 @@ set_tests_properties(edger8r_switchless_trusted_warning PROPERTIES
 add_test(NAME edger8r_switchless_untrusted_warning COMMAND edger8r ${EDGER8R_ARGS} switchless_untrusted.edl)
 set_tests_properties(edger8r_switchless_untrusted_warning PROPERTIES
   PASS_REGULAR_EXPRESSION "error: Function 'switchless': switchless ecalls and ocalls are not yet supported by Open Enclave SDK.")
+
+# These need to be separate tests to ensure that each type, for both
+# trusted and untrusted functions, generate the appropriate warning,
+# but we can reuse the EDL file.
+add_test(NAME edger8r_portability_trusted_wchar_t_warning COMMAND edger8r ${EDGER8R_ARGS} portability.edl)
+set_tests_properties(edger8r_portability_trusted_wchar_t_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Function 'ocall': wchar_t has different sizes")
+
+add_test(NAME edger8r_portability_trusted_long_double_warning COMMAND edger8r ${EDGER8R_ARGS} portability.edl)
+set_tests_properties(edger8r_portability_trusted_long_double_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Function 'ocall': long double has different sizes")
+
+add_test(NAME edger8r_portability_trusted_long_warning COMMAND edger8r ${EDGER8R_ARGS} portability.edl)
+set_tests_properties(edger8r_portability_trusted_long_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Function 'ocall': long has different sizes")
+
+add_test(NAME edger8r_portability_trusted_unsigned_long_warning COMMAND edger8r ${EDGER8R_ARGS} portability.edl)
+set_tests_properties(edger8r_portability_trusted_unsigned_long_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Function 'ocall': unsigned long has different sizes")
+
+add_test(NAME edger8r_portability_untrusted_wchar_t_warning COMMAND edger8r ${EDGER8R_ARGS} portability.edl)
+set_tests_properties(edger8r_portability_untrusted_wchar_t_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Function 'ecall': wchar_t has different sizes")
+
+add_test(NAME edger8r_portability_untrusted_long_double_warning COMMAND edger8r ${EDGER8R_ARGS} portability.edl)
+set_tests_properties(edger8r_portability_untrusted_long_double_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Function 'ecall': long double has different sizes")
+
+add_test(NAME edger8r_portability_untrusted_long_warning COMMAND edger8r ${EDGER8R_ARGS} portability.edl)
+set_tests_properties(edger8r_portability_untrusted_long_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Function 'ecall': long has different sizes")
+
+add_test(NAME edger8r_portability_untrusted_unsigned_long_warning COMMAND edger8r ${EDGER8R_ARGS} portability.edl)
+set_tests_properties(edger8r_portability_untrusted_unsigned_long_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Function 'ecall': unsigned long has different sizes")

--- a/tests/oeedger8r/behavior/CMakeLists.txt
+++ b/tests/oeedger8r/behavior/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set(EDGER8R_ARGS --header-only --search-path ${CMAKE_CURRENT_SOURCE_DIR})
+
+# TODO: Check exit code of edger8r. Unfortunately, the `WILL_FAIL`
+# property does not combine well with the regular expression checks,
+# so we're preferring those for now.
+add_test(NAME edger8r_private_trusted_warning COMMAND edger8r ${EDGER8R_ARGS} private_trusted.edl)
+set_tests_properties(edger8r_private_trusted_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "error: Function 'private': 'private' specifier is not supported by oeedger8r")

--- a/tests/oeedger8r/behavior/allow_list.edl
+++ b/tests/oeedger8r/behavior/allow_list.edl
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+        // Normally this would be `private`, but that is also not
+        // supported, so we need to make this public in order to test
+        // the next code.
+        public void ecall();
+    };
+
+    untrusted {
+        // Allow lists are not supported. NOTE: `allow` is reserved as
+        // a keyword, so the function cannot also be named `allow()`.
+        void ocall_allow() allow(ecall);
+    };
+};

--- a/tests/oeedger8r/behavior/portability.edl
+++ b/tests/oeedger8r/behavior/portability.edl
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+      public void ecall(wchar_t w, long double ld, long l, unsigned long ul);
+    };
+
+    untrusted {
+      void ocall(wchar_t w, long double ld, long l, unsigned long ul);
+    };
+};

--- a/tests/oeedger8r/behavior/private_trusted.edl
+++ b/tests/oeedger8r/behavior/private_trusted.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+        // Private functions not supported, must have `public`.
+        void private();
+    };
+};

--- a/tests/oeedger8r/behavior/switchless_trusted.edl
+++ b/tests/oeedger8r/behavior/switchless_trusted.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+        // Switchless functions not supported.
+        public void switchless() transition_using_threads;
+    };
+};

--- a/tests/oeedger8r/behavior/switchless_untrusted.edl
+++ b/tests/oeedger8r/behavior/switchless_untrusted.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+    untrusted {
+        // Switchless functions not supported.
+        void switchless() transition_using_threads;
+    };
+};

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -877,7 +877,6 @@ let validate_oe_support (ec: enclave_content) (ep: edger8r_params) =
         failwithf "Function '%s': 'private' specifier is not supported by oeedger8r" f.Ast.tf_fdecl.fname);
     (if f.Ast.tf_is_switchless then
         failwithf "Function '%s': switchless ecalls and ocalls are not yet supported by Open Enclave SDK." f.Ast.tf_fdecl.fname);  
-    warn_non_portable_types f.Ast.tf_fdecl;   
   ) ec.tfunc_decls;
   List.iter (fun f -> 
     (if f.Ast.uf_fattr.fa_convention <> Ast.CC_NONE then
@@ -889,8 +888,15 @@ let validate_oe_support (ec: enclave_content) (ep: edger8r_params) =
         printf "Warning: Function '%s': Reentrant ocalls are not supported by Open Enclave. Allow list ignored.\n" f.Ast.uf_fdecl.fname);
     (if f.Ast.uf_is_switchless then
         failwithf "Function '%s': switchless ecalls and ocalls are not yet supported by Open Enclave SDK." f.Ast.uf_fdecl.fname);
-    warn_non_portable_types f.Ast.uf_fdecl;          
-  ) ec.ufunc_decls
+  ) ec.ufunc_decls;
+  (* Map warning functions over trusted and untrusted function
+     declarations *)
+  let ufuncs = List.map (fun f -> (f.Ast.uf_fdecl)) ec.ufunc_decls in
+  let tfuncs = List.map (fun f -> (f.Ast.tf_fdecl)) ec.tfunc_decls in
+  let funcs = List.append ufuncs tfuncs in
+  List.iter (fun f ->
+    warn_non_portable_types f;
+  ) funcs
 
   (*
     Includes are emitted in args.h.


### PR DESCRIPTION
This adds the following tests:

```
edger8r_private_trusted_warning
edger8r_allow_list_warning
edger8r_switchless_trusted_warning
edger8r_switchless_untrusted_warning
edger8r_portability_trusted_wchar_t_warning
edger8r_portability_trusted_long_double_warning
edger8r_portability_trusted_long_warning
edger8r_portability_trusted_unsigned_long_warning
edger8r_portability_untrusted_wchar_t_warning
edger8r_portability_untrusted_long_double_warning
edger8r_portability_untrusted_long_warning
edger8r_portability_untrusted_unsigned_long_warning
```

The tests check the behavior of the edger8r for specific EDL code. That is, they check that the edger8r emits the correct warning given unsupported or dangerous code.