### PR TITLE
Fixes to oeenclave OP-TEE build and NuGet targets

### DIFF
--- a/new_platforms/nuget/build/native/openenclave.targets
+++ b/new_platforms/nuget/build/native/openenclave.targets
@@ -328,7 +328,7 @@
     -->
 
     <!-- Post-Build Events for Enclaves -->
-    <ItemDefinitionGroup Condition="'$(OEType)' == 'Enclave' And '$(ConfigurationType)'=='DynamicLibrary'">
+    <ItemDefinitionGroup Condition="'$(OEType)' == 'Enclave' And '$(ConfigurationType)' == 'DynamicLibrary'">
         <!-- *-SGX-* & *-SGX-Simulation-* -->
         <PostBuildEvent Condition="$(OEIsSgx) == True">
             <Command>"$(SGXSDKInstallPath)bin\win32\release\sgx_sign.exe" sign -key "$(ProjectDir)$(TargetName)_private.pem" -enclave "$(OutDir)$(TargetFileName)" -out "$(OutDir)$(TargetName).signed.dll" -config "$(ProjectDir)$(TargetName).config.xml"</Command>
@@ -336,7 +336,7 @@
         </PostBuildEvent>
 
         <!-- *-SGX-Release -->
-        <PostBuildEvent Condition="$(OEIsSgx) == True And '$(ConfigurationType)'=='DynamicLibrary' And $(OEIsSim) == False And $(OEIsRelease) == True">
+        <PostBuildEvent Condition="$(OEIsSgx) == True And '$(ConfigurationType)' == 'DynamicLibrary' And $(OEIsSim) == False And $(OEIsRelease) == True">
             <Command>"$(SGXSDKInstallPath)bin\win32\release\sgx_sign.exe" gendata -enclave "$(OutDir)$(TargetFileName)" -out "$(OutDir)$(TargetName).hex" -config "$(ProjectDir)$(TargetName).config.xml"</Command>
             <Message>Generate the enclave signing material for Intel SGX.</Message>
         </PostBuildEvent>

--- a/new_platforms/nuget/build/native/openenclave.targets
+++ b/new_platforms/nuget/build/native/openenclave.targets
@@ -328,7 +328,7 @@
     -->
 
     <!-- Post-Build Events for Enclaves -->
-    <ItemDefinitionGroup Condition="'$(OEType)' == 'Enclave'">
+    <ItemDefinitionGroup Condition="'$(OEType)' == 'Enclave' And '$(ConfigurationType)'=='DynamicLibrary'">
         <!-- *-SGX-* & *-SGX-Simulation-* -->
         <PostBuildEvent Condition="$(OEIsSgx) == True">
             <Command>"$(SGXSDKInstallPath)bin\win32\release\sgx_sign.exe" sign -key "$(ProjectDir)$(TargetName)_private.pem" -enclave "$(OutDir)$(TargetFileName)" -out "$(OutDir)$(TargetName).signed.dll" -config "$(ProjectDir)$(TargetName).config.xml"</Command>
@@ -336,7 +336,7 @@
         </PostBuildEvent>
 
         <!-- *-SGX-Release -->
-        <PostBuildEvent Condition="$(OEIsSgx) == True And $(OEIsSim) == False And $(OEIsRelease) == True">
+        <PostBuildEvent Condition="$(OEIsSgx) == True And '$(ConfigurationType)'=='DynamicLibrary' And $(OEIsSim) == False And $(OEIsRelease) == True">
             <Command>"$(SGXSDKInstallPath)bin\win32\release\sgx_sign.exe" gendata -enclave "$(OutDir)$(TargetFileName)" -out "$(OutDir)$(TargetName).hex" -config "$(ProjectDir)$(TargetName).config.xml"</Command>
             <Message>Generate the enclave signing material for Intel SGX.</Message>
         </PostBuildEvent>

--- a/new_platforms/src/enc/optee/sub.mk
+++ b/new_platforms/src/enc/optee/sub.mk
@@ -10,7 +10,6 @@ CFLAGS +=                                  \
 	-I$(NP_INC)/optee/enclave              \
 	-I$(NP_INC)/optee                      \
 	-I$(NP_INC)                            \
-	-I$(OPTEE_OS_PATH)/lib/libutee/include \
 	-I$(CYREP_PATH)/cyrep                  \
 	-I$(CYREP_PATH)/tcps                   \
 	-I$(TINYCBOR_PATH)/src                 \


### PR DESCRIPTION
This PR addresses two issues:

1. We used to include the headers under `libutee` from the OP-TEE OS submodule. This is an issue if the developer uses their own OP-TEE TA Dev Kit since the headers in the submodule would override those provided by the developer;
2. Do not invoke `sgx_sign.exe` on any MSBuild targets that are not DLL's.