### PR TITLE
Deprecate oe_call_enclave, oe_call_host, and oe_call_host_by_address.

### DIFF
--- a/include/openenclave/enclave.h
+++ b/include/openenclave/enclave.h
@@ -87,13 +87,19 @@ oe_result_t oe_remove_vectored_exception_handler(
  * While handling the OCALL, the host is not allowed to make an ECALL back into
  * the enclave. A re-entrant ECALL will fail and return OE_REENTRANT_ECALL.
  *
+ * @deprecated This function has been deprecated. Use oeedger8r to generate
+ * code that will call oe_ocall() instead.
+ *
  * @param func The name of the enclave function that will be called.
  * @param args The arguments to be passed to the enclave function.
  *
  * @returns This function return **OE_OK** on success.
  *
  */
-oe_result_t oe_call_host(const char* func, void* args);
+OE_DEPRECATED(
+    oe_result_t oe_call_host(const char* func, void* args),
+    "This function is deprecated. Use oeedger8r to generate code that will "
+    "call oe_ocall() instead.");
 
 /**
  * Perform a high-level host function call (OCALL).
@@ -111,6 +117,9 @@ oe_result_t oe_call_host(const char* func, void* args);
  * the call and not of the underlying function. The OCALL implementation must
  * define its own error reporting scheme based on **args**.
  *
+ * @deprecated This function has been deprecated. Use oeedger8r to generate
+ * code that will call oe_ocall() instead.
+ *
  * @param func The address of the host function that will be called.
  * @param args The arguments to be passed to the host function.
  *
@@ -118,9 +127,11 @@ oe_result_t oe_call_host(const char* func, void* args);
  * @return OE_INVALID_PARAMETER a parameter is invalid.
  * @return OE_FAILURE the call failed.
  */
-oe_result_t oe_call_host_by_address(
-    void (*func)(void*, oe_enclave_t*),
-    void* args);
+OE_DEPRECATED(
+    oe_result_t
+        oe_call_host_by_address(void (*func)(void*, oe_enclave_t*), void* args),
+    "This function is deprecated. Use oeedger8r to generate code that will "
+    "call oe_ocall() instead.");
 
 /**
  * Check whether the given buffer is strictly within the enclave.

--- a/include/openenclave/host.h
+++ b/include/openenclave/host.h
@@ -140,6 +140,9 @@ oe_result_t oe_terminate_enclave(oe_enclave_t* enclave);
  * the call and not of the underlying function. The ECALL implementation must
  * define its own error reporting scheme based on **args**.
  *
+ * @deprecated This function has been deprecated. Use oeedger8r to generate
+ * code that will call oe_ecall() instead.
+ *
  * @param enclave The instance of the enclave to be called.
  *
  * @param func The name of the enclave function that will be called.
@@ -149,10 +152,11 @@ oe_result_t oe_terminate_enclave(oe_enclave_t* enclave);
  * @returns This function return **OE_OK** on success.
  *
  */
-oe_result_t oe_call_enclave(
-    oe_enclave_t* enclave,
-    const char* func,
-    void* args);
+OE_DEPRECATED(
+    oe_result_t
+        oe_call_enclave(oe_enclave_t* enclave, const char* func, void* args),
+    "This function is deprecated. Use oeedger8r to generate code that will "
+    "call oe_ecall() instead.");
 
 #if (OE_API_VERSION < 2)
 #define oe_get_report oe_get_report_v1


### PR DESCRIPTION
This addresses  issue #833.

These changes were replicated from pr https://github.com/Microsoft/openenclave/commit/a73e101d188caed30bbf606519688bd41cee07fa that was submitted by @britel.