### PR TITLE
Decouple the OE environment setup from the `jenkins-setup.yml` playbook

### DIFF
--- a/scripts/ansible/jenkins-setup.yml
+++ b/scripts/ansible/jenkins-setup.yml
@@ -2,27 +2,13 @@
 # Licensed under the MIT License.
 
 ---
+- import_playbook: oe-linux-acc-setup.yml
+
 - hosts: linux-agents
   any_errors_fatal: true
   gather_facts: true
   become: yes
   tasks:
-    - import_role:
-        name: linux/openenclave
-        tasks_from: environment-setup.yml
-
-    - import_role:
-        name: linux/intel
-        tasks_from: sgx-driver.yml
-
-    - import_role:
-        name: linux/intel
-        tasks_from: sgx-packages.yml
-
-    - import_role:
-        name: linux/az-dcap-client
-        tasks_from: stable-install.yml
-
     - import_role:
         name: linux/jenkins
         tasks_from: slave-setup.yml
@@ -31,18 +17,12 @@
         name: linux/validation
         tasks_from: slave-validation.yml
 
+- import_playbook: oe-windows-acc-setup.yml
+
 - hosts: windows-agents
   any_errors_fatal: true
   become_method: runas
   tasks:
-    - import_role:
-        name: windows/openenclave
-        tasks_from: environment-setup.yml
-
-    - import_role:
-        name: windows/az-dcap-client
-        tasks_from: environment-setup.yml
-
     - import_role:
         name: windows/jenkins
         tasks_from: slave-setup.yml

--- a/scripts/ansible/oe-linux-acc-setup.yml
+++ b/scripts/ansible/oe-linux-acc-setup.yml
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+- hosts: linux-agents
+  any_errors_fatal: true
+  gather_facts: true
+  become: yes
+  tasks:
+    - import_role:
+        name: linux/openenclave
+        tasks_from: environment-setup.yml
+
+    - import_role:
+        name: linux/intel
+        tasks_from: sgx-driver.yml
+
+    - import_role:
+        name: linux/intel
+        tasks_from: sgx-packages.yml
+
+    - import_role:
+        name: linux/az-dcap-client
+        tasks_from: stable-install.yml

--- a/scripts/ansible/oe-windows-acc-setup.yml
+++ b/scripts/ansible/oe-windows-acc-setup.yml
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+- hosts: windows-agents
+  any_errors_fatal: true
+  become_method: runas
+  tasks:
+    - import_role:
+        name: windows/openenclave
+        tasks_from: environment-setup.yml
+
+    - import_role:
+        name: windows/az-dcap-client
+        tasks_from: environment-setup.yml


### PR DESCRIPTION
Two new playbooks created (one for Linux, one for Windows), each of them having the necessary roles to create the OE environment.
The 'jenkins-setup.yml' file contains only the slave-setup task and the other tasks are imported from the newly created playbooks. 