### PR TITLE
Add Ansible role for Windows DCAP CI testing

### DIFF
--- a/docs/GettingStartedDocs/AnsibleGettingStarted.md
+++ b/docs/GettingStartedDocs/AnsibleGettingStarted.md
@@ -1,0 +1,48 @@
+# Getting started with Ansible
+
+The Open Enclave repository contains various playbooks to configure the supported platforms for either developing Open Enclave applications or maintaining the SDK itself.
+
+If you are interested in the Open Enclave deployment options via Ansible, see [this section](https://github.com/Microsoft/openenclave/tree/master/scripts/ansible#open-enclave-deployment-options-via-ansible) from our Ansible README.
+
+## Install the Ansible package
+
+The Ansible package works reliably (as tested) only on Unix platforms due to the various unix specific internal code.
+
+If you wish to run Ansible from a Windows machine, feel free to enable the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10), install the Ubuntu (16.04 or 18.04) distribution from the Windows store, and open the Linux terminal.
+
+To get Ansible ready to use, simply run the [install-ansible.sh](/scripts/ansible/install-ansible.sh) script (this requires execution with sudo).
+
+After the script finishes, you can check that Ansible is installed by running:
+
+```
+ansible --version
+```
+
+Ansible communicates with the target machines via:
+
+* SSH (port 22) if the target machine is a Linux system
+* WinRM (port 5986) if the target machine is a Windows system
+
+## Steps to configure target Ansible machines
+
+1. Make sure that the target platform is included in the [supported operating systems](https://github.com/Microsoft/openenclave/blob/master/scripts/ansible/README.md#supported-platforms-by-the-ansible-playbooks) by the Open Enclave playbook files.
+
+2. Configure SSH / WinRM on the target machines:
+
+    * SSH needs to be configured only on the target Linux machines. From the terminal where Ansible is used, make sure you can SSH into the Linux machines without any password prompt. You may need to generate a SSH key pair via `ssh-keygen` and authorize the key via `ssh-copy-id`.
+
+    * WinRM needs to be configured only on the Windows machines. Make sure that WinRM is running and it allows remote auth via user and password. If you don't have WinRM configured on the Windows machines, execute the following [official Ansible PowerShell steps](https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html#winrm-setup). After these steps are successfully executed, WinRM is properly configured.
+
+3. Make sure that the Linux machines SSH (port 22) or Windows machines WinRM (port 5986) are reachable from the terminal where Ansible is used.
+
+    Check the communication port for every target machine. You may need to open some extra firewall ports if the machines are running in a public cloud and you are using the public address.
+
+4. Set up the Ansible inventory with connection details for all the target machines. See details on how to do this [here](/scripts/ansible/inventory).
+
+5. Change directory to `scripts/ansible` and execute the following command:
+
+    ```
+    ansible -m setup all
+    ```
+
+    This will try and execute the `setup` Ansible built-in module and get platform details from every machine added to the [inventory](/scripts/ansible/inventory). If this command finishes without any error, the Ansible machines are prepared to run our playbooks from the [ansible](/scripts/ansible) directory.

--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -11,21 +11,29 @@ On the target machine where Open Enclave is desired to be configured, you may se
 
 1. Open Enclave environment for contributors:
 
-```
-ansible-playbook oe-contributors-setup.yml
-```
+    ```
+    ansible-playbook oe-contributors-setup.yml
+    ```
 
 2. Open Enclave environment for contributors using ACC hardware:
 
-```
-ansible-playbook oe-contributors-acc-setup.yml
-```
+    ```
+    ansible-playbook oe-contributors-acc-setup.yml
+    ```
 
 3. Open Enclave vanilla environment (without SGX packages and with Azure-DCAP-Client package)
 
-```
-ansible-playbook oe-vanilla-prelibsgx-setup.yml
-```
+    ```
+    ansible-playbook oe-vanilla-prelibsgx-setup.yml
+    ```
+
+4. Setup the remote Windows agents with all the requirements for the DCAP Windows testing:
+
+    ```
+    ansible windows-agents -m import_role -a "name=windows/az-dcap-client tasks_from=environment-setup.yml"
+    ```
+
+    This assumes that the inventory was properly set up with the `windows-agents` machines.
 
 # Configure new Jenkins slaves
 

--- a/scripts/ansible/inventory/README.md
+++ b/scripts/ansible/inventory/README.md
@@ -1,5 +1,16 @@
 # Ansible inventory
 
-Make sure to update the [hosts](/scripts/ansible/inventory/hosts) file with the nodes details.
+Make sure to update the [hosts](/scripts/ansible/inventory/hosts) file with the targeted node addresses.
 
-Ensure that [group_vars](/scripts/ansible/inventory/group_vars) contain the right details to connect to the target servers.
+The hosts targeted by Ansible are grouped into:
+
+* `linux-agents` - represent any Linux (Ubuntu 16.04 and Ubuntu 18.04) to be configured
+* `windows-agents` - represent any Windows Server 2016 ACC machine to be configured
+
+Ensure that [group_vars](/scripts/ansible/inventory/group_vars) contain the right details to connect to the targeted servers. There are 3 files with global variables applied to the machines:
+
+* `all` - global variables applied to every Ansible targeted machine
+* `linux-agents` - global variables applied only to the Linux machines declared in the [hosts](/scripts/ansible/inventory/hosts) file
+* `windows-agents` - global variables applied only to the Windows Server 2016 ACC machines declared in the [hosts](/scripts/ansible/inventory/hosts) file
+
+If you want to granularly apply configs only to a single Ansible target machine, you need to create a new file under [host_vars](/scripts/ansible/inventory/host_vars) directory. The file name must be the machine address as declared in the [hosts](/scripts/ansible/inventory/hosts) file. For more information on this, see the README from the [host_vars](/scripts/ansible/inventory/host_vars) directory.

--- a/scripts/ansible/jenkins-setup.yml
+++ b/scripts/ansible/jenkins-setup.yml
@@ -4,6 +4,7 @@
 ---
 - hosts: linux-agents
   any_errors_fatal: true
+  gather_facts: true
   become: yes
   tasks:
     - import_role:
@@ -44,6 +45,7 @@
 
 - hosts: windows-agents
   any_errors_fatal: true
+  become_method: runas
   tasks:
     - block:
       - import_role:
@@ -56,6 +58,10 @@
       fail:
         msg: "The node_secret fact is not defined!"
       when: node_secret is undefined
+
+    - import_role:
+        name: windows/az-dcap-client
+        tasks_from: environment-setup.yml
 
     - import_role:
         name: windows/jenkins

--- a/scripts/ansible/requirements.txt
+++ b/scripts/ansible/requirements.txt
@@ -1,3 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 ansible==2.7.2
+pywinrm==0.2.1

--- a/scripts/ansible/roles/windows/az-dcap-client/tasks/environment-setup.yml
+++ b/scripts/ansible/roles/windows/az-dcap-client/tasks/environment-setup.yml
@@ -1,0 +1,213 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+- name: Gather Ansible facts
+  setup:
+
+- name: Azure DCAP Client | Include vars
+  include_vars: "{{ ansible_os_family | lower }}.yml"
+
+- name: Azure DCAP Client | Download the Intel SGX self-extracting archives and devcon.exe
+  win_get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+    timeout: 60
+  retries: 3
+  with_items:
+    - { url: "{{ psw_archive_url }}", dest: "{{ tmp_dir }}\\Intel_SGX_PSW.exe" }
+    - { url: "{{ dcap_archive_url }}", dest: "{{ tmp_dir }}\\Intel_SGX_DCAP.exe" }
+    - { url: "{{ devcon_bin_url }}", dest: "{{ tmp_dir }}\\devcon.exe" }
+
+- name: Azure DCAP Client | Create new temp directories to be used by Ansible
+  block:
+    - win_file:
+        state: absent
+        path: "{{ item }}"
+      with_items:
+        - "{{ tmp_dir }}\\Intel_SGX_PSW"
+        - "{{ tmp_dir }}\\Intel_SGX_DCAP"
+        - "{{ tmp_dir }}\\Azure_DCAP_Cient_nupkg"
+
+    - win_file:
+        state: directory
+        path: "{{ item }}"
+      with_items:
+        - "{{ tmp_dir }}\\Intel_SGX_PSW"
+        - "{{ tmp_dir }}\\Intel_SGX_DCAP"
+        - "{{ tmp_dir }}\\Azure_DCAP_Cient_nupkg"
+
+- name: Azure DCAP Client | Extract files from self-extracting archives
+  raw: "{{ item.path }} /auto {{ item.dest_dir }}"
+  with_items:
+    - { path: "{{ tmp_dir }}\\Intel_SGX_PSW.exe", dest_dir: "{{ tmp_dir }}\\Intel_SGX_PSW" }
+    - { path: "{{ tmp_dir }}\\Intel_SGX_DCAP.exe", dest_dir: "{{ tmp_dir }}\\Intel_SGX_DCAP" }
+
+- name: Azure DCAP Client | Remove self-extracting archives
+  win_file:
+    state: absent
+    path: "{{ item }}"
+  with_items:
+    - "{{ tmp_dir }}\\Intel_SGX_PSW.exe"
+    - "{{ tmp_dir }}\\Intel_SGX_DCAP.exe"
+
+- name: Azure DCAP Client | Install Intel SGX Platform Software
+  win_shell: |
+    $ErrorActionPreference = "Stop"
+    $installer = Get-Item "{{ tmp_dir }}\Intel_SGX_PSW\Intel SGX PSW for Windows *\PSW_EXE_RS2_and_before\Intel(R)_SGX_Windows_x64_PSW_*.exe"
+    if(!$installer) {
+        Throw "Cannot find the installer executable"
+    }
+    if($installer.Count -gt 1) {
+        Throw "Multiple installer executables found"
+    }
+    $unattendedParams = @('--s', '--a', 'install', '--output={{ tmp_dir }}\Intel_SGX_PSW\psw-installer.log', '--eula=accept', '--no-progress')
+    $p = Start-Process -Wait -NoNewWindow -FilePath $installer -ArgumentList $unattendedParams -PassThru
+    if($p.ExitCode -ne 0) {
+        Get-Content "{{ tmp_dir }}\Intel_SGX_PSW\psw-installer.log"
+        Throw "Failed to install Intel PSW"
+    }
+
+- name: Azure DCAP Client | Remove existing Intel SGX DCAP drivers (if present)
+  register: reboot_needed
+  win_shell: |
+    $ErrorActionPreference = "Stop"
+    $rebootRequired = $false
+    $hardwareIDs = @(
+        'root\SgxLCDevice',
+        'root\SgxLCDevice_DCAP'
+    )
+    foreach($id in $hardwareIDs) {
+        $output = & "{{ tmp_dir }}\devcon.exe" remove $id
+        if($LASTEXITCODE -eq 1) {
+            #
+            # Unfortunately, the exit code is 1 even when the operation was
+            # successful, but a reboot is required. So, we parse the output
+            # to see if a reboot was requested.
+            #
+            $output | ForEach-Object {
+                if($_.Contains("Removed on reboot")) {
+                    $rebootRequired = $true
+                    continue
+                }
+            }
+            #
+            # If we reach this point, it means that the exit code was 1 and
+            # no reboot is needed. Therefore, most probably an error occured.
+            #
+            Write-Output $output
+            Write-Output "ERROR: Failed to remove $id"
+            exit 1
+        } elseif($LASTEXITCODE -ne 0) {
+            Write-Output $output
+            Write-Output "ERROR: Unknown exit code $LASTEXITCODE"
+            exit 1
+        }
+    }
+    Write-Output $rebootRequired
+
+- name: Azure DCAP Client | Reboot the node (if needed)
+  win_reboot:
+  when: (reboot_needed.stdout | trim) == "True"
+
+- name: Azure DCAP Client | Install Intel SGX DCAP drivers
+  win_shell: |
+    $ErrorActionPreference = "Stop"
+    $drivers = @{
+        'sgx_base_dev' = @{
+            'zip_path' = '{{ tmp_dir }}\Intel_SGX_DCAP\Intel SGX DCAP for Windows *\LC_driver_WinServer2016\WinServer2016\Signed_*.zip'
+            'location' = 'root\SgxLCDevice'
+        }
+        'sgx_dcap_dev' = @{
+            'zip_path' = '{{ tmp_dir }}\Intel_SGX_DCAP\Intel SGX DCAP for Windows *\DCAP_INF\WinServer2016\Signed_*.zip'
+            'location' = 'root\SgxLCDevice_DCAP'
+        }
+    }
+    foreach($driver in $drivers.Keys) {
+        $zip = Get-Item $drivers[$driver]['zip_path']
+        if(!$zip) {
+            Throw "Cannot find the zile file with $driver"
+        }
+        if($zip.Count -gt 1) {
+            $zip
+            Throw "Multiple driver zip files found"
+        }
+        New-Item -ItemType Directory -Force -Path "{{ tmp_dir }}\Intel_SGX_DCAP\$driver"
+        Expand-Archive -Path $zip -DestinationPath "{{ tmp_dir }}\Intel_SGX_DCAP\$driver" -Force
+        $inf = Get-Item "{{ tmp_dir }}\Intel_SGX_DCAP\$driver\drivers\*\$driver.inf"
+        if(!$inf) {
+            Throw "Cannot find $driver.inf file"
+        }
+        if($inf.Count -gt 1) {
+            $inf
+            Throw "Multiple $driver.inf files found"
+        }
+        & "{{ tmp_dir }}\devcon.exe" install "$($inf.FullName)" $drivers[$driver]['location']
+        if($LASTEXITCODE) {
+            Throw "Failed to install $driver driver"
+        }
+    }
+
+- name: Azure DCAP Client | Download Azure DCAP Client nupkg file
+  win_get_url:
+    url: "{{ azure_dcap_client_nupkg_url }}"
+    dest: "{{ tmp_dir }}\\Azure_DCAP_Cient_nupkg\\{{ azure_dcap_client_nupkg_url.split('/')[-1] }}"
+    timeout: 60
+  retries: 3
+
+- name: Azure DCAP Client | Copy the Intel nupkg files
+  win_shell: |
+    $ErrorActionPreference = "Stop"
+    $nupkgDir = Get-Item "{{ tmp_dir }}\Intel_SGX_DCAP\Intel SGX DCAP for Windows *\nupkg"
+    if(!$nupkgDir) {
+        Throw "Cannot find the Intel DCAP nupkg directory"
+    }
+    if($nupkgDir.Count -gt 1) {
+        Throw "Multiple Intel DCAP nupkg directories found"
+    }
+    Copy-Item -Recurse -Force "$nupkgDir\*" "{{ tmp_dir }}\Azure_DCAP_Cient_nupkg"
+
+- name: Azure DCAP Client | Create the OE nuget directory
+  win_file:
+    state: directory
+    path: "{{ oe_nuget_dir }}"
+
+- name: Azure DCAP Client | Download NuGet binary
+  win_get_url:
+    url: "{{ nuget_bin_url }}"
+    dest: "{{ tmp_dir }}\\Azure_DCAP_Cient_nupkg\\nuget.exe"
+    timeout: 60
+  retries: 3
+
+- name: Azure DCAP Client | Install the nupkg packages
+  raw: >
+    {{ tmp_dir }}\\Azure_DCAP_Cient_nupkg\\nuget.exe install '{{ item.name }}' -Source '{{ item.source }}' -OutputDirectory '{{ oe_nuget_dir }}' -ExcludeVersion
+  register: result
+  retries: 5
+  until: result.rc == 0
+  with_items:
+    - { name: "EnclaveCommonAPI", source: "{{ tmp_dir }}\\Azure_DCAP_Cient_nupkg" }
+    - { name: "DCAP_Components", source: "{{ tmp_dir }}\\Azure_DCAP_Cient_nupkg" }
+    - { name: "Microsoft.Azure.DCAP.Client", source: "{{ tmp_dir }}\\Azure_DCAP_Cient_nupkg;nuget.org" }
+
+- name: Azure DCAP Client | Enable LC driver
+  block:
+    - name: Azure DCAP Client | Set LC driver registry enable flag
+      win_regedit:
+        path: '{{ lc_driver.reg_path }}'
+        name: '{{ lc_driver.reg_key }}'
+        data: '{{ lc_driver.reg_value }}'
+        type: dword
+
+- name: Azure DCAP Client | Reboot the node
+  win_reboot:
+
+- name: Azure DCAP Client | Remove temp install directories and files
+  win_file:
+    state: absent
+    path: "{{ item }}"
+  with_items:
+    - "{{ tmp_dir }}\\Intel_SGX_PSW"
+    - "{{ tmp_dir }}\\Intel_SGX_DCAP"
+    - "{{ tmp_dir }}\\Azure_DCAP_Cient_nupkg"
+    - "{{ tmp_dir }}\\devcon.exe"

--- a/scripts/ansible/roles/windows/az-dcap-client/vars/windows.yml
+++ b/scripts/ansible/roles/windows/az-dcap-client/vars/windows.yml
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+psw_archive_url: 'http://registrationcenter-download.intel.com/akdlm/irc_nas/15018/Intel%20SGX%20PSW%20for%20Windows%20v2.2.100.48339.exe'
+dcap_archive_url: 'http://registrationcenter-download.intel.com/akdlm/irc_nas/15017/Intel%20SGX%20DCAP%20for%20Windows%20v1.0.100.48134.exe'
+azure_dcap_client_nupkg_url: 'https://oejenkins.blob.core.windows.net/oejenkins/Microsoft.Azure.DCAP.Client.1.0.0.nupkg'
+nuget_bin_url: 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe'
+devcon_bin_url: 'https://oejenkins.blob.core.windows.net/oejenkins/devcon.exe'
+
+oe_nuget_dir: "C:\\openenclave\\prereqs\\nuget"
+
+lc_driver:
+  reg_path: HKLM:\SYSTEM\CurrentControlSet\Services\sgx_lc_msr\Parameters
+  reg_key: SGX_Launch_Config_Optin
+  reg_value: 1


### PR DESCRIPTION
These changes address all the environment requirements
needed to do Azure-DCAP-Client CI testing on Windows.

This is a new set of Ansible tasks bundled into the file
`windows/az-dcap-client/tasks/environment-setup.yml`.

All the requirements are greatly documented in the issue https://github.com/Microsoft/openenclave/issues/1320.

Fixes https://github.com/Microsoft/openenclave/issues/1320