### PR TITLE
Alternative fix for CRL date mismatch due to leap year.

### DIFF
--- a/tests/crypto/crl_tests.c
+++ b/tests/crypto/crl_tests.c
@@ -146,7 +146,7 @@ static void _test_get_dates(void)
     // The two values are not guaranteed to be equal.
     // OE_TEST(last.seconds == _time.seconds);
 
-    OE_TEST(next.year == _time.year + 1);
+    OE_TEST(next.year == _time.year + 4);
     OE_TEST(next.month == _time.month);
     OE_TEST(next.day == _time.day);
     OE_TEST(next.hours == _time.hours);

--- a/tests/crypto/data/intermediate.cnf
+++ b/tests/crypto/data/intermediate.cnf
@@ -16,7 +16,7 @@ crlnumber   = ./intermediate_crl_number  # For certificate revocation lists
 private_key       = ../data/Intermediate.key.pem
 certificate       = ../data/Intermediate.crt.pem
 
-default_days     = 365        # how long to certify for
-default_crl_days = 365       # how long before next CRL
+default_days     = 1461       # how long to certify for
+default_crl_days = 1461       # how long before next CRL
 default_md       = default    # use public key default MD
 preserve         = no         # keep passed DN ordering


### PR DESCRIPTION
This is an alternative solution to the problem that #1517 solves. This only works for normal leap years, though. (A non-normal leap year will happen next in the year 2100, which is probably an okay trade-off :) )