### PR TITLE
Added more logging to make root-causing remote attestation issues easier

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -97,6 +97,8 @@ const char* oe_result_str(oe_result_t result)
             return "OE_INVALID_QE_IDENTITY_INFO";
         case OE_UNSUPPORTED_ENCLAVE_IMAGE:
             return "OE_UNSUPPORTED_ENCLAVE_IMAGE";
+        case OE_VERIFY_CRL_EXPIRED:
+            return "OE_VERIFY_CRL_EXPIRED";
         case __OE_RESULT_MAX:
             break;
     }

--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -178,7 +178,10 @@ oe_result_t VerifyQuoteImpl(
 
     if (sgx_quote->version != OE_SGX_QUOTE_VERSION)
     {
-        OE_RAISE(OE_VERIFY_FAILED);
+        OE_RAISE_MSG(
+            OE_VERIFY_FAILED,
+            "Unexpected quote version sgx_quote->version=%d",
+            sgx_quote->version);
     }
 
     // The certificate provided in the quote is preferred.
@@ -191,11 +194,15 @@ oe_result_t VerifyQuoteImpl(
     }
     else
     {
-        OE_RAISE(OE_MISSING_CERTIFICATE_CHAIN);
+        OE_RAISE_MSG(
+            OE_MISSING_CERTIFICATE_CHAIN,
+            "Unexpected certificate type (qe_cert_data.type=%d)",
+            qe_cert_data.type);
     }
 
     if (pem_pck_certificate == NULL)
-        OE_RAISE(OE_MISSING_CERTIFICATE_CHAIN);
+        OE_RAISE_MSG(
+            OE_MISSING_CERTIFICATE_CHAIN, "No certificate found", NULL);
 
     // PckCertificate Chain validations.
     {

--- a/common/sgx/revocation.c
+++ b/common/sgx/revocation.c
@@ -219,6 +219,10 @@ oe_result_t oe_enforce_revocation(
             &crl_issuer_chain[i],
             revocation_args.crl_issuer_chain[i],
             revocation_args.crl_issuer_chain_size[i]));
+        OE_TRACE_VERBOSE(
+            "CRL certificate[%d]: \n[%s]\n",
+            i,
+            revocation_args.crl_issuer_chain[i]);
     }
 
     // Verify the leaf cert.

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -503,12 +503,20 @@ oe_result_t oe_parse_tcb_info_json(
     if (itr == end)
     {
         if (platform_tcb_level->status != OE_TCB_LEVEL_STATUS_UP_TO_DATE)
+        {
+            for (uint32_t i = 0;
+                 i < OE_COUNTOF(platform_tcb_level->sgx_tcb_comp_svn);
+                 ++i)
+                OE_TRACE_VERBOSE(
+                    "sgx_tcb_comp_svn[%d] = 0x%x",
+                    i,
+                    platform_tcb_level->sgx_tcb_comp_svn[i]);
+            OE_TRACE_VERBOSE("pce_svn = 0x%x", platform_tcb_level->pce_svn);
             OE_RAISE_MSG(
                 OE_TCB_LEVEL_INVALID,
                 "Platform TCB (%d) is not up-to-date",
                 platform_tcb_level->status);
-
-        OE_TRACE_VERBOSE("TCB Info json parsing successful.\n");
+        }
         result = OE_OK;
     }
 done:

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -503,7 +503,10 @@ oe_result_t oe_parse_tcb_info_json(
     if (itr == end)
     {
         if (platform_tcb_level->status != OE_TCB_LEVEL_STATUS_UP_TO_DATE)
-            OE_RAISE(OE_TCB_LEVEL_INVALID);
+            OE_RAISE_MSG(
+                OE_TCB_LEVEL_INVALID,
+                "Platform TCB (%d) is not up-to-date",
+                platform_tcb_level->status);
 
         OE_TRACE_VERBOSE("TCB Info json parsing successful.\n");
         result = OE_OK;

--- a/enclave/cert.c
+++ b/enclave/cert.c
@@ -352,6 +352,7 @@ static oe_result_t _verify_whole_chain(mbedtls_x509_crt* chain)
             oe_verify_cert_error_t error;
             mbedtls_x509_crt_verify_info(
                 error.buf, sizeof(error.buf), "", flags);
+
             OE_RAISE_MSG(
                 OE_FAILURE,
                 "mbedtls_x509_crt_verify failed with %s (flags=0x%x)",
@@ -754,7 +755,7 @@ oe_result_t oe_cert_verify(
         OE_RAISE(OE_INVALID_PARAMETER);
     }
 
-    // Build the list of CRLS if any. Copy them onto auxilliary memory
+    // Build the list of CRLS if any. Copy them onto auxiliary memory
     // to avoid modifying them when putting them on the list.
     if (crls && num_crls)
     {
@@ -806,6 +807,8 @@ oe_result_t oe_cert_verify(
                 "mbedtls_x509_crt_verify failed with %s (flags=0x%x)\n",
                 error->buf,
                 flags);
+            if (flags & MBEDTLS_X509_BADCRL_EXPIRED)
+                OE_RAISE(OE_VERIFY_CRL_EXPIRED);
         }
         OE_RAISE(OE_VERIFY_FAILED);
     }

--- a/host/crypto/openssl/cert.c
+++ b/host/crypto/openssl/cert.c
@@ -713,7 +713,8 @@ oe_result_t oe_cert_verify(
 
         errorno = X509_STORE_CTX_get_error(ctx);
         OE_RAISE_MSG(
-            OE_VERIFY_FAILED,
+            (X509_V_ERR_CRL_HAS_EXPIRED == errorno) ? OE_VERIFY_CRL_EXPIRED
+                                                    : OE_VERIFY_FAILED,
             "X509_verify_cert failed!\n"
             " error: (%d) %s\n",
             errorno,

--- a/host/sgx/linux/sgxquoteprovider.c
+++ b/host/sgx/linux/sgxquoteprovider.c
@@ -141,6 +141,10 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
     uint8_t* p = 0;
     uint8_t* p_end = 0;
 
+#if defined(OE_USE_LIBSGX)
+    OE_CHECK(oe_initialize_quote_provider());
+#endif
+
     if (!_get_revocation_info || !_free_revocation_info)
         OE_RAISE(OE_QUOTE_PROVIDER_LOAD_ERROR);
 
@@ -199,6 +203,8 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
             OE_RAISE_MSG(
                 OE_INVALID_REVOCATION_INFO, "crl[%d].crl_data is NULL.", i);
         }
+        OE_TRACE_VERBOSE(
+            "crl_data = \n[%s]\n", revocation_info->crls[i].crl_data);
         // CRL is in DER format. Null not added.
         host_buffer_size += revocation_info->crls[i].crl_data_size;
 
@@ -326,6 +332,10 @@ oe_result_t oe_get_qe_identity_info(oe_get_qe_identity_info_args_t* args)
     uint8_t* p = 0;
     uint8_t* p_end = 0;
     OE_TRACE_INFO("Calling %s\n", __PRETTY_FUNCTION__);
+
+#if defined(OE_USE_LIBSGX)
+    OE_CHECK(oe_initialize_quote_provider());
+#endif
 
     if (!_get_qe_identity_info || !_free_qe_identity_info)
     {

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -264,6 +264,11 @@ typedef enum _oe_result
      */
     OE_UNSUPPORTED_ENCLAVE_IMAGE,
 
+    /**
+     * The CRL for a PCK certification expired
+     */
+    OE_VERIFY_CRL_EXPIRED,
+
     __OE_RESULT_MAX = OE_ENUM_MAX,
 } oe_result_t;
 /**< typedef enum _oe_result oe_result_t*/


### PR DESCRIPTION
1. Added a new error code OE_VERIFY_CRL_EXPIRED, used when handling CRL expiration error from the 
_verify_cert call (such as  MBEDTLS_X509_BADCRL_EXPIRED  from X509_verify_cert )
2. Added logging for bad OE_SGX_QUOTE_VERSION input 
3. Added logging to distinguish two different OE_MISSING_CERTIFICATE_CHAIN error scenarios.
3. Logged crl_issuer_chain information in verbose mode
4. Added more debug message for OE_TCB_LEVEL_INVALID error code
5. Call oe_initialize_quote_provider() for oe_get_revocation_info call paths, which enable a host to verify a remote report without having to call get_report first