### PR TITLE
Fix exported CMake package

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+# NOTE: This is set here so that both `libcxx` and `musl` can use it
+# without setting it twice. This is necessary due to an odd dependency
+# between the two targets. See their respective CMake files for more
+# details.
+set(LIBCXX_INCLUDES ${OE_INCDIR}/openenclave/libcxx)
+
 add_subdirectory(libcxx)
 add_subdirectory(libcxxrt)
 add_subdirectory(libunwind)

--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-set(LIBCXX_INCLUDES ${OE_INCDIR}/openenclave/libcxx)
-
 include (ExternalProject)
 ExternalProject_Add(libcxx_includes
   DOWNLOAD_COMMAND ""
@@ -64,10 +62,10 @@ target_compile_definitions(libcxx
 
 target_link_libraries(libcxx PUBLIC oelibc)
 
+# NOTE: The `PUBLIC` headers for `libcxx` are actually added to
+# `oelibc_includes`, this is necessary to get the ordering correct.
+# See `../musl/CMakeLists.txt` for more details.
 target_include_directories(libcxx
-  PUBLIC
-  $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${LIBCXX_INCLUDES}>>
-  $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
   PRIVATE
   libcxx/src
   ../libcxxrt/libcxxrt/src)

--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -67,7 +67,7 @@ target_link_libraries(libcxx PUBLIC oelibc)
 target_include_directories(libcxx
   PUBLIC
   $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${LIBCXX_INCLUDES}>>
-  $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
+  $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
   PRIVATE
   libcxx/src
   ../libcxxrt/libcxxrt/src)

--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -81,15 +81,15 @@ add_dependencies(mbedcrypto mbedtls-wrap)
 
 target_include_directories(mbedcrypto INTERFACE
   $<BUILD_INTERFACE:${SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty>)
 
 target_link_libraries(mbedcrypto INTERFACE
   $<BUILD_INTERFACE:mbedtls_imported>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/libmbedtls.a>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/libmbedtls.a>
   $<BUILD_INTERFACE:mbedx509_imported>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/libmbedx509.a>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/libmbedx509.a>
   $<BUILD_INTERFACE:mbedcrypto_imported>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/libmbedcrypto.a>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/openenclave/enclave/libmbedcrypto.a>
   # NOTE: This dependency is repeated because during installation the
   # imported libraries are not part of the CMake dependency graph, so
   # this transitive dependency would be left out.

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -105,7 +105,7 @@ add_dependencies(oelibc_includes musl_includes)
 target_include_directories(oelibc_includes
   SYSTEM INTERFACE
   $<BUILD_INTERFACE:${MUSL_INCLUDES}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libc>)
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libc>)
 
 if (CMAKE_C_COMPILER_ID MATCHES GNU AND
     CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "7.1.0")

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -95,15 +95,24 @@ add_library(oelibc_includes INTERFACE)
 
 add_dependencies(oelibc_includes musl_includes)
 
-# NOTE: This is explicitly marked as a `SYSTEM` directory because it
-# must be searched last. In particularly, the headers found in
-# `libcxx` utilize an unfortunate GNU pre-processor extension,
-# `#include_next`, which forces an order on the include paths. It
-# means that `-Ilibcxx` must come before `-Ilibc`, and the least
-# troublesome way to do this in CMake is set this as a `SYSTEM`
-# include path.
+# NOTE: The `libcxx` headers are added to this target, not `libcxx`
+# itself, so that the correct ordering is enforced. See
+# `../libcxxrt/CMakeLists.txt` for the target.
+#
+# In particular, the headers found in `libcxx` utilize an unfortunate
+# GNU pre-processor extension, `#include_next`, which forces an order
+# on the include paths. It means that `-Ilibcxx` must come before
+# `-Ilibc`, and the least troublesome way to do this in CMake is to
+# explicitly add them to the same target. We previously accomplished
+# this by setting the `libc` headers as `SYSTEM` headers, but this
+# approach broke down in the exported CMake package.
+#
+# TODO: Perhaps give this a less misleading name as it includes both C
+# and C++ headers (but the latter only when the language is C++).
 target_include_directories(oelibc_includes
-  SYSTEM INTERFACE
+  INTERFACE
+  $<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:${LIBCXX_INCLUDES}>>
+  $<INSTALL_INTERFACE:$<$<COMPILE_LANGUAGE:CXX>:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libcxx>>
   $<BUILD_INTERFACE:${MUSL_INCLUDES}>
   $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/openenclave/3rdparty/libc>)
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,8 +7,7 @@ add_library(oe_includes INTERFACE)
 add_dependencies(oe_includes oe_includes_place)
 target_include_directories(oe_includes INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    )
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>)
 install(DIRECTORY openenclave/bits DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(DIRECTORY openenclave/edger8r DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)
 install(FILES openenclave/enclave.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openenclave/)

--- a/tools/oeedger8r/CMakeLists.txt
+++ b/tools/oeedger8r/CMakeLists.txt
@@ -72,4 +72,11 @@ add_dependencies(edger8r oeedger8r_target)
 
 # Can't use `install(TARGETS)` on an imported executable, because it
 # causes CMake to crash with a segmentation fault.
+#
+# TODO: Get CMake to fix this as it is particularly annoying. It
+# prevents us from exporting a proper target for our users to consume.
+#
+# Because of this bug, consumers of the Open Enclave SDK CMake package
+# are forced to manually import the oeedger8r executable into their
+# graph.
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${BINARY} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(oesign oehost)
 set_property(TARGET oesign PROPERTY RUNTIME_OUTPUT_DIRECTORY ${OE_BINDIR})
 
 # install rule
-install (TARGETS oesign EXPORT openenclave DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS oesign EXPORT openenclave-targets DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This fixes our project to export a mostly usable [CMake package](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#creating-packages). It's been loosely tested against @Lusitanian's code base.