### PR TITLE
Removed kobanyan.jenkins-jnlp-slave 3rd party dependency

### DIFF
--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -39,12 +39,6 @@ As a good practice, it is advised to address the nodes via their hostnames direc
 10.0.28.143    ACC-1604-5
 ```
 
-At the moment, the Jenkins setup playbook has a third party dependency on `kobanyan.jenkins-jnlp-slave`. Before running the main playbook, make sure this is installed:
-
-```
-ansible-galaxy install kobanyan.jenkins-jnlp-slave
-```
-
 The playbook can be started with:
 
 ```

--- a/scripts/ansible/roles/linux/jenkins/tasks/slave-setup.yml
+++ b/scripts/ansible/roles/linux/jenkins/tasks/slave-setup.yml
@@ -89,11 +89,24 @@
     name: jenkins
     groups: docker
 
-- name: Jenkins | Setup JNLP Slave
-  import_role:
-    name: kobanyan.jenkins-jnlp-slave
-  vars:
-    jenkins_master: "{{ jenkins_url }}"
-    jenkins_slave_secret: "{{ node_secret }}"
-    jenkins_slave_name: "{{ jenkins_agent_name }}"
-    jenkins_slave_home: "{{ jenkins_agent_root_dir }}"
+- name: Make Jenkins JNLP slave directories
+  file:
+    path: "{{ jenkins_agent_root_dir }}"
+    state: directory
+    owner: jenkins
+    group: jenkins
+
+- name: Template Jenkins JNLP slave files
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - { src: jenkins-slave.service.j2, dest: /etc/systemd/system/jenkins-slave.service, mode: 755 }
+    - { src: jenkins-slave.default.j2, dest: /etc/default/jenkins-slave, mode: 644 }
+
+- name: Start Jenkins JNLP slave
+  systemd:
+    name: jenkins-slave
+    enabled: yes
+    state: restarted
+    daemon_reload: yes

--- a/scripts/ansible/roles/linux/jenkins/templates/jenkins-slave.default.j2
+++ b/scripts/ansible/roles/linux/jenkins/templates/jenkins-slave.default.j2
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+JENKINS_RUN=/var/run/jenkins
+JENKINS_URL="{{ jenkins_url }}"
+JENKINS_NODE_NAME="{{ jenkins_agent_name }}"
+JENKINS_SECRET="{{ node_secret }}"

--- a/scripts/ansible/roles/linux/jenkins/templates/jenkins-slave.service.j2
+++ b/scripts/ansible/roles/linux/jenkins/templates/jenkins-slave.service.j2
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+[Unit]
+Description=Jenkins JNLP Slave
+Wants=network.target
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/jenkins-slave
+ExecStartPre=/bin/mkdir -p ${JENKINS_RUN}
+ExecStartPre=/bin/chown -R jenkins:jenkins ${JENKINS_RUN}
+ExecStartPre=/usr/bin/wget -q -O ${JENKINS_RUN}/slave.jar ${JENKINS_URL}/jnlpJars/slave.jar
+ExecStart=/usr/bin/java -jar ${JENKINS_RUN}/slave.jar -jnlpUrl ${JENKINS_URL}/computer/${JENKINS_NODE_NAME}/slave-agent.jnlp -secret=${JENKINS_SECRET}
+User=jenkins
+PermissionsStartOnly=true
+LimitNOFILE=8192
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This pull request addresses https://github.com/Microsoft/openenclave/issues/1354 2nd item in checklist by removing kobanyan.jenkins-jnlp-slave 3rd party dependency with cleaner integrated tasks under Ansible role linux/jenkins