### PR TITLE
Fixed test to account for leap year days.

### DIFF
--- a/tests/crypto/crl_tests.c
+++ b/tests/crypto/crl_tests.c
@@ -124,6 +124,32 @@ static void _test_verify_without_crl(
     printf("=== passed %s()\n", __FUNCTION__);
 }
 
+static bool _year_is_a_leap_year(uint32_t year)
+{
+    if (year % 4 == 0)
+    {
+        if (year % 100 == 0)
+        {
+            if (year % 400 == 0)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else
+        {
+            return true;
+        }
+    }
+    else
+    {
+        return false;
+    }
+}
+
 static void _test_get_dates(void)
 {
     printf("=== begin %s()\n", __FUNCTION__);
@@ -146,11 +172,65 @@ static void _test_get_dates(void)
     // The two values are not guaranteed to be equal.
     // OE_TEST(last.seconds == _time.seconds);
 
-    OE_TEST(next.year == _time.year + 1);
-    OE_TEST(next.month == _time.month);
-    OE_TEST(next.day == _time.day);
-    OE_TEST(next.hours == _time.hours);
-    OE_TEST(next.minutes == _time.minutes);
+    oe_datetime_t next_expected;
+    next_expected.year = _time.year + 1;
+    next_expected.month = _time.month;
+    next_expected.day = _time.day;
+    next_expected.hours = _time.hours;
+    next_expected.minutes = _time.minutes;
+
+    // If a leap day occurs in the next time period, need to adjust
+    // expected next date.
+    if ((_time.month >= 3 && _year_is_a_leap_year(next.year)) ||
+        (_time.month <= 2 && _year_is_a_leap_year(_time.year)))
+    {
+        next_expected.day -= 1;
+        if (next_expected.day == 0)
+        {
+            // Rollover for month
+            next_expected.month -= 1;
+            if (next_expected.month == 0)
+            {
+                // Rollover for year
+                next_expected.year -= 1;
+                next_expected.month = 12;
+            }
+            switch (next_expected.month)
+            {
+                case 2:
+                    if (_year_is_a_leap_year(next_expected.year))
+                    {
+                        next_expected.day = 29;
+                    }
+                    else
+                    {
+                        next_expected.day = 28;
+                    }
+                    break;
+                case 4:
+                case 6:
+                case 9:
+                case 11:
+                    next_expected.day = 30;
+                    break;
+                case 1:
+                case 3:
+                case 5:
+                case 7:
+                case 8:
+                case 10:
+                case 12:
+                    next_expected.day = 31;
+                    break;
+            }
+        }
+    }
+
+    OE_TEST(next.year == next_expected.year);
+    OE_TEST(next.month == next_expected.month);
+    OE_TEST(next.day == next_expected.day);
+    OE_TEST(next.hours == next_expected.hours);
+    OE_TEST(next.minutes == next_expected.minutes);
     // TEMPORARILY Disabled: see above.
     // OE_TEST(next.seconds == _time.seconds);
 


### PR DESCRIPTION
This will hopefully unblock all CI failures due to the latest comments in #1203. This new logic checks if there's a leap day within the next year, and if so, subtracts 1 day from the expected day (and accounts for month/year rollovers).

It might be worth it to factor out the logic into different functions, like having a "calculate time difference" function, which we then use to calculate if the "Next" datetime is valid, but I'm not sure how far we want to go down that hole of implementing standard datetime functions. Are there any libraries we can rely on to do these calculations?

Questions for consideration: Is there any logic I'm missing here? Is daylight savings time a consideration? (I don't think so, but I'd like thoughts from others). Are there better solutions?

I guess there are alternatives to solving this problem, like changing the CRL expiration to be 4 years (365 * 4 + 1 days) in the future (instead of 365 days), but that doesn't solve for the 100-year/400-year leap year case, which is most likely unnecessary to consider. Does solving this problem with a change to the CRL expiration being 4 years have anything to be concerned about? Thanks!
