### PR TITLE
Disable libcxx test for gcc 7

### DIFF
--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -42,5 +42,14 @@ foreach(testcase ${alltests})
         endif()
     endif()
 
+# the following test fails on GCC version 7, see  #1523 -- Skipping this test in GCC 7.0 -> 7.5
+    if ("${name}" MATCHES "std_utilities_function.objects_comparisons_constexpr_init.pass")
+        if(CMAKE_CXX_COMPILER_ID MATCHES GNU
+               AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7
+               AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.5)
+            continue()
+        endif()
+    endif()
+
     add_enclave_test(tests/libcxxtest-${name} libcxx_host libcxxtest-${name}_enc)
 endforeach(testcase)

--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 add_subdirectory(host)
 
 if (BUILD_ENCLAVES)
-	add_subdirectory(enc)
+    add_subdirectory(enc)
 endif()
 
 foreach(testcase ${alltests})
@@ -30,16 +30,16 @@ foreach(testcase ${alltests})
             OR "${name}" MATCHES "sequences_array_at.pass" 
             OR "${name}" MATCHES "libcxx_containers_unord_next_pow2.pass" 
             OR "${name}" MATCHES "std_utilities_template.bitset_bitset.members_count.pass")
-	    if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-	        continue()
+        if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
+            continue()
         endif()
     endif()
 
 # the following test fails when built with clang, see #830 -- Skipping this test in clang
     if ("${name}" MATCHES "array_sized_delete_array_calls_unsized_delete_array.pass")
         if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
-	    continue()
-	endif()
+            continue()
+        endif()
     endif()
 
     add_enclave_test(tests/libcxxtest-${name} libcxx_host libcxxtest-${name}_enc)

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -84,7 +84,7 @@ foreach(testcase ${alltests})
         string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
         if (CMAKE_CXX_COMPILER_ID MATCHES Clang AND BUILD_TYPE_UPPER MATCHES REL)
             continue()
-	endif()
+        endif()
     endif()
 
 # few functions invoked in these tests are not supported in gnu and excluded from GCC builds
@@ -93,15 +93,15 @@ foreach(testcase ${alltests})
             OR "${name}" MATCHES "libcxx_containers_unord_next_pow2.pass" 
             OR "${name}" MATCHES "std_utilities_template.bitset_bitset.members_count.pass")
             if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
-	        continue()
+                continue()
             endif()
     endif()
 
 # the following test fails when built with clang, see #830 -- Skipping this test in clang
     if ("${name}" MATCHES "array_sized_delete_array_calls_unsized_delete_array.pass")
         if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
-	    continue()
-	endif()
+            continue()
+        endif()
     endif()
 
     add_libcxx_test_enc("${name}" "${testcase}")

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -104,5 +104,14 @@ foreach(testcase ${alltests})
         endif()
     endif()
 
+# the following test fails on GCC version 7, see  #1523 -- Skipping this test in GCC 7.0 -> 7.5
+    if ("${name}" MATCHES "std_utilities_function.objects_comparisons_constexpr_init.pass")
+        if(CMAKE_CXX_COMPILER_ID MATCHES GNU
+               AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7
+               AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.5)
+            continue()
+        endif()
+    endif()
+
     add_libcxx_test_enc("${name}" "${testcase}")
 endforeach(testcase)


### PR DESCRIPTION
- Fix whitespace on tests/libcxx/CMakeLists.txt
- Fix whitespace on tests/libcxx/enc/CMakeLists.txt
- Disable libcxx test std_utilities_function.objects_comparisons_constexpr_init

Fixes: https://github.com/Microsoft/openenclave/issues/1523