### PR TITLE
Remove custom oelibc pthread member from td_t

### DIFF
--- a/enclave/core/sgx/errno.c
+++ b/enclave/core/sgx/errno.c
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <openenclave/corelibc/assert.h>
 #include <openenclave/corelibc/errno.h>
-#include <openenclave/enclave.h>
-#include <openenclave/internal/sgxtypes.h>
+
+static __thread int _oe_errno = 0;
 
 int* __oe_errno_location(void)
 {
-    td_t* td = (td_t*)oe_get_thread_data();
-    oe_assert(td);
-    return &td->linux_errno;
+    return &_oe_errno;
 }

--- a/include/openenclave/internal/sgxtypes.h
+++ b/include/openenclave/internal/sgxtypes.h
@@ -554,7 +554,7 @@ oe_thread_data_t* oe_get_thread_data(void);
 
 #define TD_MAGIC 0xc90afe906c5d19a3
 
-#define OE_THREAD_LOCAL_SPACE (3304)
+#define OE_THREAD_LOCAL_SPACE (3840)
 
 typedef struct _callsite Callsite;
 
@@ -594,19 +594,6 @@ typedef struct _td
 
     /* Simulation mode is active if non-zero */
     uint64_t simulate;
-
-    /* Linux error number: from <errno.h> */
-    int linux_errno;
-    int padding1;
-
-    // The pthread implementation structure is overlaid here. This is only
-    // used by oelibc to implement the pthread functions (see libc/pthread.c
-    // for details).
-    uint64_t pthread[64];
-
-    // List of functions to call when the thread exits.
-    oe_tls_atexit_t* tls_atexit_functions;
-    uint64_t num_tls_atexit_functions;
 
     /* Reserved for thread-local variables. */
     uint8_t thread_local_data[OE_THREAD_LOCAL_SPACE];


### PR DESCRIPTION
With the added support for `thread_local` and `__thread` keywords, refactor `oelibc` to declare its own thread local structure for MUSL pthread instead of requiring `oecore` to break encapsulation by with a custom member in `td_t`.