### PR TITLE
Fix regression: Wait until release becomes 1.

### DIFF
--- a/tests/ecall_ocall/enc/enc.cpp
+++ b/tests/ecall_ocall/enc/enc.cpp
@@ -82,11 +82,10 @@ oe_result_t enc_parallel_execution(
 
         ++(*counter);
 
-        unsigned release_val;
-        do
-        {
-            release_val = release->load(std::memory_order_acquire);
-        } while (0 != release_val);
+        // Wait for the signal from host before continuing.
+        // (wait until release becomes non-zero)
+        while (0 == release->load(std::memory_order_acquire))
+            ;
 
         old_flow_id = g_per_thread_flow_id.get_u();
         if (old_flow_id != flow_id)


### PR DESCRIPTION
Host sets _release_ to 1 to signal waiting threads to continue to completion.
https://github.com/Microsoft/openenclave/blob/master/tests/ecall_ocall/host/host.cpp#L182-L184

Therefore the enclave threads need to wait for _release_ to become 1.