### PR TITLE
Removal of OE_ENCLAVE_TYPE_UNKNOWN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      may require compiling with the `-std=c++11` option when building with GCC.
 - Update minimum required CMake version for building from source to 3.13.1.
 - Update minimum required C++ standard for building from source to C++14.
-- OE_ENCLAVE_TYPE_UNDEFINED was renumbered as we used 0 in the enumeration to
-  represent OE_ENCLAVE_TYPE_AUTO.
 
 ### Deprecated
 
 - String based `ocalls`/`ecalls`, `OE_ECALL`, and `OE_OCALL` macros.
+- OE_ENCLAVE_TYPE_UNDEFINED was removed and replaced with OE_ENCLAVE_TYPE_AUTO.
 
 [v0.4.1] - 2018-12-21
 ---------------------

--- a/include/openenclave/bits/types.h
+++ b/include/openenclave/bits/types.h
@@ -90,7 +90,6 @@ typedef enum _oe_enclave_type
 {
     OE_ENCLAVE_TYPE_AUTO,
     OE_ENCLAVE_TYPE_SGX,
-    OE_ENCLAVE_TYPE_UNDEFINED,
     __OE_ENCLAVE_TYPE_MAX = OE_ENUM_MAX,
 } oe_enclave_type_t;
 

--- a/tests/create-errors/host/host.c
+++ b/tests/create-errors/host/host.c
@@ -21,7 +21,7 @@ static void _test_invalid_param(const char* path, uint32_t flags)
 
     /* Invalid enclave type. Note that 0 is now allowed! */
     result = oe_create_create_errors_enclave(
-        path, OE_ENCLAVE_TYPE_UNDEFINED, flags, NULL, 0, &enclave);
+        path, (OE_ENCLAVE_TYPE_SGX + 1), flags, NULL, 0, &enclave);
 
     OE_TEST(result == OE_INVALID_PARAMETER);
 


### PR DESCRIPTION
This is a minor update to my previous checking #1401 due to a request to remove the OE_ENCLAVE_TYPE_UNKNOWN flag from the enumeration
