### PR TITLE
[Ansible] Use GCC 5 on Ubuntu 1804 & Fix Linux validation

### DIFF
--- a/scripts/ansible/inventory/group_vars/linux-agents
+++ b/scripts/ansible/inventory/group_vars/linux-agents
@@ -3,18 +3,17 @@
 
 ansible_ssh_user: azureuser
 
-cmake_target_version: 3.13.1
-docker_target_version: 18.09.2
-dockerd_target_version: 18.09.2
-clang_target_version: 7.0.1
-ocaml_target_version: 4.02.3
+cmake_target_version: "3.13"
+docker_target_version: "18.09"
+dockerd_target_version: "18.09"
+clang_target_version: "7.0"
+ocaml_target_version: "4.0"
 
 validation_directories:
   - "/opt/intel/sgxdriver"
   - "/opt/intel/libsgx-enclave-common"
   - "/usr/lib/ocaml"
   - "/usr/lib/ocaml/compiler-libs"
-  - "/usr/lib/graphviz"
   - "/usr/share/libtool"
 
 validation_files:
@@ -29,6 +28,7 @@ validation_binaries:
   - "/usr/local/bin/ccmake"
   - "/usr/local/bin/cpack"
   - "/usr/local/bin/ctest"
+  - "/usr/bin/dot"
   - "/usr/bin/gcc"
   - "/usr/bin/g++"
   - "/usr/bin/gdb"
@@ -36,7 +36,9 @@ validation_binaries:
   - "/usr/bin/libtoolize"
   - "/usr/bin/java"
   - "/usr/bin/docker"
+  - "/usr/bin/dockerd"
   - "/usr/bin/doxygen"
+  - "/usr/bin/ocaml"
   - "/usr/bin/openssl"
   - "/usr/bin/pkg-config"
   - "/usr/bin/clang-7"

--- a/scripts/ansible/roles/linux/openenclave/tasks/environment-setup.yml
+++ b/scripts/ansible/roles/linux/openenclave/tasks/environment-setup.yml
@@ -13,31 +13,53 @@
     name: linux/common
     tasks_from: apt-repo-llvm.yml
 
+- name: Set the names list of the APT packages to be installed
+  block:
+    - set_fact:
+        pkg_names:
+          - "clang-7"
+          - "clang-format-7"
+          - "libssl-dev"
+          - "make"
+          - "ocaml-native-compilers"
+          - "openssl"
+          - "pkg-config"
+          - "gdb"
+          - "ninja-build"
+          - "apt-transport-https"
+          - "autoconf"
+          - "doxygen"
+          - "graphviz"
+          - "libexpat1-dev"
+          - "libtool"
+          - "shellcheck"
+          - "subversion"
+
+    - set_fact:
+        pkg_names: "{{ pkg_names }} + {{ ['gcc', 'g++'] }}"
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial'
+
+    - set_fact:
+        pkg_names: "{{ pkg_names }} + {{ ['gcc-5', 'g++-5'] }}"
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'bionic'
+
 - name: Install all the Open Enclave prerequisites APT packages for development
   apt:
-    name:
-      - "clang-7"
-      - "clang-format-7"
-      - "libssl-dev"
-      - "make"
-      - "ocaml-native-compilers"
-      - "openssl"
-      - "pkg-config"
-      - "gcc"
-      - "gdb"
-      - "g++"
-      - "ninja-build"
-      - "apt-transport-https"
-      - "autoconf"
-      - "doxygen"
-      - "graphviz"
-      - "libexpat1-dev"
-      - "libtool"
-      - "shellcheck"
-      - "subversion"
+    name: "{{ pkg_names }}"
     state: present
     update_cache: yes
     install_recommends: no
+
+- name: Create gcc and g++ symbolic links for Ubuntu Bionic
+  file:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    force: yes
+    state: link
+  with_items:
+    - { src: "/usr/bin/gcc-5", dest: "/usr/bin/gcc" }
+    - { src: "/usr/bin/g++-5", dest: "/usr/bin/g++" }
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'bionic'
 
 - name: Install CMake 3.13.1
   unarchive:


### PR DESCRIPTION
* Use GCC 5 on Ubuntu 18.04 machines
    * This change makes the `gcc` and `g++` binaries from Ubuntu 18.04 to point to the version 5 binaries from the system. Thus, we end up with the same GCC compiler used on both Ubuntu 16.04 and 18.04.
* Fix Linux validation
    * Add `/usr/bin/dot` (graphviz binary), `/usr/bin/dockerd` and  `/usr/bin/ocaml` to the validation_files
    * Update expected versions accordingly. Removed any minor version references due to the fact that this would required more frequent updates for the Ansible code