### PR TITLE
Changed test-samples.sh to use cmake for building 'install' target.

### DIFF
--- a/samples/test-samples.sh
+++ b/samples/test-samples.sh
@@ -29,7 +29,7 @@ if test "$1" = "-i" ; then
     BIN_DIR=$(realpath $2)
     INSTALL_DIR=$(realpath -m $4$3)
     rm -rf "$INSTALL_DIR"
-    make -C "$BIN_DIR" "DESTDIR=$4" install
+    cd "$BIN_DIR" && DESTDIR=$4 cmake --build . --target install
 else
     # inside installed tree. Assume this is placed under
     # prefix/share/openenclave/samples/


### PR DESCRIPTION
Previously, test-samples.sh would use 'make' for invoking the install target, which would fail for generated Ninja builds. Now, this logic is deferred to cmake, which invokes the correct build engine.