### PR TITLE
Increase CI testing stages timeouts

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ def ACCTest(String label, String compiler, String build_type) {
             cleanWs()
             checkout scm
 
-            timeout(15) {
+            timeout(30) {
                 dir('build') {
                     if (compiler == "gcc") {
                         c_compiler = "gcc"
@@ -33,7 +33,7 @@ def ACCGNUTest() {
         node("ACC-1804") {
             cleanWs()
             checkout scm
-            timeout(15) {
+            timeout(30) {
                 dir('build') {
                     withEnv(["CC=gcc","CXX=g++"]) {
                         sh """
@@ -60,7 +60,7 @@ def simulationTest(String version, String platform_mode, String build_type) {
 
             def oetoolsSim = docker.build("oetools-simulation-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile .")
             oetoolsSim.inside {
-                timeout(15) {
+                timeout(30) {
                     dir('build') {
                         withEnv(["CC=clang-7","CXX=clang++-7","OE_SIMULATION=1"]) {
                             sh """
@@ -84,7 +84,7 @@ def ACCContainerTest(String label, String version) {
 
             def oetoolsContainer = docker.build("oetools-containertest-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile .")
             oetoolsContainer.inside('--device /dev/sgx:/dev/sgx') {
-                timeout(15) {
+                timeout(30) {
                     dir('build') {
                         withEnv(["CC=clang-7","CXX=clang++-7"]) {
                             sh """
@@ -108,7 +108,7 @@ def checkDevFlows(String version) {
 
             def oetoolsCheck = docker.build("oetools-check-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile .")
             oetoolsCheck.inside {
-                timeout(2) {
+                timeout(10) {
                     sh './scripts/check-ci'
                 }
             }
@@ -123,7 +123,7 @@ def checkDevFlows(String version) {
             def buildImage = docker.build("oetools-base-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile.scripts .")
 
             buildImage.inside {
-                timeout(15) {
+                timeout(30) {
                     // This is run to test that it works with the dependencies
                     // installed by our install-prereqs ansible playbook.
 
@@ -150,7 +150,7 @@ def win2016LinuxElfBuild(String version, String compiler, String build_type) {
             def cpp_compiler = "clang++-7"
             def oetoolsWincp = docker.build("oetools-wincp-${version}", "--build-arg ubuntu_version=${version} -f .jenkins/Dockerfile .")
             oetoolsWincp.inside {
-                timeout(15) {
+                timeout(30) {
                     dir('build') {
                         if (compiler == "gcc") {
                             c_compiler = "gcc"


### PR DESCRIPTION
Recently, I noticed few jobs getting aborted by Jenkins due to the
timeout getting exceeded.

I have bumped the values for the timeouts just to be safe for the
workload nowadays.

These are some Jenkins jobs runs that failed on the first run
(due to the small timeout), but succeed on the second run:

* [OpenEnclave-sandbox#777](https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/OpenEnclave-sandbox/detail/OpenEnclave-sandbox/777/pipeline/38/#step-287-log-1)
* [Bors-staging#642](https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/Bors/detail/staging/642/pipeline/57)
* [Bors-trying#732](https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/Bors/detail/trying/732/pipeline/43)
* [Bors-trying#736](https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/Bors/detail/trying/736/pipeline/54)
* [Bors-trying#738](https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/Bors/detail/trying/738/pipeline/53)
* [Bors-trying#739](https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/Bors/detail/trying/739/pipeline/58)
