### PR TITLE
Disallow bors r+ on PRs with the label "do not merge"

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,7 @@
 status = [ "continuous-integration/jenkins/branch" ]
 pr_status = [ "license/cla" ]
 required_approvals = 1
+block_labels = [ "do not merge" ]
 delete_merged_branches = true
 timeout_sec = 7200 # two hours
 


### PR DESCRIPTION
We can use this to block PRs from getting merged accidentally. If the
author (or a reviewer) wants to disable 'bors r+', they can just add the
"do not merge" label.