### PR TITLE
Update libc & libcxx support docs

### DIFF
--- a/docs/LibcSupport.md
+++ b/docs/LibcSupport.md
@@ -1,27 +1,27 @@
 # Open Enclave Support for libc
 
 Header | Supported | Comments |
-:---:|:---:|:---:|
+:---:|:---:|:---|
 assert.h | Yes | - |
-complex.h | Partial | Unsupported functions: cacos(), cacosh(), cacoshl(), cacosl(), casin(), casinh(), casinhl(), casinl(), csqrt(), csqrtl(), cpow(), cpowf(), cpowl() |
+complex.h | Partial | **Unsupported functions:** cacos(), cacosh(), cacoshl(), cacosl(), casin(), casinh(), casinhl(), casinl(), csqrt(), csqrtl(), cpow(), cpowf(), cpowl() |
 ctype.h | Yes | - |
 fenv.h | Yes | - |
 float.h | Yes | - |
-inttypes.h | partial | Unsupported functions: imaxabs(), imaxdiv()|
+inttypes.h | partial | **Unsupported functions:** imaxabs(), imaxdiv()|
 locale.h | Partial | Only basic support for C/POSIX locale |
-malloc.h | Partial | Unsupported functions: malloc_usable_size() |
-math.h | Partial | Unsupported functions: acosh(), asinh(), fmal(), lgamma(), lgammaf(), scalbn(), scalbnf(), scalbnl(), sinh(), sinhl(), tgamma() |
+malloc.h | Partial | **Unsupported functions:** malloc_usable_size() |
+math.h | Partial | **Unsupported functions:** acosh(), asinh(), fmal(), lgamma(), lgammaf(), scalbn(), scalbnf(), scalbnl(), sinh(), sinhl(), tgamma() |
 setjmp.h | Yes | - |
 signal.h | No | - |
 stdatomic.h | No | - |
-stdio.h | Partial | All I/O functions implicitly call out to untrusted host. Supported functions: snprintf(), sscanf(),  _vfscanf()*_, vsnprintf(), vsscanf(), sprintf(), vsprintf(), puts(), putchar(), vprintf(), printf(), _fprintf()*_, _getc()*_, _ungetc()*_, _fwrite()*_, _fflush()*_, _fputs()*_, _fputc()*_ |
-stdlib.h | Partial | Unsupported functions: div(), imaxabs(), imaxdiv(), ldiv(), lldiv() |
-string.h | Partial | Unsupported functions: strerror(), strsignal() |
-tgmath.h | Partial | Unsupported functions: acosh(), asinh(), fmal(), lgamma(), lgamma_r(), scalbn(), scalbnf(), scalbnl(), sinh(), sinhl(), tgamma() |
-threads.h | Partial | Synchronization primitives are not secure across calls to host. Threads are still scheduled by the untrusted host process and an enclave cannot rely on threads making forward progress. Unsupported functions: pthread_create(), pthread_join() and pthread_detach() |
-time.h | Partial | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. Supported functions: time(), gettimeofday(), clock_gettime(), nanosleep(). Please note that clock_gettime() only supports CLOCK_REALTIME  |
+stdio.h | Partial | All I/O functions implicitly call out to untrusted host. <br> **Supported functions:** snprintf(), sscanf(),  _vfscanf()*_, vsnprintf(), vsscanf(), sprintf(), vsprintf(), puts(), putchar(), vprintf(), printf(), _fprintf()*_, _getc()*_, _ungetc()*_, _fwrite()*_, _fflush()*_, _fputs()*_, _fputc()*_ <br> _* Only has support for the streams stderr and stdout, and does not set ferror_ |
+stdlib.h | Partial | **Unsupported functions:** div(), imaxabs(), imaxdiv(), ldiv(), lldiv() |
+string.h | Partial | **Unsupported functions:** strerror(), strsignal() |
+tgmath.h | Partial | **Unsupported functions:** acosh(), asinh(), fmal(), lgamma(), lgamma_r(), scalbn(), scalbnf(), scalbnl(), sinh(), sinhl(), tgamma() |
+pthread.h | Partial | Synchronization primitives are not secure across calls to host. Threads are still scheduled by the untrusted host process and an enclave cannot rely on threads making forward progress. <br> **Supported functions:** <br> _- General:_ pthread_self(), pthread_equal(), pthread_once() <br> _- Spinlock:_ pthread_spin_init(), pthread_spin_lock(), pthread_spin_unlock(), pthread_spin_destroy() <br> _- Mutex:_ pthread_mutexattr_init(), pthread_mutexattr_settype(), pthread_mutexattr_destroy(), pthread_mutex_init(), pthread_mutex_lock(), pthread_mutex_trylock(), pthread_mutex_unlock(), pthread_mutex_destroy() <br> _- RW Lock:_ pthread_rwlock_init(), pthread_rwlock_rdlock(), pthread_rwlock_wrlock(), pthread_rwlock_unlock(), pthread_rwlock_destroy() <br> _- Cond:_ pthread_cond_init(), pthread_cond_wait(), pthread_cond_timedwait(), pthread_cond_signal(), pthread_cond_broadcast(), pthread_cond_destroy() <br> _- Thread local storage:_ pthread_key_create(), pthread_key_delete(), pthread_setspecific(), pthread_getspecific() |
+threads.h | No | - |
+time.h | Partial | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. <br> **Supported functions:** time(), gettimeofday(), clock_gettime(), nanosleep(). _Please note that clock_gettime() only supports CLOCK_REALTIME_ |
 uchar.h | Yes | - |
