### PR TITLE
Exclude OE_API_VERSION=2 from CMake package

### DIFF
--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -132,7 +132,10 @@ target_compile_options(oecore INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 target_compile_definitions(oecore
     PUBLIC
     OE_BUILD_ENCLAVE
-    OE_API_VERSION=2)
+    # NOTE: This definition is public to the rest of our project's
+    # targets, but should not yet be exposed to consumers of our
+    # package.
+    $<BUILD_INTERFACE:OE_API_VERSION=2>)
 
 if(USE_LIBSGX)
     target_compile_definitions(oecore PUBLIC OE_USE_LIBSGX)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -154,7 +154,11 @@ endif ()
 
 # Compile definitions and options
 target_compile_definitions(oehost
-  PUBLIC -DOE_API_VERSION=2
+  PUBLIC
+  # NOTE: This definition is public to the rest of our project's
+  # targets, but should not yet be exposed to consumers of our
+  # package.
+  $<BUILD_INTERFACE:OE_API_VERSION=2>
   PRIVATE
   OE_BUILD_UNTRUSTED
   OE_REPO_BRANCH_NAME="${GIT_BRANCH}"


### PR DESCRIPTION
The samples do not expect this to be defined, and we did not intend to define it for all users of the SDK (yet). However, it should be internally public because our own build system expects it to be defined.
So we constrain it to our build system but not our package using a generator expression to exclude it from the install interface.