### PR TITLE
Add size signedness warning to edger8r

### DIFF
--- a/tests/oeedger8r/behavior/CMakeLists.txt
+++ b/tests/oeedger8r/behavior/CMakeLists.txt
@@ -69,3 +69,7 @@ add_test(NAME edger8r_count_signedness_warning COMMAND edger8r ${EDGER8R_ARGS} c
 set_tests_properties(edger8r_count_signedness_warning PROPERTIES
   PASS_REGULAR_EXPRESSION "Warning: Function 'signed_count': Size or count parameter 'count' should not be signed."
   FAIL_REGULAR_EXPRESSION "Warning: Function 'unsigned_count': Size or count parameter 'count' should not be signed.")
+
+add_test(NAME edger8r_size_and_count_warning COMMAND edger8r ${EDGER8R_ARGS} size_and_count.edl)
+set_tests_properties(edger8r_size_and_count_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Function 'size_and_count': simultaneous 'size' and 'count' parameters 'size' and 'count' are not supported by oeedger8r.")

--- a/tests/oeedger8r/behavior/CMakeLists.txt
+++ b/tests/oeedger8r/behavior/CMakeLists.txt
@@ -58,3 +58,8 @@ set_tests_properties(edger8r_portability_untrusted_long_warning PROPERTIES
 add_test(NAME edger8r_portability_untrusted_unsigned_long_warning COMMAND edger8r ${EDGER8R_ARGS} portability.edl)
 set_tests_properties(edger8r_portability_untrusted_unsigned_long_warning PROPERTIES
   PASS_REGULAR_EXPRESSION "Function 'ecall': unsigned long has different sizes")
+
+add_test(NAME edger8r_size_signedness_warning COMMAND edger8r ${EDGER8R_ARGS} size_signedness.edl)
+set_tests_properties(edger8r_size_signedness_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Warning: Function 'signed_size': Size parameter 'size' should not be signed."
+  FAIL_REGULAR_EXPRESSION "Warning: Function 'unsigned_size': Size parameter 'size' should not be signed.")

--- a/tests/oeedger8r/behavior/CMakeLists.txt
+++ b/tests/oeedger8r/behavior/CMakeLists.txt
@@ -59,7 +59,13 @@ add_test(NAME edger8r_portability_untrusted_unsigned_long_warning COMMAND edger8
 set_tests_properties(edger8r_portability_untrusted_unsigned_long_warning PROPERTIES
   PASS_REGULAR_EXPRESSION "Function 'ecall': unsigned long has different sizes")
 
+# Test signedness of size and count
 add_test(NAME edger8r_size_signedness_warning COMMAND edger8r ${EDGER8R_ARGS} size_signedness.edl)
 set_tests_properties(edger8r_size_signedness_warning PROPERTIES
-  PASS_REGULAR_EXPRESSION "Warning: Function 'signed_size': Size parameter 'size' should not be signed."
-  FAIL_REGULAR_EXPRESSION "Warning: Function 'unsigned_size': Size parameter 'size' should not be signed.")
+  PASS_REGULAR_EXPRESSION "Warning: Function 'signed_size': Size or count parameter 'size' should not be signed."
+  FAIL_REGULAR_EXPRESSION "Warning: Function 'unsigned_size': Size or count parameter 'size' should not be signed.")
+
+add_test(NAME edger8r_count_signedness_warning COMMAND edger8r ${EDGER8R_ARGS} count_signedness.edl)
+set_tests_properties(edger8r_count_signedness_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "Warning: Function 'signed_count': Size or count parameter 'count' should not be signed."
+  FAIL_REGULAR_EXPRESSION "Warning: Function 'unsigned_count': Size or count parameter 'count' should not be signed.")

--- a/tests/oeedger8r/behavior/count_signedness.edl
+++ b/tests/oeedger8r/behavior/count_signedness.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+        // Signed count should generate a warning.
+        public void signed_count(
+            [in, count=count] int* in,
+            int count);
+
+        // Unsigned count should not generate a warning.
+        public void unsigned_count(
+            [in, count=count] int* in,
+            size_t count);
+    };
+};

--- a/tests/oeedger8r/behavior/size_and_count.edl
+++ b/tests/oeedger8r/behavior/size_and_count.edl
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+        // Size and count parameters together should trigger warning.
+        public void size_and_count(
+            [in, size=size, count=count] int* in,
+            size_t size, size_t count);
+
+        public void only_count(
+            [in, count=count] int* in,
+            size_t count);
+
+        public void only_size(
+            [in, size=size] int* in,
+            size_t size);
+    };
+};

--- a/tests/oeedger8r/behavior/size_signedness.edl
+++ b/tests/oeedger8r/behavior/size_signedness.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+        // Signed size should generate a warning.
+        public void signed_size(
+            [in, size=size] void* in,
+            int size);
+
+        // Unsigned size should not generate a warning.
+        public void unsigned_size(
+            [in, size=size] void* in,
+            size_t size);
+    };
+};

--- a/tools/oeedger8r/README.md
+++ b/tools/oeedger8r/README.md
@@ -49,6 +49,15 @@ Intel's Edger8r code exists in the intel folder. The following minimal changes h
 Edge routine emitter for Open Enclave is implemented in Emitter.ml. It generates code for all the test .edl files.
 It is work in progress. There is also a new main.ml which acts are the program entry point. I would like to somehow get rid of that.
 
+#### Best Practices
 
+We follow [OCamlverse Best Practices](https://ocamlverse.github.io/content/best_practices.html).
 
+We use [ocp-indent](https://github.com/OCamlPro/ocp-indent) to indent our code
+(but not the code imported from Intel).
+This can be run manually or with an editor such as
+[Emacs](https://github.com/ocaml/tuareg/blob/master/dot-emacs.el).
 
+For comments, we are in the process of converting to
+[OCamldoc](https://ocamlverse.github.io/content/documentation_guidelines.html) style,
+which uses `(** [pre-formatted] ... *)` and can later be exported and rendered.


### PR DESCRIPTION
This first cleans up the edger8r, and then adds a test and functionality to emit a warning when a given size parameter is a signed type.

This certainly needs more testing and validation.

Will resolve #1369.