### PR TITLE
Force overwrite CMake binaries if they exist

### DIFF
--- a/scripts/ansible/roles/linux/openenclave/tasks/environment-setup.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/environment-setup.yml
@@ -48,6 +48,7 @@
   file:
     src: "/usr/local/cmake-3.13.1-Linux-x86_64/bin/{{ item }}"
     dest: "/usr/local/bin/{{ item }}"
+    force: yes
     state: link
   with_items:
     - ccmake


### PR DESCRIPTION
If the CMake binaries are present in /usr/local/bin
this patch will force update them to symbolic links

Fixes https://github.com/Microsoft/openenclave/issues/1371