### PR TITLE
Small fixes around CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,8 @@ endif ()
 
 # TODO: See #756: Fix this because it is incompatible with
 # multi-configuration generators
-if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT WIN32)
+string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+if (uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" AND NOT WIN32)
   # In non-win32 debug build, debug_malloc is on by default
   option(USE_DEBUG_MALLOC "Build oeenclave with memory leak detection capability." ON)
 else ()

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -31,7 +31,7 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebIn
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_SUFFIX)
 if (NOT DEFINED CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_SUFFIX})
-  message(FATAL_ERROR "Unknown CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE_SUFFIX}")
+  message(FATAL_ERROR "Unknown CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 endif ()
 
 # TODO: When ARM support is added, we will need to exclude the check


### PR DESCRIPTION
  Error out using user defined CMAKE_BUILD_TYPE
  Use case insensitive compare when checking the CMAKE_BUILD_TYPE

 CMakeLists.txt                | 3 ++-
 cmake/compiler_settings.cmake | 2 +-
 2 files changed, 3 insertions(+), 2 deletions(-)