### PR TITLE
Added optional pceid parsing in tcbinfo json 

### DIFF
--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -431,6 +431,28 @@ static oe_result_t _read_tcb_info(
         itr, end, parsed_info->fmspc, sizeof(parsed_info->fmspc)));
     OE_CHECK(_read(',', itr, end));
 
+    {
+        const uint8_t* old_itr = *itr;
+
+        // read optional "pceId", if it does not exist, restore the read
+        // pointers
+        OE_TRACE_VERBOSE("Attempt reading optional pceId field...");
+
+        parsed_info->pceid[0] = 0;
+        parsed_info->pceid[1] = 0;
+        result = _read_property_name_and_colon("pceId", itr, end);
+        if (result == OE_OK)
+        {
+            OE_CHECK(_read_hex_string(
+                itr, end, parsed_info->pceid, sizeof(parsed_info->pceid)));
+            OE_CHECK(_read(',', itr, end));
+        }
+        else if (result == OE_JSON_INFO_PARSE_ERROR)
+        {
+            *itr = old_itr;
+        }
+    }
+
     OE_TRACE_VERBOSE("Reading tcbLevels");
     OE_CHECK(_read_property_name_and_colon("tcbLevels", itr, end));
     OE_CHECK(_read('[', itr, end));

--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -38,6 +38,7 @@ typedef struct _oe_parsed_tcb_info
     oe_datetime_t issue_date;
     oe_datetime_t next_update;
     uint8_t fmspc[6];
+    uint8_t pceid[2];
     uint8_t signature[64];
     const uint8_t* tcb_info_start;
     size_t tcb_info_size;

--- a/tests/report/data/tcbInfo_with_pceid.json
+++ b/tests/report/data/tcbInfo_with_pceid.json
@@ -1,0 +1,100 @@
+{
+  "tcbInfo": {
+    "version": 1,
+    "issueDate": "2018-06-06T10:12:17Z",
+    "nextUpdate": "2019-06-06T10:12:17Z",
+    "fmspc": "00906EA10000",
+    "pceId":"0000",
+    "tcbLevels": [
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 4,
+          "sgxtcbcomp02svn": 4,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 5
+        },
+        "status": "UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 4
+        },
+        "status": "ConfigurationNeeded"
+      }, 
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 3
+        },
+        "status": "OutOfDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomp01svn": 2,
+          "sgxtcbcomp02svn": 2,
+          "sgxtcbcomp03svn": 2,
+          "sgxtcbcomp04svn": 4,
+          "sgxtcbcomp05svn": 1,
+          "sgxtcbcomp06svn": 128,
+          "sgxtcbcomp07svn": 1,
+          "sgxtcbcomp08svn": 1,
+          "sgxtcbcomp09svn": 1,
+          "sgxtcbcomp10svn": 1,
+          "sgxtcbcomp11svn": 1,
+          "sgxtcbcomp12svn": 1,
+          "sgxtcbcomp13svn": 1,
+          "sgxtcbcomp14svn": 1,
+          "sgxtcbcomp15svn": 1,
+          "sgxtcbcomp16svn": 1,
+          "pcesvn": 2
+        },
+        "status": "Revoked"
+      }
+    ]
+  },
+  "signature": "62d181c4ba863213b825d1c0b66b92a3dbdb27b8ff7c7250cb2b2ab87a8f90d5e5a1416914369d8f82c56cd3d875caa54ae4b917caf4af7a93dec52067cbfd7b"
+}

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -16,7 +16,9 @@
 
 #define SKIP_RETURN_CODE 2
 
-extern void TestVerifyTCBInfo(oe_enclave_t* enclave);
+extern void TestVerifyTCBInfo(
+    oe_enclave_t* enclave,
+    const char* test_file_name);
 extern std::vector<uint8_t> FileToBytes(const char* path);
 
 void generate_and_save_report(oe_enclave_t* enclave)
@@ -125,7 +127,8 @@ int main(int argc, const char* argv[])
 #ifdef OE_USE_LIBSGX
     OE_TEST(enclave_test_remote_verify_report(enclave) == OE_OK);
 
-    TestVerifyTCBInfo(enclave);
+    TestVerifyTCBInfo(enclave, "./data/tcbInfo.json");
+    TestVerifyTCBInfo(enclave, "./data/tcbInfo_with_pceid.json");
 
     // Get current time and pass it to enclave.
     std::time_t t = std::time(0);


### PR DESCRIPTION
The recent TCB Info contains pceid field, which is not supported by the the current hardcoded CBInfo parser. This PR is to make the parser can optionally handle an pceid field.
