### PR TITLE
Fix Ubuntu 18.04 GCC tests

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -79,7 +79,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
 
   # We should only need this for in-enclave code but it's easier
   # and conservative to specify everywhere
-  add_compile_options(-fno-builtin-malloc -fno-builtin-calloc)
+  add_compile_options(-fno-builtin-malloc -fno-builtin-calloc -fno-builtin)
 elseif (MSVC)
   # MSVC options go here
   if (MSVC_VERSION VERSION_LESS 1910)

--- a/cmake/maybe_build_using_clangw.cmake
+++ b/cmake/maybe_build_using_clangw.cmake
@@ -40,7 +40,7 @@ function(maybe_build_using_clangw OE_TARGET)
         -Wall -Werror -Wpointer-arith -Wconversion -Wextra -Wno-missing-field-initializers
         -fno-strict-aliasing
         -mxsave
-        -fno-builtin-malloc -fno-builtin-calloc)
+        -fno-builtin-malloc -fno-builtin-calloc -fno-builtin)
 
     # Setup library names variables
     set(CMAKE_STATIC_LIBRARY_PREFIX "lib" PARENT_SCOPE)

--- a/tests/oeedger8r/enc/testpointer.cpp
+++ b/tests/oeedger8r/enc/testpointer.cpp
@@ -266,7 +266,17 @@ static T* ecall_pointer_fun_impl(
         if (p4)
         {
             OE_TEST(oe_is_within_enclave(p4, sizeof(T) * 16));
-            OE_TEST(memcmp(p4, exp, sizeof(T) * 16) == 0);
+
+            // This next test verifies that the elements in p4[] are equivalent
+            // to the expected elements in exp[]. Previously, this next test
+            // line did a 'memcmp' over the entirety of the array. A 'memcmp'
+            // function call will not work for the 'long double' type. This
+            // is because the 'long double' type appears to use only 10 of its
+            // 16 bytes for actual data, and the extra 6 bytes are irrelevant.
+            // (On x86_64 systems, at least). Those irrelevant bytes can differ
+            // between two 'long double' values, and yet those values will be
+            // considered equivalent.
+            OE_TEST(array_compare(exp, p4) == 0);
 
             // change p4. Should not have any effect on host.
             memset(p4, 0, sizeof(T) * 16);
@@ -276,7 +286,7 @@ static T* ecall_pointer_fun_impl(
         if (p5)
         {
             OE_TEST(oe_is_within_enclave(p5, sizeof(T) * 16));
-            OE_TEST(memcmp(p5, exp, sizeof(T) * 16) == 0);
+            OE_TEST(array_compare(exp, p5) == 0);
             reverse(p5, 16);
         }
 


### PR DESCRIPTION
This PR contains two fixes that are necessary to enabling Ubuntu 18.04 builds/tests with gcc. The first change tells the gcc compiler to not use builtin functions, which the new compiler optimizer tends to use very often. In fact, there is some very weird behavior where it will expect "memmove" as a required undefined symbol in one of the object files we produce, even though we don't reference memmove anywhere in that translation unit (and in fact, we redefine memmove to be "oe_memmove"). This is probably a compiler optimization bug, but honestly I have no clue! There were also issues with gcc in-lining floating point rounding functions when we want to use specifically defined assembly routines. In any case, adding the "-fno-builtin" option at compile time resolves these issues.

The other change in this PR is associated with the use of 'memcmp' over the full 16 bytes of a 'long double' type to compare equality of long double values. This is not a reliable way to compare two long double values, because the long double type appears to use only 10 of its 16 bytes for actual data when compiled with gcc, and the extra 6 bytes are irrelevant for equivalency (on x86_64 systems, at least). Those irrelevant bytes can differ between two long double values, and yet those values will be considered equivalent. https://en.wikipedia.org/wiki/Long_double#Implementations

Perhaps clang-7 and earlier versions of gcc always initialize these irrelevant bits of the long double type to zero? Or maybe they use all 16 bytes? I'll probably look into this sometime, for curiosity's sake.
