### PR TITLE
Ephemeral Jenkins build servers for the libcxx nightly job

### DIFF
--- a/.jenkins/Dockerfile.deploy
+++ b/.jenkins/Dockerfile.deploy
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+FROM ubuntu:18.04
+
+ARG UNAME
+ARG GNAME
+ARG UID
+ARG GID
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install make build-essential git jq vim curl wget netcat && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" | \
+      tee /etc/apt/sources.list.d/azure-cli.list && \
+    wget https://packages.microsoft.com/keys/microsoft.asc && \
+    apt-key add microsoft.asc && \
+    apt-get update && \
+    apt-get -y install apt-transport-https azure-cli && \
+    curl https://oejenkins.blob.core.windows.net/oejenkins/oe-engine -o /usr/bin/oe-engine  && \
+    chmod +x /usr/bin/oe-engine && \
+    groupadd --gid ${GID} ${GNAME} && \
+    useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME}
+
+COPY scripts/ansible /ansible
+
+RUN /ansible/install-ansible.sh

--- a/.jenkins/libcxx_tests.Jenkinsfile
+++ b/.jenkins/libcxx_tests.Jenkinsfile
@@ -1,87 +1,146 @@
-pipeline {
-  agent any
-  stages {
-    stage('Build and Run libcxx Tests') {
-      parallel {
-        stage('libcxx clang-7 Debug') {
-          agent {
-            node {
-              label 'ACC-1604'
-          }
+import hudson.slaves.*
+import hudson.model.*
 
-          }
-          steps {
-            timeout(180) {
-              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libcxx_tests --compiler=clang-7'
-            }
-          }
-        }
-        stage('libcxx clang-7 Release') {
-          agent {
-            node {
-              label 'ACC-1604'
-          }
+env.XENIAL_LABEL = "LIBCXX-${BUILD_NUMBER}-1604"
+env.XENIAL_HOSTS = "libcxx-${BUILD_NUMBER}-1604-1.eastus.cloudapp.azure.com," + \
+                   "libcxx-${BUILD_NUMBER}-1604-2.eastus.cloudapp.azure.com," + \
+                   "libcxx-${BUILD_NUMBER}-1604-3.eastus.cloudapp.azure.com"
 
-          }
-          steps {
-            timeout(180) {
-              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libcxx_tests --compiler=clang-7'
-            }
-          }
-        }
-        stage('libcxx clang-7 RelWithDebInfo') {
-          agent {
-            node {
-              label 'ACC-1604'
-          }
 
-          }
-          steps {
-            timeout(180) {
-              sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libcxx_tests --compiler=clang-7'
-            }
-          }
-        }
-        stage('libcxx gcc Debug') {
-          agent {
-            node {
-              label 'ACC-1604'
-          }
-
-          }
-          steps {
-            timeout(180) {
-              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Debug -d --enable_full_libcxx_tests --compiler=gcc'
-            }
-          }
-        }
-        stage('libcxx gcc Release') {
-          agent {
-            node {
-              label 'ACC-1604'
-          }
-
-          }
-          steps {
-            timeout(180) {
-              sh 'bash ./scripts/test-build-config -p SGX1FLC -b Release -d --enable_full_libcxx_tests --compiler=gcc'
-            }
-          }
-        }
-        stage('libcxx gcc RelWithDebInfo') {
-          agent {
-            node {
-              label 'ACC-1604'
-          }
-
-          }
-          steps {
-            timeout(180) {
-              sh 'bash ./scripts/test-build-config -p SGX1FLC -b RelWithDebInfo -d --enable_full_libcxx_tests --compiler=gcc'
-            }
-          }
-        }
-      }
+String dockerBuildArgs(String... args) {
+    String argumentString = ""
+    for(arg in args) {
+        argumentString += " --build-arg ${arg}"
     }
-  }
+    return argumentString
+}
+
+def azureEnvironment(String task) {
+    node("nonSGX") {
+        cleanWs()
+        checkout scm
+        String buildArgs = dockerBuildArgs("UID=\$(id -u)",
+                                           "GID=\$(id -g)",
+                                           "UNAME=\$(id -un)",
+                                           "GNAME=\$(id -gn)")
+
+        def azure_image = docker.build("oetools-deploy", "${buildArgs} -f .jenkins/Dockerfile.deploy .")
+        azure_image.inside {
+            timeout(60) {
+                withCredentials([usernamePassword(credentialsId: 'SERVICE_PRINCIPAL_OSTCLAB',
+                                                  passwordVariable: 'SERVICE_PRINCIPAL_PASSWORD',
+                                                  usernameVariable: 'SERVICE_PRINCIPAL_ID'),
+                                 string(credentialsId: 'OSCTLabSubID', variable: 'SUBSCRIPTION_ID'),
+                                 string(credentialsId: 'TenantID', variable: 'TENANT_ID')]) {
+                    withEnv(["REGION=eastus", "RESOURCE_GROUP=oe-libcxx-${BUILD_NUMBER}"]) {
+                        dir('.jenkins/provision') {
+                            sh "${task}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+def ACCDeployVM(String agent_name, String agent_type) {
+    stage("Deploy ${agent_name}") {
+        withEnv(["AGENT_NAME=${agent_name}", "AGENT_TYPE=${agent_type}"]) {
+            azureEnvironment("./deploy-agent.sh")
+        }
+    }
+}
+
+def registerJenkinsSlaves() {
+    stage("Register Jenkins Slaves") {
+        withCredentials([usernamePassword(credentialsId: 'oe-ci',
+                                          passwordVariable: 'JENKINS_ADMIN_PASSWORD',
+                                          usernameVariable: 'JENKINS_ADMIN_NAME'),
+                         string(credentialsId: 'JENKINS_PRIVATE_URL',
+                                variable: 'JENKINS_PRIVATE_URL')]) {
+            withEnv(["JENKINS_URL=${JENKINS_PRIVATE_URL}"]) {
+                azureEnvironment("./register-agents.sh")
+            }
+        }
+    }
+}
+
+def ACClibcxxTest(String agent_name, String compiler, String build_type) {
+    stage("${agent_name} SGX1FLC ${compiler} ${build_type}") {
+        node("${agent_name}") {
+            cleanWs()
+            checkout scm
+
+            timeout(180) {
+                def c_compiler = "clang-7"
+                def cpp_compiler = "clang++-7"
+                if (compiler == "gcc") {
+                  c_compiler = "gcc"
+                  cpp_compiler = "g++"
+                }
+                dir('build'){
+                    withEnv(["CC=${c_compiler}","CXX=${cpp_compiler}"]) {
+                        sh """
+                        CMAKE="cmake .. -DCMAKE_BUILD_TYPE=${build_type} -DUSE_LIBSGX=ON -DENABLE_FULL_LIBCXX_TESTS=ON"
+                        if ! \${CMAKE}; then
+                            echo ""
+                            echo "cmake failed for SGX1FLC"
+                            echo ""
+                            exit 1
+                        fi
+                        if ! make; then
+                            echo ""
+                            echo "Build failed for SGX1FLC"
+                            echo ""
+                            exit 1
+                        fi
+                        if ! ctest -VV -debug; then
+                            echo ""
+                            echo "Test failed for SGX1FLC ${build_type} on agent ${agent_name}"
+                            echo ""
+                            exit 1
+                        fi
+                        """
+                    }
+                }
+            }
+        }
+    }
+}
+
+def deleteRG() {
+    stage("Delete the libcxx resource group") {
+        azureEnvironment("./cleanup.sh")
+    }
+}
+
+def unregisterJenkinsSlaves() {
+    stage("Unregister Jenkins Slaves") {
+        node("nonSGX") {
+            for (s in hudson.model.Hudson.instance.slaves) {
+                if(s.getLabelString() == "${env.XENIAL_LABEL}") {
+                    s.getComputer().doDoDelete()
+                }
+            }
+        }
+    }
+}
+
+
+try {
+    ACCDeployVM("libcxx-${BUILD_NUMBER}-1604-1", "xenial")
+    ACCDeployVM("libcxx-${BUILD_NUMBER}-1604-2", "xenial")
+    ACCDeployVM("libcxx-${BUILD_NUMBER}-1604-3", "xenial")
+
+    registerJenkinsSlaves()
+
+    parallel "libcxx ACC1604 clang-7 Debug" :          { ACClibcxxTest("${env.XENIAL_LABEL}", 'clang-7', 'Debug') },
+             "libcxx ACC1604 clang-7 Release" :        { ACClibcxxTest("${env.XENIAL_LABEL}", 'clang-7','Release') },
+             "libcxx ACC1604 clang-7 RelWithDebInfo" : { ACClibcxxTest("${env.XENIAL_LABEL}", 'clang-7', 'RelWithDebinfo') },
+             "libcxx ACC1604 gcc Debug" :              { ACClibcxxTest("${env.XENIAL_LABEL}", 'gcc', 'Debug') },
+             "libcxx ACC1604 gcc Release" :            { ACClibcxxTest("${env.XENIAL_LABEL}", 'gcc', 'Release') },
+             "libcxx ACC1604 gcc RelWithDebInfo" :     { ACClibcxxTest("${env.XENIAL_LABEL}", 'gcc', 'RelWithDebInfo') }
+} finally {
+    deleteRG()
+    unregisterJenkinsSlaves()
 }

--- a/.jenkins/provision/cleanup.sh
+++ b/.jenkins/provision/cleanup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -o errexit
+
+if [[ -z $SUBSCRIPTION_ID ]]; then echo "ERROR: Env variable SUBSCRIPTION_ID is not set"; exit 1; fi
+if [[ -z $SERVICE_PRINCIPAL_ID ]]; then echo "ERROR: Env variable SERVICE_PRINCIPAL_ID is not set"; exit 1; fi
+if [[ -z $SERVICE_PRINCIPAL_PASSWORD ]]; then echo "ERROR: Env variable SERVICE_PRINCIPAL_PASSWORD is not set"; exit 1; fi
+if [[ -z $TENANT_ID ]]; then echo "ERROR: Env variable TENANT_ID is not set"; exit 1; fi
+if [[ -z $RESOURCE_GROUP ]]; then echo "ERROR: Env variable RESOURCE_GROUP is not set"; exit 1; fi
+
+az login --service-principal -u "${SERVICE_PRINCIPAL_ID}" -p "${SERVICE_PRINCIPAL_PASSWORD}" --tenant "${TENANT_ID}" --output table
+az account set --subscription "${SUBSCRIPTION_ID}"
+RG_EXISTS=$(az group exists --name "$RESOURCE_GROUP")
+if [[ "$RG_EXISTS" = "true" ]]; then
+    az group delete --name "${RESOURCE_GROUP}" --yes --no-wait
+fi

--- a/.jenkins/provision/deploy-agent.sh
+++ b/.jenkins/provision/deploy-agent.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -o errexit
+
+if [[ -z $SUBSCRIPTION_ID ]]; then echo "ERROR: Env variable SUBSCRIPTION_ID is not set"; exit 1; fi
+if [[ -z $SERVICE_PRINCIPAL_ID ]]; then echo "ERROR: Env variable SERVICE_PRINCIPAL_ID is not set"; exit 1; fi
+if [[ -z $SERVICE_PRINCIPAL_PASSWORD ]]; then echo "ERROR: Env variable SERVICE_PRINCIPAL_PASSWORD is not set"; exit 1; fi
+if [[ -z $TENANT_ID ]]; then echo "ERROR: Env variable TENANT_ID is not set"; exit 1; fi
+if [[ -z $REGION ]]; then echo "ERROR: Env variable REGION is not set"; exit 1; fi
+if [[ -z $RESOURCE_GROUP ]]; then echo "ERROR: Env variable RESOURCE_GROUP is not set"; exit 1; fi
+
+if [[ -z $AGENT_NAME ]]; then echo "ERROR: Env variable AGENT_NAME is not set"; exit 1; fi
+if [[ "$AGENT_TYPE" != "xenial" ]] && [[ "$AGENT_TYPE" != "bionic" ]]; then
+    echo "ERROR: Env variable AGENT_TYPE has the wrong value. The allowed values for the script are: xenial, bionic"
+    exit 1
+fi
+
+check_open_port() {
+    #
+    # Checks with a timeout if a particular port (TCP or UDP) is open (nc tool is used for this)
+    #
+    local ADDRESS="$1"
+    local PORT="$2"
+    local TIMEOUT=900
+    echo "Checking, with a timeout of $TIMEOUT seconds, if the port $PORT is open at the address: $ADDRESS"
+    SECONDS=0
+    while true; do
+        if [[ $SECONDS -gt $TIMEOUT ]]; then
+            echo "ERROR: Port $PORT didn't open at $ADDRESS within $TIMEOUT seconds"
+            return 1
+        fi
+        if nc -w 5 -z "$ADDRESS" "$PORT" &>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+    echo "Success: Port $PORT is open at the address $ADDRESS"
+}
+
+#
+# Create the Azure ACC VM via oe-engine
+#
+az login --service-principal -u "${SERVICE_PRINCIPAL_ID}" -p "${SERVICE_PRINCIPAL_PASSWORD}" --tenant "${TENANT_ID}" --output table
+az account set --subscription "${SUBSCRIPTION_ID}"
+
+KEY=$(az keyvault secret show --vault-name "oe-ci-test-kv" --name "id-rsa-oe-test-pub" | jq -r .value | base64 -d)
+export SSH_PUBLIC_KEY="$KEY"
+
+DIR=$(dirname "$0")
+cd "$DIR"
+eval "cat << EOF
+$(cat "templates/oe-engine/ubuntu-${AGENT_TYPE}.json")
+EOF
+" > oe-engine-template.json
+oe-engine generate --api-model oe-engine-template.json
+RG_EXISTS=$(az group exists --name "$RESOURCE_GROUP")
+if [[ "$RG_EXISTS" = "false" ]]; then
+    az group create --name "$RESOURCE_GROUP" --location "$REGION" --output table
+fi
+az group deployment create --name "$AGENT_NAME" \
+                           --resource-group "$RESOURCE_GROUP" \
+                           --template-file _output/azuredeploy.json \
+                           --parameters @_output/azuredeploy.parameters.json \
+                           --output table
+az image delete --resource-group "$RESOURCE_GROUP" --name "CustomLinuxImage"
+check_open_port "${AGENT_NAME}.${REGION}.cloudapp.azure.com" "22"

--- a/.jenkins/provision/register-agents.sh
+++ b/.jenkins/provision/register-agents.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -o errexit
+
+if [[ -z $SUBSCRIPTION_ID ]]; then echo "ERROR: Env variable SUBSCRIPTION_ID is not set"; exit 1; fi
+if [[ -z $SERVICE_PRINCIPAL_ID ]]; then echo "ERROR: Env variable SERVICE_PRINCIPAL_ID is not set"; exit 1; fi
+if [[ -z $SERVICE_PRINCIPAL_PASSWORD ]]; then echo "ERROR: Env variable SERVICE_PRINCIPAL_PASSWORD is not set"; exit 1; fi
+if [[ -z $TENANT_ID ]]; then echo "ERROR: Env variable TENANT_ID is not set"; exit 1; fi
+
+if [[ -z $XENIAL_HOSTS ]] && [[ -z $BIONIC_HOSTS ]]; then echo "ERROR: No env variable for Ansible hosts is set (XENIAL_HOSTS, BIONIC_HOSTS)"; exit 1; fi
+if [[ ! -z $XENIAL_HOSTS ]] && [[ -z $XENIAL_LABEL ]]; then echo "ERROR: Env variable XENIAL_LABEL is not set"; exit 1; fi
+if [[ ! -z $BIONIC_HOSTS ]] && [[ -z $BIONIC_LABEL ]]; then echo "ERROR: Env variable BIONIC_LABEL is not set"; exit 1; fi
+if [[ -z $JENKINS_URL ]]; then echo "ERROR: Env variable JENKINS_URL is not set"; exit 1; fi
+if [[ -z $JENKINS_ADMIN_NAME ]]; then echo "ERROR: Env variable JENKINS_ADMIN_NAME is not set"; exit 1; fi
+if [[ -z $JENKINS_ADMIN_PASSWORD ]]; then echo "ERROR: Env variable JENKINS_ADMIN_PASSWORD is not set"; exit 1; fi
+
+DIR=$(dirname "$0")
+
+#
+# Register the Azure ACC VM to Jenkins via the Ansible scripts
+#
+ANSIBLE_DIR=$(realpath "$DIR/../../scripts/ansible")
+cd "$ANSIBLE_DIR"
+
+SSH_PRIVATE_KEY="id-rsa-oe-test"
+az login --service-principal -u "${SERVICE_PRINCIPAL_ID}" -p "${SERVICE_PRINCIPAL_PASSWORD}" --tenant "${TENANT_ID}" --output table
+az account set --subscription "${SUBSCRIPTION_ID}"
+az keyvault secret show --vault-name "oe-ci-test-kv" --name "id-rsa-oe-test" | jq -r .value | base64 -d > $SSH_PRIVATE_KEY
+chmod 600 $SSH_PRIVATE_KEY
+
+generate_ansible_host_var_file() {
+    local AGENT_HOSTNAME=$1
+    local AGENT_LABEL=$2
+    AGENT_NAME=$(echo "$AGENT_HOSTNAME" | cut -d '.' -f1)
+    {
+        echo "jenkins_agent_name: $AGENT_NAME"
+        echo "jenkins_agent_label: $AGENT_LABEL"
+        echo "jenkins_url: '$JENKINS_URL'"
+        echo "jenkins_admin_name: '$JENKINS_ADMIN_NAME'"
+        echo "jenkins_admin_password: '$JENKINS_ADMIN_PASSWORD'"
+    } > "inventory/host_vars/$AGENT_HOSTNAME"
+}
+
+LINUX_AGENTS=()
+if [[ ! -z $XENIAL_HOSTS ]]; then
+    for HOST in $(echo "$XENIAL_HOSTS" | tr ',' '\n'); do
+        generate_ansible_host_var_file "$HOST" "$XENIAL_LABEL"
+        LINUX_AGENTS+=("$HOST")
+    done
+fi
+if [[ ! -z $BIONIC_HOSTS ]]; then
+    for HOST in $(echo "$BIONIC_HOSTS" | tr ',' '\n'); do
+        generate_ansible_host_var_file "$HOST" "$BIONIC_LABEL"
+        LINUX_AGENTS+=("$HOST")
+    done
+fi
+
+
+echo "[linux-agents]" > inventory/hosts
+for AGENT in "${LINUX_AGENTS[@]}"; do
+    echo "$AGENT" >> inventory/hosts
+done
+
+export ANSIBLE_HOST_KEY_CHECKING=False
+ansible-playbook jenkins-agents-register.yml --extra-vars="ansible_ssh_private_key_file=$SSH_PRIVATE_KEY"

--- a/.jenkins/provision/templates/oe-engine/ubuntu-bionic.json
+++ b/.jenkins/provision/templates/oe-engine/ubuntu-bionic.json
@@ -23,10 +23,7 @@
         }
       ],
       "osImage": {
-        "publisher": "Canonical",
-        "offer": "UbuntuServer",
-        "sku": "18.04-LTS",
-        "version": "latest"
+        "url": "https://oejenkins.blob.core.windows.net/disks/jenkins-agent-1804-base-disk.vhd"
       }
     },
     "diagnosticsProfile": {

--- a/.jenkins/provision/templates/oe-engine/ubuntu-bionic.json
+++ b/.jenkins/provision/templates/oe-engine/ubuntu-bionic.json
@@ -1,0 +1,36 @@
+{
+  "properties": {
+    "vmProfiles": [
+      {
+        "name": "${AGENT_NAME}",
+        "osType": "Linux",
+        "vmSize": "Standard_DC2s",
+        "ports": [22],
+        "isVanilla": true,
+        "hasDNSName": true
+      }
+    ],
+    "vnetProfile": {
+      "vnetResourceGroup": "OE-Jenkins-CI-VNET",
+      "vnetName": "OE-Jenkins-CI-VNET",
+      "subnetName": "default"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "sshPublicKeys": [
+        {
+          "keyData": "${SSH_PUBLIC_KEY}"
+        }
+      ],
+      "osImage": {
+        "publisher": "Canonical",
+        "offer": "UbuntuServer",
+        "sku": "18.04-LTS",
+        "version": "latest"
+      }
+    },
+    "diagnosticsProfile": {
+      "enabled": false
+    }
+  }
+}

--- a/.jenkins/provision/templates/oe-engine/ubuntu-xenial.json
+++ b/.jenkins/provision/templates/oe-engine/ubuntu-xenial.json
@@ -21,7 +21,10 @@
         {
           "keyData": "${SSH_PUBLIC_KEY}"
         }
-      ]
+      ],
+      "osImage": {
+        "url": "https://oejenkins.blob.core.windows.net/disks/jenkins-agent-1604-base-disk.vhd"
+      }
     },
     "diagnosticsProfile": {
       "enabled": false

--- a/.jenkins/provision/templates/oe-engine/ubuntu-xenial.json
+++ b/.jenkins/provision/templates/oe-engine/ubuntu-xenial.json
@@ -1,0 +1,30 @@
+{
+  "properties": {
+    "vmProfiles": [
+      {
+        "name": "${AGENT_NAME}",
+        "osType": "Linux",
+        "vmSize": "Standard_DC2s",
+        "ports": [22],
+        "isVanilla": true,
+        "hasDNSName": true
+      }
+    ],
+    "vnetProfile": {
+      "vnetResourceGroup": "OE-Jenkins-CI-VNET",
+      "vnetName": "OE-Jenkins-CI-VNET",
+      "subnetName": "default"
+    },
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "sshPublicKeys": [
+        {
+          "keyData": "${SSH_PUBLIC_KEY}"
+        }
+      ]
+    },
+    "diagnosticsProfile": {
+      "enabled": false
+    }
+  }
+}

--- a/scripts/ansible/roles/linux/docker/tasks/stable-install.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/stable-install.yml
@@ -6,15 +6,27 @@
   apt_key:
     url: "https://download.docker.com/linux/ubuntu/gpg"
     state: present
+  retries: 10
+  delay: 10
+  register: result
+  until: result is success
 
 - name: Docker | Add the APT repository
   apt_repository:
     repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
     state: present
     update_cache: yes
+  retries: 10
+  delay: 10
+  register: result
+  until: result is success
 
 - name: Docker | Install Docker-CE
   apt:
     name: docker-ce
     state: present
     update_cache: yes
+  retries: 10
+  delay: 10
+  register: result
+  until: result is success

--- a/scripts/ansible/roles/linux/jenkins/tasks/slave-setup.yml
+++ b/scripts/ansible/roles/linux/jenkins/tasks/slave-setup.yml
@@ -19,6 +19,10 @@
     name: openjdk-8-jre
     state: present
     update_cache: yes
+  retries: 10
+  delay: 10
+  register: result
+  until: result is success
 
 - name: Jenkins | Create the Jenkins group
   group:


### PR DESCRIPTION
Fixes https://github.com/Microsoft/openenclave/issues/1495

Adds the necessary scripts and the Jenkinsfile's modifications to enable ephemeral Jenkins build servers for the libcxx nightly job:

* New servers are deployed with the `oe-engine` tool from a pre-built `VHD` image with all the requirements already set
* The Ansible tasks are run against the new servers and they are registered in the main Jenkins master server
* The full `libcxx` testing stages are run in parallel against the new nodes
* The new servers are cleaned up from Azure and unregistered from the Jenkins master