### PR TITLE
Windows: Add spectre mitigation flags when using clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,35 @@ if (OE_SGX)
   endif()
 
   if (BUILD_ENCLAVES AND WIN32)
+    # Search for prerequisites
+    find_program(CLANG clang)
+    if (NOT CLANG)
+      message(FATAL_ERROR "Clang is required to build ELF enclaves on Windows")
+    endif ()
+
+    # Get the list of clang specific defines and search for __clang_major__
+    execute_process(
+      COMMAND cmd.exe /c " clang -dM -E -x c nul | findstr __clang_major__ "
+      RESULT_VARIABLE HAD_ERROR
+      OUTPUT_VARIABLE CONFIG_OUTPUT
+    )
+    if (HAD_ERROR)
+      message(FATAL_ERROR "Could not parse clang major version")
+    endif ()
+
+    # Format the output for a list
+    string(REPLACE " " ";" CONFIG_OUTPUT ${CONFIG_OUTPUT})
+    # Get the major version for clang
+    list(GET CONFIG_OUTPUT 2 MAJOR_VERSION)
+    if (MAJOR_VERSION VERSION_LESS 7)
+      message(FATAL_ERROR "Clang version 7.0 or higher is required")
+    endif ()
+
     # Setup cross compiler (clangw)
     add_subdirectory(windows/clangw)  
     set(USE_CLANGW ON)
   endif()
-else()
+else() # NOT OE_SGX
   # On non-sgx enclaves are built by default on Unix
   if (UNIX)
     set(BUILD_ENCLAVES ON)

--- a/cmake/maybe_build_using_clangw.cmake
+++ b/cmake/maybe_build_using_clangw.cmake
@@ -40,7 +40,8 @@ function(maybe_build_using_clangw OE_TARGET)
         -Wall -Werror -Wpointer-arith -Wconversion -Wextra -Wno-missing-field-initializers
         -fno-strict-aliasing
         -mxsave
-        -fno-builtin-malloc -fno-builtin-calloc -fno-builtin)
+        -fno-builtin-malloc -fno-builtin-calloc -fno-builtin
+        -mllvm -x86-speculative-load-hardening)
 
     # Setup library names variables
     set(CMAKE_STATIC_LIBRARY_PREFIX "lib" PARENT_SCOPE)


### PR DESCRIPTION
Add check to verify clang is installed and at least version 7.

Add `-mllvm -x86-speculative-load-hardening` to clang when compiling on Windows.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
Fixes: https://github.com/Microsoft/openenclave/issues/1368