-wchar.h | Partial | Supported functions: wcscoll(), wcsxfrm() |
+wchar.h | Partial | **Supported functions:** wcscoll(), wcsxfrm() |
 wctype.h | Yes | - |
 
-_* Only has support for the streams stderr and stdout, and does not set ferror_

--- a/docs/LibcxxSupport.md
+++ b/docs/LibcxxSupport.md
@@ -1,47 +1,49 @@
 # Open Enclave Support for libcxx
 
 Header | Supported | Comments |
-:---:|:---:|:---:|
-algorithm | Partial | Supported functions: find(), find_first_of(), count(), mismatch(), equal(), search(), copy(), move(), transform(), replace(), fill(), generate(), remove(), unique(), reverse(), min(), max(), sort(), lower_bound() |
+:---:|:---:|:---|
+algorithm | Partial | **Supported functions:** find(), find_first_of(), count(), mismatch(), equal(), search(), copy(), move(), transform(), replace(), fill(), generate(), remove(), unique(), reverse(), min(), max(), sort(), lower_bound() |
 array | Yes | - |
-bitset | Partial | Supported functions: base(), bitset(), reset(), set(), to_string(), test() |
+bitset | Partial | **Supported functions:** base(), bitset(), reset(), set(), to_string(), test() |
 cassert | Yes | - |
-cctype | Partial | Unsupported functions: isalnum(), isaplha(), iscntrl(), isgraph(), isspace(), isblank(), isprint(), ispunct() |
+cctype | Partial | **Unsupported functions:** isalnum(), isaplha(), iscntrl(), isgraph(), isspace(), isblank(), isprint(), ispunct() |
 cfenv | No | - |
 charconv | No | - |
-chrono | Partial | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. Supported functions: time(), gettimeofday(), clock_gettime(), nanosleep(). Please note that clock_gettime() only supports CLOCK_REALTIME |
+chrono | Partial | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. <br> **Supported classes:** system_clock, treat_as_floating_point, duration_values |
 clocale | Partial | Only basic support for C/POSIX locale |
-cmath | Partial | Supported functions: abs(), nan(), exp(), log(), sin(), tan(), asin(), erf(), trunc(), round(), rint(), modf() |
+cmath | Partial | **Supported functions:** abs(), nan(), exp(), log(), sin(), tan(), asin(), erf(), trunc(), round(), rint(), modf() |
 codecvt | Yes | - |
 compare | No | - |
 complex | Yes | - |
 condition_variable | Yes | - |
+csetjmp | Yes | - |
 csignal | Yes | - |
 cstdarg | No | - |
 cstddef | Yes | - |
 cstdint | Yes | - |
