### PR TITLE
Setting SECS Attributes.XFRM in enclave to match that supported by Platform and OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ as listed below.
 
 - Add appropriate validations for ELF64 in Open Enclave loader.
 - Expand libc/libcxx test coverage.
+- Check support for AVX in platform/OS before setting SECS.ATTRIBUTES.XFRM in enclave.
 
 ### Security
 

--- a/enclave/core/sgx/properties.c
+++ b/enclave/core/sgx/properties.c
@@ -17,13 +17,13 @@ OE_STATIC_ASSERT(
 
 OE_CHECK_SIZE(sizeof(oe_enclave_properties_header_t), 32);
 
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 16);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_config_t), 24);
 
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, header), 0);
 OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, config), 32);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 48);
-OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 96);
-OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1912);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, image_info), 56);
+OE_CHECK_SIZE(OE_OFFSETOF(oe_sgx_enclave_properties_t, sigstruct), 104);
+OE_CHECK_SIZE(sizeof(oe_sgx_enclave_properties_t), 1920);
 
 //
 // Declare an invalid oeinfo to ensure .oeinfo section exists

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -67,14 +67,16 @@ if (OE_SGX)
       sgx/linux/entersim.S
       sgx/linux/exception.c
       sgx/linux/sgxioctl.c
-      sgx/linux/sgxquoteprovider.c)
+      sgx/linux/sgxquoteprovider.c
+      sgx/linux/xstate.c)
   else()
     list(APPEND PLATFORM_SRC
       sgx/windows/aep.asm
       sgx/windows/aesm.c
       sgx/windows/enter.asm
       sgx/windows/entersim.asm
-      sgx/windows/exception.c)
+      sgx/windows/exception.c
+      sgx/windows/xstate.c)
   endif()
 
   set(PLATFORM_FLAGS "-m64")

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -544,6 +544,8 @@ oe_result_t oe_sgx_build_enclave(
                 NULL);
         }
     }
+    // Set the XFRM field
+    props.config.xfrm = context->attributes.xfrm;
 
     /* Calculate the size of image */
     OE_CHECK(oeimage.calculate_size(&oeimage, &image_size));

--- a/host/sgx/linux/xstate.c
+++ b/host/sgx/linux/xstate.c
@@ -9,7 +9,6 @@
 #define XSAVE_SHIFT 26
 #define OSXSAVE_SHIFT 27
 #define AVX_SHIFT 28
-bool is_xgetbv_supported(void);
 
 // Returns if processor and OS support extended states feature.
 // If cpuid.01h:ECX.XSAVE[bit 26] is 1, the processor supports the XSAVE/XRSTOR
@@ -17,7 +16,7 @@ bool is_xgetbv_supported(void);
 // If cpuid.01h:ECX.XSAVE[bit 27] is 1, it indicates that OS has set CR4,OSXSAVE
 // to enable XSETBV/XGETBV instructions to access XCR0 and to support processor
 // extended state management using XSAVE/XRSTOR.
