### PR TITLE
Refactor and fix Jenkinsfile

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -3,10 +3,10 @@ def PowerShellWrapper(psCmd) {
     bat "powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command \"\$ErrorActionPreference='Stop';[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;$psCmd;EXIT \$global:LastExitCode\""
 }
 
-def ACCTest(String label, String compiler, String platform_mode, String build_type) {
-    def c_compiler
-    def cpp_compiler
-    stage("${label} ${compiler} ${platform_mode} ${build_type}") {
+def ACCTest(String label, String compiler, String build_type) {
+    def c_compiler = "clang-7"
+    def cpp_compiler = "clang++-7"
+    stage("${label} ${compiler} SGX1FLC ${build_type}") {
         node("${label}") {
             cleanWs()
             checkout scm
@@ -16,9 +16,6 @@ def ACCTest(String label, String compiler, String platform_mode, String build_ty
                     if (compiler == "gcc") {
                         c_compiler = "gcc"
                         cpp_compiler = "g++"
-                    } else if (compiler == "clang-7") {
-                        c_compiler = "clang-7"
-                        cpp_compiler = "clang++-7"
                     }
                     withEnv(["CC=${c_compiler}","CXX=${cpp_compiler}"]) {
                         sh """
@@ -34,10 +31,8 @@ def ACCTest(String label, String compiler, String platform_mode, String build_ty
     }
 }
 
-def simulationTest(String compiler, String platform_mode, String build_type ) {
-    def c_compiler
-    def cpp_compiler
-    stage("Sim ${compiler} ${platform_mode} ${build_type}") {
+def simulationTest(String platform_mode, String build_type) {
+    stage("Sim clang-7 ${platform_mode} ${build_type}") {
         node {
             cleanWs()
             checkout scm
@@ -46,14 +41,7 @@ def simulationTest(String compiler, String platform_mode, String build_type ) {
             oetoolsSim.inside {
                 timeout(15) {
                     dir('build') {
-                        if (compiler == "gcc") {
-                            c_compiler = "gcc"
-                            cpp_compiler = "g++"
-                        } else if (compiler == "clang-7") {
-                            c_compiler = "clang-7"
-                            cpp_compiler = "clang++-7"
-                        }
-                        withEnv(["CC=${c_compiler}","CXX=${cpp_compiler}","OE_SIMULATION=1"]) {
+                        withEnv(["CC=clang-7","CXX=clang++-7","OE_SIMULATION=1"]) {
                             sh """
                             cmake .. -DCMAKE_BUILD_TYPE=${build_type} -DUSE_LIBSGX=OFF
                             make
@@ -122,7 +110,7 @@ def checkDevFlows() {
                         sh '''
                         cmake .. -DUSE_LIBSGX=OFF
                         make
-                    '''
+                        '''
                         // Note that `make package` is not expected to work
                         // without extra configuration.
                     }
@@ -174,23 +162,23 @@ def win2016CrossCompile(String build_type) {
     }
 }
 
-parallel "Check Developer Experience" :         { checkDevFlows() },
-        "Sim clang-7 SGX1 Debug" :              { simulationTest('clang-7', 'SGX1', 'Debug')},
-        "Sim clang-7 SGX1 Release" :            { simulationTest('clang-7', 'SGX1', 'Release')},
-        "Sim clang-7 SGX1 RelWithDebInfo" :     { simulationTest('clang-7', 'SGX1', 'RelWithDebInfo')},
-        "Sim clang-7 SGX1-FLC Debug" :          { simulationTest('clang-7', 'SGX1FLC', 'Debug')},
-        "Sim clang-7 SGX1-FLC Release" :        { simulationTest('clang-7', 'SGX1FLC', 'Release')},
-        "Sim clang-7 SGX1-FLC RelWithDebInfo" : { simulationTest('clang-7', 'SGX1FLC', 'RelWithDebInfo')},
-        "ACC1604 clang-7 Debug" :               { ACCTest('ACC-1604', 'clang-7', 'SGX1FLC', 'Debug') },
-        "ACC1604 clang-7 Release" :             { ACCTest('ACC-1604', 'clang-7', 'SGX1FLC','Release') },
-        "ACC1604 clang-7 RelWithDebInfo" :      { ACCTest('ACC-1604', 'clang-7', 'SGX1FLC', 'RelWithDebinfo') },
-        "ACC1604 gcc Debug" :                   { ACCTest('ACC-1604', 'gcc', 'SGX1FLC', 'Debug') },
-        "ACC1604 gcc Release" :                 { ACCTest('ACC-1604', 'gcc', 'SGX1FLC', 'Release') },
-        "ACC1604 gcc RelWithDebInfo" :          { ACCTest('ACC-1604', 'gcc', 'SGX1FLC', 'RelWithDebInfo') },
-        "ACC1804 clang-7 Debug" :               { ACCTest('ACC-1804', 'clang-7', 'SGX1FLC', 'Debug') },
-        "ACC1804 clang-7 RelWithDebInfo" :      { ACCTest('ACC-1804', 'clang-7', 'SGX1FLC', 'RelWithDebinfo') },
-        "Win2016 Debug Cross Compile" :         { win2016CrossCompile("Debug") },
-        "Win2016 Release Cross Compile" :       { win2016CrossCompile("Release") },
-        "Win2016 Debug Linux-Elf-build" :       { win2016LinuxElfBuild("Debug") },
-        "Win2016 Release Linux-Elf-build" :     { win2016LinuxElfBuild("Release") },
-        "ACC1604 Container RelWithDebInfo" :    { ACCContainerTest('ACC-1604') }
+parallel "Check Developer Experience" :          { checkDevFlows() },
+         "Sim clang-7 SGX1 Debug" :              { simulationTest('SGX1', 'Debug')},
+         "Sim clang-7 SGX1 Release" :            { simulationTest('SGX1', 'Release')},
+         "Sim clang-7 SGX1 RelWithDebInfo" :     { simulationTest('SGX1', 'RelWithDebInfo')},
+         "Sim clang-7 SGX1-FLC Debug" :          { simulationTest('SGX1FLC', 'Debug')},
+         "Sim clang-7 SGX1-FLC Release" :        { simulationTest('SGX1FLC', 'Release')},
+         "Sim clang-7 SGX1-FLC RelWithDebInfo" : { simulationTest('SGX1FLC', 'RelWithDebInfo')},
+         "ACC1604 clang-7 Debug" :               { ACCTest('ACC-1604', 'clang-7', 'Debug') },
+         "ACC1604 clang-7 Release" :             { ACCTest('ACC-1604', 'clang-7', 'Release') },
+         "ACC1604 clang-7 RelWithDebInfo" :      { ACCTest('ACC-1604', 'clang-7', 'RelWithDebinfo') },
+         "ACC1604 gcc Debug" :                   { ACCTest('ACC-1604', 'gcc', 'Debug') },
+         "ACC1604 gcc Release" :                 { ACCTest('ACC-1604', 'gcc', 'Release') },
+         "ACC1604 gcc RelWithDebInfo" :          { ACCTest('ACC-1604', 'gcc', 'RelWithDebInfo') },
+         "ACC1804 clang-7 Debug" :               { ACCTest('ACC-1804', 'clang-7', 'Debug') },
+         "ACC1804 clang-7 RelWithDebInfo" :      { ACCTest('ACC-1804', 'clang-7', 'RelWithDebinfo') },
+         "Win2016 Debug Cross Compile" :         { win2016CrossCompile("Debug") },
+         "Win2016 Release Cross Compile" :       { win2016CrossCompile("Release") },
+         "Win2016 Debug Linux-Elf-build" :       { win2016LinuxElfBuild("Debug") },
+         "Win2016 Release Linux-Elf-build" :     { win2016LinuxElfBuild("Release") },
+         "ACC1604 Container RelWithDebInfo" :    { ACCContainerTest('ACC-1604') }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -32,6 +32,10 @@ def ACCTest(String label, String compiler, String build_type) {
 }
 
 def simulationTest(String platform_mode, String build_type) {
+    def use_libsgx = "OFF"
+    if (platform_mode == "SGX1FLC") {
+        use_libsgx = "ON"
+    }
     stage("Sim clang-7 ${platform_mode} ${build_type}") {
         node {
             cleanWs()
@@ -43,7 +47,7 @@ def simulationTest(String platform_mode, String build_type) {
                     dir('build') {
                         withEnv(["CC=clang-7","CXX=clang++-7","OE_SIMULATION=1"]) {
                             sh """
-                            cmake .. -DCMAKE_BUILD_TYPE=${build_type} -DUSE_LIBSGX=OFF
+                            cmake .. -DCMAKE_BUILD_TYPE=${build_type} -DUSE_LIBSGX=${use_libsgx}
                             make
                             ctest --output-on-failure
                             """

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -132,8 +132,8 @@ def checkDevFlows() {
     }
 }
 
-def win2016DebugLinuxElfBuild() {
-    stage('Linux SGX1 Debug') {
+def win2016LinuxElfBuild(String build_type) {
+    stage("Linux SGX1 ${build_type}") {
         node {
             cleanWs()
             checkout scm
@@ -143,78 +143,37 @@ def win2016DebugLinuxElfBuild() {
                     dir('build') {
                         withEnv(["CC=clang-7","CXX=clang++-7"]) {
                             sh """
-                            cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_DEBUG_MALLOC=OFF
+                            cmake .. -DCMAKE_BUILD_TYPE=${build_type} -DUSE_DEBUG_MALLOC=OFF
                             make
                             """
                         }
                     }
-                    stash includes: 'build/tests/**', name: 'linuxdebug'
+                    stash includes: 'build/tests/**', name: "linux${build_type}"
                 }
             }
         }
     }
-    stage('Windows Debug') {
+    stage("Windows ${build_type}") {
         node('SGXFLC-Windows') {
             cleanWs()
             checkout scm
-            unstash 'linuxdebug'
+            unstash "linux${build_type}"
             PowerShellWrapper('mv build linuxbin')
-            PowerShellWrapper('./scripts/test-build-config.ps1 -add_windows_enclave_tests -build_type Debug -linux_bin_dir $ENV:WORKSPACE/linuxbin/tests')
+            PowerShellWrapper("./scripts/test-build-config.ps1 -add_windows_enclave_tests -build_type ${build_type} -linux_bin_dir ${WORKSPACE}/linuxbin/tests")
        }
     }
 }
 
-def win2016ReleaseLinuxElfBuild() {
-    stage('Linux SGX1 Release') {
-        node {
-            cleanWs()
-            checkout scm
-            def oetoolsWin = docker.build("oetools-wincp", "-f .jenkins/Dockerfile .")
-            oetoolsWin.inside {
-                timeout(15) {
-                    dir('build') {
-                        withEnv(["CC=clang-7","CXX=clang++-7"]) {
-                            sh """
-                            cmake .. -DCMAKE_BUILD_TYPE=Release
-                            make
-                            """
-                        }
-                    }
-                    stash includes: 'build/tests/**', name: 'linuxrelease'
-                }
-            }
-        }
-    }
-    stage('Windows Release') {
+def win2016CrossCompile(String build_type) {
+    stage("Windows ${build_type}") {
         node('SGXFLC-Windows') {
             cleanWs()
             checkout scm
-            unstash 'linuxrelease'
-            PowerShellWrapper('mv build linuxbin')
-            PowerShellWrapper('./scripts/test-build-config.ps1 -add_windows_enclave_tests -build_type Release -linux_bin_dir $ENV:WORKSPACE/linuxbin/tests')
-        }
-    }
-}
-
-def win2016DebugCrossCompile() {
-    stage('Windows Debug') {
-        node('SGXFLC-Windows') {
-            cleanWs()
-            checkout scm
-            PowerShellWrapper('./scripts/test-build-config.ps1 -build_type Debug -build_enclaves')
+            PowerShellWrapper("./scripts/test-build-config.ps1 -build_type ${build_type} -build_enclaves")
        }
     }
 }
 
-def win2016ReleaseCrossCompile() {
-    stage('Windows Release') {
-        node('SGXFLC-Windows') {
-            cleanWs()
-            checkout scm
-            PowerShellWrapper('./scripts/test-build-config.ps1 -build_type Release -build_enclaves')
-        }
-    }
-}
 parallel "Check Developer Experience" :         { checkDevFlows() },
         "Sim clang-7 SGX1 Debug" :              { simulationTest('clang-7', 'SGX1', 'Debug')},
         "Sim clang-7 SGX1 Release" :            { simulationTest('clang-7', 'SGX1', 'Release')},
@@ -230,8 +189,8 @@ parallel "Check Developer Experience" :         { checkDevFlows() },
         "ACC1604 gcc RelWithDebInfo" :          { ACCTest('ACC-1604', 'gcc', 'SGX1FLC', 'RelWithDebInfo') },
         "ACC1804 clang-7 Debug" :               { ACCTest('ACC-1804', 'clang-7', 'SGX1FLC', 'Debug') },
         "ACC1804 clang-7 RelWithDebInfo" :      { ACCTest('ACC-1804', 'clang-7', 'SGX1FLC', 'RelWithDebinfo') },
-        "Win2016 Debug Cross Compile" :         { win2016DebugCrossCompile() },
-        "Win2016 Release Cross Compile" :       { win2016ReleaseCrossCompile() },
-        "Win2016 Debug Linux-Elf-build" :       { win2016DebugLinuxElfBuild() },
-        "Win2016 Release Linux-Elf-build" :     { win2016ReleaseLinuxElfBuild() },
+        "Win2016 Debug Cross Compile" :         { win2016CrossCompile("Debug") },
+        "Win2016 Release Cross Compile" :       { win2016CrossCompile("Release") },
+        "Win2016 Debug Linux-Elf-build" :       { win2016LinuxElfBuild("Debug") },
+        "Win2016 Release Linux-Elf-build" :     { win2016LinuxElfBuild("Release") },
         "ACC1604 Container RelWithDebInfo" :    { ACCContainerTest('ACC-1604') }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -3,11 +3,11 @@ def PowerShellWrapper(psCmd) {
     bat "powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command \"\$ErrorActionPreference='Stop';[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;$psCmd;EXIT \$global:LastExitCode\""
 }
 
-def ACCTest(String label, String compiler, String unit, String suite) {
+def ACCTest(String label, String compiler, String platform_mode, String build_type) {
     def c_compiler
     def cpp_compiler
-    stage("$label $compiler $unit $suite") {
-        node("$label") {
+    stage("${label} ${compiler} ${platform_mode} ${build_type}") {
+        node("${label}") {
             cleanWs()
             checkout scm
 
@@ -22,7 +22,7 @@ def ACCTest(String label, String compiler, String unit, String suite) {
                     }
                     withEnv(["CC=${c_compiler}","CXX=${cpp_compiler}"]) {
                         sh """
-                        cmake .. -DCMAKE_BUILD_TYPE=${suite}
+                        cmake .. -DCMAKE_BUILD_TYPE=${build_type}
                         make
                         ctest --output-on-failure
                         """
@@ -34,10 +34,10 @@ def ACCTest(String label, String compiler, String unit, String suite) {
     }
 }
 
-def simulationTest(String compiler, String unit, String suite ) {
+def simulationTest(String compiler, String platform_mode, String build_type ) {
     def c_compiler
     def cpp_compiler
-    stage("Sim $compiler $unit $suite") {
+    stage("Sim ${compiler} ${platform_mode} ${build_type}") {
         node {
             cleanWs()
             checkout scm
@@ -55,7 +55,7 @@ def simulationTest(String compiler, String unit, String suite ) {
                         }
                         withEnv(["CC=${c_compiler}","CXX=${cpp_compiler}","OE_SIMULATION=1"]) {
                             sh """
-                            cmake .. -DCMAKE_BUILD_TYPE=${suite} -DUSE_LIBSGX=OFF
+                            cmake .. -DCMAKE_BUILD_TYPE=${build_type} -DUSE_LIBSGX=OFF
                             make
                             ctest --output-on-failure
                             """
@@ -68,8 +68,8 @@ def simulationTest(String compiler, String unit, String suite ) {
 }
 
 def ACCContainerTest(String label) {
-    stage("$label Container RelWithDebInfo") {
-        node("$label") {
+    stage("${label} Container RelWithDebInfo") {
+        node("${label}") {
             cleanWs()
             checkout scm
 


### PR DESCRIPTION
- Rename Jenkins variables:
    suite -> build_type
    unit -> platform_mode

- Refactored Windows functions:
   win2016ReleaseLinuxElfBuild, win2016DebugLinuxElfBuild  -> win2016LinuxElfBuild(build_type)
   win2016ReleaseCrossCompile, win2016DebugCrossCompile  -> win2016CrossCompile(build_type)

- Removed unused platform_mode parameter from ACCTest

- Removed unused compiler parameter from SimulationTest

- Add -DUSE_LIBSGX=ON for SGX1FLC Simulation tests
     Currently Simulation tests are running with -DUSE_LIBSGX=OFF for all types of Simulation tests
     Added check to use -DUSE_LIBSGX=ON for SGX1FLC platform_mode 