### PR TITLE
Add ending newline to .jenkins/Jenkinsfile

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -213,4 +213,4 @@ parallel "Check Developer Experience Ubuntu 16.04" :            { checkDevFlows(
          "Win2016 Ubuntu1804 clang-7 Release Linux-Elf-build" : { win2016LinuxElfBuild('18.04', 'clang-7', 'Release') },
          "Win2016 Debug Cross Compile" :                        { win2016CrossCompile('Debug') },
          "Win2016 Release Cross Compile" :                      { win2016CrossCompile('Release') }
-         
+


### PR DESCRIPTION
Fix the GitHub warning (`No newline at end of file`) reported at https://github.com/Microsoft/openenclave/pull/1478#discussion_r259530368.