### PR TITLE
Configure ExperimentalMemCheck if valgrind is installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,16 @@ endif ()
 
 option(ADD_WINDOWS_ENCLAVE_TESTS "Build Windows enclave tests" OFF)
 
+find_program(VALGRIND "valgrind")
+if (VALGRIND)
+  set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --error-exitcode=1")
+  # include Dart to generate the site configuration:
+  # https://gitlab.kitware.com/cmake/community/wikis/doc/ctest/Generating-Testing-Files#using-cmake
+  include(Dart)
+  message(STATUS "ExperimentalMemCheck can be used to run tests under valgrind")
+else ()
+  message(STATUS "Valgrind not found")
+endif ()
 # Configure testing
 enable_testing()
 include(add_enclave_test)


### PR DESCRIPTION
This patch enables testing via `ctest -D ExperimentalMemCheck` if valgrind
is installed.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>