### PR TITLE
Skip std_containers_associative_map_map.access_at test on GCC >7 release builds

### DIFF
--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -51,5 +51,13 @@ foreach(testcase ${alltests})
         endif()
     endif()
 
+# the following test fails on GCC 7 or newer, see #1559 -- Skip this test on GCC 7.0 and above in non debug builds
+    if ("${name}" MATCHES "std_containers_associative_map_map.access_at.pass")
+        string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+        if (CMAKE_CXX_COMPILER_ID MATCHES GNU AND BUILD_TYPE_UPPER MATCHES REL)
+            continue()
+        endif()
+    endif()
+
     add_enclave_test(tests/libcxxtest-${name} libcxx_host libcxxtest-${name}_enc)
 endforeach(testcase)

--- a/tests/libcxx/enc/CMakeLists.txt
+++ b/tests/libcxx/enc/CMakeLists.txt
@@ -113,5 +113,13 @@ foreach(testcase ${alltests})
         endif()
     endif()
 
+# the following test fails on GCC 7 or newer, see #1559 -- Skip this test on GCC 7.0 and above in non debug builds
+    if ("${name}" MATCHES "std_containers_associative_map_map.access_at.pass")
+        string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+        if (CMAKE_CXX_COMPILER_ID MATCHES GNU AND BUILD_TYPE_UPPER MATCHES REL)
+            continue()
+        endif()
+    endif()
+
     add_libcxx_test_enc("${name}" "${testcase}")
 endforeach(testcase)


### PR DESCRIPTION

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>