### PR TITLE
Add oe_abort to corelibc/stdlib.h

### DIFF
--- a/include/openenclave/corelibc/assert.h
+++ b/include/openenclave/corelibc/assert.h
@@ -4,9 +4,36 @@
 #ifndef _OE_ASSERT_H
 #define _OE_ASSERT_H
 
+/* Defined here in addition to openenclave/enclave.h (public API),
+ * for assert.h parity and so that use of corelibc/assert.h doesn't
+ * pull in that entire header which contains oeenclave methods.
+ */
+void __oe_assert_fail(
+    const char* expr,
+    const char* file,
+    int line,
+    const char* func);
+
+/* Ideally, this should be defined once in bits and included here and
+ * in enclave.h, but we also use enclave.h as the canonical reference
+ * for the public API surface, so oe_assert needs to be defined there
+ * as well just for visibility.
+ */
+#if !defined(oe_assert)
+#ifndef NDEBUG
+#define oe_assert(EXPR)                                                \
+    do                                                                 \
+    {                                                                  \
+        if (!(EXPR))                                                   \
+            __oe_assert_fail(#EXPR, __FILE__, __LINE__, __FUNCTION__); \
+    } while (0)
+#else
+#define oe_assert(EXPR)
+#endif
+#endif /* !defined(oe_assert) */
+
 #if defined(OE_NEED_STDC_NAMES)
 
-#include <openenclave/enclave.h>
 #define assert(EXPR) oe_assert(EXPR)
 #define __assert_fail(EXPR) __oe_assert_fail(EXPR)
 

--- a/include/openenclave/corelibc/bits/abort.h
+++ b/include/openenclave/corelibc/bits/abort.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef _OE_BITS_ABORT_H
+#define _OE_BITS_ABORT_H
+
+OE_INLINE
+void abort(void)
+{
+    return oe_abort();
+}
+
+#endif /* _OE_BITS_ABORT_H */

--- a/include/openenclave/corelibc/stdlib.h
+++ b/include/openenclave/corelibc/stdlib.h
@@ -29,8 +29,15 @@ unsigned long int oe_strtoul(const char* nptr, char** endptr, int base);
 
 int oe_atexit(void (*function)(void));
 
+/* Defined here in addition to openenclave/enclave.h (public API),
+ * for stdlib.h parity and so that use of corelibc/stdlib.h doesn't
+ * pull in that entire header which includes oeenclave methods.
+ */
+void oe_abort(void);
+
 #if defined(OE_NEED_STDC_NAMES)
 
+#include "bits/abort.h"
 #include "bits/atexit.h"
 #include "bits/malloc.h"
 #include "bits/strtoul.h"

--- a/include/openenclave/enclave.h
+++ b/include/openenclave/enclave.h
@@ -234,6 +234,7 @@ void __oe_assert_fail(
  * string representation of the expression as well as the file, the line, and
  * the function name where the macro was expanded.
  */
+#if !defined(oe_assert)
 #ifndef NDEBUG
 #define oe_assert(EXPR)                                                \
     do                                                                 \
@@ -244,6 +245,7 @@ void __oe_assert_fail(
 #else
 #define oe_assert(EXPR)
 #endif
+#endif /* !defined(oe_assert) */
 
 #if (OE_API_VERSION < 2)
 #define oe_get_report oe_get_report_v1


### PR DESCRIPTION
Per observations from the allocator PR, add `oe_abort()` to the corelibc header surface for completeness.

Also clean up corelibc/assert.h which has a similar enclave.h dependency.