-bool is_xgetbv_supported()
+static bool _is_xgetbv_supported()
 {
     uint32_t eax, ebx, ecx, edx;
 
@@ -54,7 +53,7 @@ uint64_t oe_get_xfrm()
 
     // Ensure that Processor and OS support extended states feature. XGETBV will
     // #GP fault otherwise.
-    if (is_xgetbv_supported())
+    if (_is_xgetbv_supported())
     {
         /* Invoke xgetbv to get the value of the Extended Control Register XCR0
          */

--- a/host/sgx/linux/xstate.c
+++ b/host/sgx/linux/xstate.c
@@ -6,14 +6,10 @@
 #include <openenclave/internal/trace.h>
 #include "../cpuid.h"
 
-/*
-**==============================================================================
-**
-** Implementation of SGX Platform Capability Discovery.
-** Example usage is to set SECS.ATTRIBUTES correctly
-**
-**==============================================================================
-*/
+#define XSAVE_SHIFT 26
+#define OSXSAVE_SHIFT 27
+#define AVX_SHIFT 28
+bool is_xgetbv_supported(void);
 
 // Returns if processor and OS support extended states feature.
 // If cpuid.01h:ECX.XSAVE[bit 26] is 1, the processor supports the XSAVE/XRSTOR
@@ -21,11 +17,6 @@
 // If cpuid.01h:ECX.XSAVE[bit 27] is 1, it indicates that OS has set CR4,OSXSAVE
 // to enable XSETBV/XGETBV instructions to access XCR0 and to support processor
 // extended state management using XSAVE/XRSTOR.
-#define XSAVE_SHIFT 26
-#define OSXSAVE_SHIFT 27
-#define AVX_SHIFT 28
-bool is_xgetbv_supported(void);
-
 bool is_xgetbv_supported()
 {
     uint32_t eax, ebx, ecx, edx;
@@ -54,6 +45,7 @@ bool is_xgetbv_supported()
     return true;
 }
 
+/* Returns the value of XCR0 register which is programmed by the OS */
 uint64_t oe_get_xfrm()
 {
     uint32_t eax, edx, index;

--- a/host/sgx/linux/xstate.c
+++ b/host/sgx/linux/xstate.c
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../xstate.h"
+#include <openenclave/internal/sgxtypes.h>
+#include <openenclave/internal/trace.h>
+#include "../cpuid.h"
+
+/*
+**==============================================================================
+**
+** Implementation of SGX Platform Capability Discovery.
+** Example usage is to set SECS.ATTRIBUTES correctly
+**
+**==============================================================================
+*/
+
+// Returns if processor and OS support extended states feature.
+// If cpuid.01h:ECX.XSAVE[bit 26] is 1, the processor supports the XSAVE/XRSTOR
+// processor extended states feature, the XSETBV/XGETBV instructions, and XCR0
+// If cpuid.01h:ECX.XSAVE[bit 27] is 1, it indicates that OS has set CR4,OSXSAVE
+// to enable XSETBV/XGETBV instructions to access XCR0 and to support processor
+// extended state management using XSAVE/XRSTOR.
+#define XSAVE_SHIFT 26
+#define OSXSAVE_SHIFT 27
+#define AVX_SHIFT 28
+bool is_xgetbv_supported(void);
+
+bool is_xgetbv_supported()
+{
+    uint32_t eax, ebx, ecx, edx;
+
+    eax = ebx = ecx = edx = 0;
+
+    // Obtain feature information using CPUID Leaf 1
+    oe_get_cpuid(1, 0, &eax, &ebx, &ecx, &edx);
+
+    // Check if AVX instruction extensions (bit 28) are supported in the
+    // processor
+    if (!(ecx & (1 << AVX_SHIFT)))
+        OE_TRACE_INFO("Processor does not support AVX instructions");
+    else
+        OE_TRACE_INFO("Processor supports AVX instructions");
+
+    // Check bits 26 and 27 that indicate support for
+    // XSAVE/XRSTOR/XSETBV/XGETBV/XCR0 and the OS has set these bits to allow
+    // access.
+    if (!(ecx & (1 << XSAVE_SHIFT)) || !(ecx & (1 << OSXSAVE_SHIFT)))
+    {
+        OE_TRACE_INFO("Plaform/OS does not support Extended Feature States");
+        return false;
+    }
+
+    return true;
+}
+
+uint64_t oe_get_xfrm()
+{
+    uint32_t eax, edx, index;
+    eax = edx = 0;
+    index = 0; // XCR0 register is returned
+
+    // Ensure that Processor and OS support extended states feature. XGETBV will
+    // #GP fault otherwise.
+    if (is_xgetbv_supported())
+    {
+        /* Invoke xgetbv to get the value of the Extended Control Register XCR0
+         */
+        asm volatile(".byte 0x0f,0x01,0xd0" /* xgetbv */
+                     : "=a"(eax), "=d"(edx)
+                     : "c"(index));
+        return eax + ((uint64_t)edx << 32);
+    }
+    else
+        return 0;
+}

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -124,12 +124,14 @@ static int _make_memory_protect_param(uint64_t inflags, bool simulate)
 }
 
 /* Detect the XSave Feature Request Mask (XFRM) to set in the enclave */
-uint64_t _xfrm_detect()
+static uint64_t _detect_xfrm()
 {
     uint64_t xfrm = SGX_ATTRIBUTES_DEFAULT_XFRM;
     // Enable AVX in the enclave if supported by the OS
     if ((oe_get_xfrm() & SGX_XFRM_AVX) == SGX_XFRM_AVX)
         xfrm |= SGX_XFRM_AVX;
+
+    OE_TRACE_INFO("Value of XFRM to be set in enclave is %d\n", xfrm);
     return xfrm;
 }
 
@@ -214,7 +216,6 @@ static void* _allocate_enclave_memory(size_t enclave_size, int fd)
         }
 
         /* Exit early in hardware backed enclaves, since it's aligned. */
-
         if (fd > -1)
         {
             assert((uintptr_t)mptr % mmap_size == 0);
@@ -427,7 +428,7 @@ oe_result_t oe_sgx_initialize_load_context(
     /* Set attributes before checking context properties */
     context->type = type;
     context->attributes.flags = attributes;
-    context->attributes.xfrm = _xfrm_detect();
+    context->attributes.xfrm = _detect_xfrm();
 
     context->dev = OE_SGX_NO_DEVICE_HANDLE;
 #if !defined(OE_USE_LIBSGX) && defined(__linux__)
@@ -496,9 +497,6 @@ oe_result_t oe_sgx_create_enclave(
     /* Create SECS structure */
     if (!(secs = _new_secs((uint64_t)base, enclave_size, context)))
         OE_RAISE(OE_OUT_OF_MEMORY);
-
-    /* Set the platform xfrm value in context */
-    context->attributes.xfrm = secs->xfrm;
 
     /* Measure this operation */
     OE_CHECK(oe_sgx_measure_create_enclave(&context->hash_context, secs));

--- a/host/sgx/sgxload.h
+++ b/host/sgx/sgxload.h
@@ -15,13 +15,13 @@ OE_EXTERNC_BEGIN
 OE_INLINE bool oe_sgx_is_simulation_load_context(
     const oe_sgx_load_context_t* context)
 {
-    return (context && (context->attributes & OE_ENCLAVE_FLAG_SIMULATE));
+    return (context && (context->attributes.flags & OE_ENCLAVE_FLAG_SIMULATE));
 }
 
 OE_INLINE bool oe_sgx_is_debug_load_context(
     const oe_sgx_load_context_t* context)
 {
-    return (context && (context->attributes & OE_ENCLAVE_FLAG_DEBUG));
+    return (context && (context->attributes.flags & OE_ENCLAVE_FLAG_DEBUG));
 }
 
 oe_result_t oe_sgx_create_enclave(

--- a/host/sgx/sgxsign.c
+++ b/host/sgx/sgxsign.c
@@ -502,7 +502,9 @@ static oe_result_t _init_sigstruct(
 
     /* sgx_sigstruct_t.attributemask */
     sigstruct->attributemask.flags = SGX_SIGSTRUCT_ATTRIBUTEMASK_FLAGS;
-    sigstruct->attributemask.xfrm = SGX_SIGSTRUCT_ATTRIBUTEMASK_XFRM;
+    sigstruct->attributemask.xfrm =
+        SGX_SIGSTRUCT_ATTRIBUTEMASK_XFRM; // Reason this mask is 0 is because we
+                                          // don't enforce XFRM in signature
 
     /* In debug enclaves, we don't care about the debug bit, so unmask it. */
     if (attributes & SGX_FLAGS_DEBUG)

--- a/host/sgx/windows/xstate.c
+++ b/host/sgx/windows/xstate.c
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../xstate.h"
+#include "Windows.h"
+
+uint64_t oe_get_xfrm()
+{
+    return (GetEnabledXStateFeatures());
+}

--- a/host/sgx/xstate.h
+++ b/host/sgx/xstate.h
@@ -4,7 +4,7 @@
 #ifndef _OE_XSTATE_H
 #define _OE_XSTATE_H
 
-#include <openenclave/internal/sgxtypes.h>
+#include <openenclave/bits/types.h>
 
 /* Read XCR0 register, which the OS programs to reflect the features for
  * which it provides context management.

--- a/host/sgx/xstate.h
+++ b/host/sgx/xstate.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef _OE_XSTATE_H
+#define _OE_XSTATE_H
+
+#include <openenclave/internal/sgxtypes.h>
+
+/* Detect the XSave Feature Request Mask (XFRM) to set in the enclave */
+uint64_t _xfrm_detect(void);
+
+/* Read XCR0 register, which the OS programs to reflect the features for
+ * which it provides context management.
+ */
+uint64_t oe_get_xfrm(void);
+
+#endif /* _OE_XSTATE_H */

--- a/host/sgx/xstate.h
+++ b/host/sgx/xstate.h
@@ -6,9 +6,6 @@
 
 #include <openenclave/internal/sgxtypes.h>
 
-/* Detect the XSave Feature Request Mask (XFRM) to set in the enclave */
-uint64_t _xfrm_detect(void);
-
 /* Read XCR0 register, which the OS programs to reflect the features for
  * which it provides context management.
  */

--- a/include/openenclave/bits/sgx/sgxproperties.h
+++ b/include/openenclave/bits/sgx/sgxproperties.h
@@ -43,6 +43,9 @@ typedef struct oe_sgx_enclave_config_t
 
     /* (OE_SGX_FLAGS_DEBUG | OE_SGX_FLAGS_MODE64BIT) */
     uint64_t attributes;
+
+    /* XSave Feature Request Mask */
+    uint64_t xfrm;
 } oe_sgx_enclave_config_t;
 
 /* Extends oe_enclave_properties_header_t base type */

--- a/include/openenclave/internal/sgxcreate.h
+++ b/include/openenclave/internal/sgxcreate.h
@@ -41,8 +41,11 @@ struct _oe_sgx_load_context
     oe_sgx_load_type_t type;
     oe_sgx_load_state_t state;
 
-    /* OE_FLAG bits to be applied to the enclave such as debug */
-    uint64_t attributes;
+    /* attributes includes:
+     *  - OE_FLAG bits to be applied to the enclave, such as debug.
+     *  - XFRM supported by the OS to be used in enclave creation.
+     */
+    sgx_attributes_t attributes;
 
     /* Fields used when attributes contain OE_FLAG_SIMULATION */
     struct

--- a/include/openenclave/internal/sgxtypes.h
+++ b/include/openenclave/internal/sgxtypes.h
@@ -25,10 +25,17 @@ OE_EXTERNC_BEGIN
 #define SGX_FLAGS_PROVISION_KEY 0x0000000000000010ULL
 #define SGX_FLAGS_EINITTOKEN_KEY 0x0000000000000020ULL
 
-#define SGX_XFRM_LEGACY 0x0000000000000003ULL
-#define SGX_XFRM_AVX 0x0000000000000006ULL
-#define SGX_XFRM_AVX512 0x00000000000000E6ULL
-#define SGX_XFRM_MPX 0x0000000000000018ULL
+#define SGX_XFRM_LEGACY                                                     \
+    0x0000000000000003ULL /* Legacy XFRM which includes basic feature bits  \
+                             required by SGX i.e. X87 (bit 0) and SSE state \
+                             (bit 1) */
+#define SGX_XFRM_AVX                                                           \
+    0x0000000000000006ULL /* AVX XFRM which includes AVX (bit 2) and SSE State \
+                             (Bit 1) required by AVX */
+#define SGX_XFRM_AVX512 \
+    0x00000000000000E6ULL /* AVX512 - not supported by Intel SGX */
+#define SGX_XFRM_MPX \
+    0x0000000000000018ULL /* MPX XFRM - not supported by Intel SGX */
 
 #define SGX_SECINFO_R 0x0000000000000000001
 #define SGX_SECINFO_W 0x0000000000000000002
@@ -83,10 +90,10 @@ OE_STATIC_ASSERT(sizeof(sgx_enclu_leaf_t) == sizeof(unsigned int));
 */
 
 /* Default value for sgx_attributes_t.flags */
-#define SGX_ATTRIBUTES_DEFAULT_FLAGS 0x0000000000000006
+#define SGX_ATTRIBUTES_DEFAULT_FLAGS 0x0000000000000006ULL
 
 /* Default value for sgx_attributes_t.xfrm */
-#define SGX_ATTRIBUTES_DEFAULT_XFRM 0x0000000000000007
+#define SGX_ATTRIBUTES_DEFAULT_XFRM 0x0000000000000003ULL
 
 OE_PACK_BEGIN
 typedef struct _sgx_attributes
@@ -122,10 +129,10 @@ OE_CHECK_SIZE(sizeof(sgx_attributes_t), 16);
 #define SGX_SIGSTRUCT_MISCMASK 0xffffffff
 
 /* sgx_sigstruct_t.flags */
-#define SGX_SIGSTRUCT_ATTRIBUTEMASK_FLAGS 0Xfffffffffffffffb
+#define SGX_SIGSTRUCT_ATTRIBUTEMASK_FLAGS 0XfffffffffffffffbULL
 
 /* sgx_sigstruct_t.xfrm */
-#define SGX_SIGSTRUCT_ATTRIBUTEMASK_XFRM 0x0000000000000000
+#define SGX_SIGSTRUCT_ATTRIBUTEMASK_XFRM 0x0000000000000000ULL
 
 /* 1808 bytes */
 OE_PACK_BEGIN

--- a/tests/props/README.md
+++ b/tests/props/README.md
@@ -14,6 +14,8 @@ OE_SET_ENCLAVE_SGX macro.
 The propshost program tests both of these scenarios. It is run once for 
 the unsigned case and once for the signed case as follows.
 
+The test also verifies that legacy and AVX configurations work for creating enclaves.
+
 ```
 # ./host/propshost ./enc/propsenc unsigned
 # ./host/propshost ./enc/propsenc.signed signed

--- a/tools/oesign/oedump.c
+++ b/tools/oesign/oedump.c
@@ -178,6 +178,8 @@ void dump_enclave_properties(const oe_sgx_enclave_properties_t* props)
     bool debug = props->config.attributes & OE_SGX_FLAGS_DEBUG;
     printf("debug=%u\n", debug);
 
+    printf("xfrm=%x\n", props->config.xfrm);
+
     printf(
         "num_heap_pages=%llu\n",
         OE_LLU(props->header.size_settings.num_heap_pages));


### PR DESCRIPTION
Fix for Bug #1511 filed by Intel. Platform/OS supported X-State Features are only set in SECS.ATTRIBUTES.XFRM instead of a hard-coded value. This will prevent failures on platforms that don't support all the features, such as Intel's Silver Line platforms that supports SGX but not AVX. 
Enhanced core to check for AVX support before setting SECS.ATTRIBUTES.XFRM in enclave.
Enhanced test props to validate oe_create_enclave with both legacy (SSE only) and AVX configurations.