-cstdio | Partial | All I/O functions implicitly call out to untrusted host. Unsupported functions: ferror(), vscanf() |
-cstdlib | Partial | Unsupported functions: at_quick_exit(), quick_exit() |
-cstring | Partial | Unsupported functions: strcpy(), strcat(), strncat(), strchr(), strcspn(), strspn() |
-ctime | Yes | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. Supported functions: time(), gettimeofday(), clock_gettime(), nanosleep(). Please note that clock_gettime() only supports CLOCK_REALTIME |
-cwchar | Partial | Unsupported functions: wscanf(), wprintf() |
+cstdio | Partial | All I/O functions implicitly call out to untrusted host. <br> **Unsupported functions:** ferror(), vscanf() |
+cstdlib | Partial | **Unsupported functions:** at_quick_exit(), quick_exit() |
+cstring | Partial | **Unsupported functions:** strcpy(), strcat(), strncat(), strchr(), strcspn(), strspn() |
+ctime | Yes | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. <br> **Supported functions:** time(), gettimeofday(), clock_gettime(), nanosleep(). _Please note that clock_gettime() only supports CLOCK_REALTIME_ |
+cwchar | Partial | **Unsupported functions:** wscanf(), wprintf() |
 cwctype | Yes | - |
 cuchar | No | - |
-exception | Partial | Unsupported functions: throw_with_nested(), rethrow_if_nested() |
+exception | Partial | **Unsupported functions:** throw_with_nested(), rethrow_if_nested() |
 functional | No | - |
 future | Yes | - |
 fstream | Yes | All I/O functions implicitly call out to untrusted host. |
 initializer_list | Yes | - |
-ios | Partial | Unsupported functions: nounitbuf(), nouppercase(), noshowpos(), noshowpoint(), noshowbase(), noboolalpha() |
+iomanip | Partial | **Unsupported functions:** get_money(), put_money(), get_time(), put_time() |
+ios | Partial | **Unsupported functions:** nounitbuf(), nouppercase(), noshowpos(), noshowpoint(), noshowbase(), noboolalpha() |
 istream | Yes | - |
-iterator | Partial | Unsupported functions: make_reverse_iterator(), make_move_iterator(), front_inserter(), back_inserter(), inserter(), begin(), cbegin(), rbegin(), crbegin() |
+iterator | Partial | **Unsupported functions:** make_reverse_iterator(), make_move_iterator(), front_inserter(), back_inserter(), inserter(), begin(), cbegin(), rbegin(), crbegin() |
 new | Yes | - |
-numeric | Partial | Unsupported functions: accumulate(), inner_product(), adjacent_difference(), partial_sum() |
+numeric | Partial | **Unsupported functions:** accumulate(), inner_product(), adjacent_difference(), partial_sum() |
 mutex | Yes | - |
 optional | Yes | - |
-ostream | Partial | Unsupported function: endl() |
+ostream | Partial | **Unsupported function:** endl() |
 queue | Yes | - |
-random | Partial | Unsupported functions: generate_canonical() |
+random | Partial | **Unsupported functions:** generate_canonical() |
 ratio | Yes | - |
 regex | No | - |
 set | Yes | - |
@@ -49,12 +51,13 @@ sstream | Yes | - |
 stddef | Yes |  - |
 streambuf | Yes | - |
 system_error | Yes | - |
-thread | Partial | Synchronization primitives are not secure across calls to host. Threads are still scheduled by the untrusted host process and an enclave cannot rely on threads making forward progress. Unsupported function: sleep_until(), std::create, std::join and std::detach are not supported on the enclave |
-tuple | Partial | Supported function: tie() |
+thread | No | - |
+tuple | Partial | **Supported function:** tie() |
+typeindex | Yes | - |
 typeinfo | No | - |
 type_traits | No | - |
 unordered_map | Yes | - |
 unordered_set | Yes | - |
-utility | Partial | Unsupported function : make_pair() |  
+utility | Partial | **Unsupported function:** make_pair() |
 vector | Yes | - |
 version | No | - |


### PR DESCRIPTION
- Fix #1487 by adding `pthread.h` entry & marking `threads.h` as unsupported.
- Fix #1488 by correcting `thread` support to unsupported.
- Fix #1533 by correcting `chrono` support description.
- Fix #1534 by adding `iomanip` support description.
- Add `csetjmp` & `typeindex` support descriptions.

This change set addresses existing reported issues. More comprehensive review for the documentation is tracked by #1544)
