### PR TITLE
[Ansible] Use role vars instead of global group vars

### DIFF
--- a/scripts/ansible/inventory/group_vars/linux-agents
+++ b/scripts/ansible/inventory/group_vars/linux-agents
@@ -8,8 +8,6 @@ docker_target_version: "18.09"
 dockerd_target_version: "18.09"
 clang_target_version: "7.0"
 ocaml_target_version: "4.0"
-intel_sgx_driver_1604: "https://download.01.org/intel-sgx/dcap-1.0.1/dcap_installer/ubuntuServer1604/sgx_linux_x64_driver_dcap_4f32b98.bin"
-intel_sgx_driver_1804: "https://download.01.org/intel-sgx/dcap-1.0.1/dcap_installer/ubuntuServer1804/sgx_linux_x64_driver_dcap_4f32b98.bin"
 
 validation_directories:
   - "/opt/intel/sgxdriver"

--- a/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
@@ -10,10 +10,14 @@
     update_cache: yes
     install_recommends: no
 
+- name: Populate service facts
+  service_facts:
+
 - name: Ensure aesmd service stopped
   service:
     name: aesmd
     state: stopped
+  when: "'aesmd.service' in ansible_facts.services"
 
 - name: Download Intel SGX DCAP Driver
   get_url:
@@ -46,3 +50,4 @@
     name: aesmd
     state: started
     enabled: yes
+  when: "'aesmd.service' in ansible_facts.services"

--- a/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-driver.yml
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 
 ---
+- name: Intel SGX Driver | Include vars
+  include_vars: "{{ ansible_distribution_release | lower }}.yml"
+
 - name: Install the dkms package
   apt:
     name:
@@ -21,21 +24,11 @@
 
 - name: Download Intel SGX DCAP Driver
   get_url:
-    url: "{{ intel_sgx_driver_1604 }}"
+    url: "{{ intel_sgx_driver_url }}"
     dest: /tmp/sgx_linux_x64_driver_dcap.bin
     mode: 0755
     timeout: 120
   retries: 3
-  when: ansible_distribution_version == "16.04"
-
-- name: Download Intel SGX DCAP Driver
-  get_url:
-    url: "{{ intel_sgx_driver_1804 }}"
-    dest: /tmp/sgx_linux_x64_driver_dcap.bin
-    mode: 0755
-    timeout: 120
-  retries: 3
-  when: ansible_distribution_version != "16.04"
 
 - name: Install the Intel SGX DCAP Driver
   command: /tmp/sgx_linux_x64_driver_dcap.bin

--- a/scripts/ansible/roles/linux/intel/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/intel/vars/bionic.yml
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.0.1/dcap_installer/ubuntuServer1804/sgx_linux_x64_driver_dcap_4f32b98.bin"

--- a/scripts/ansible/roles/linux/intel/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/intel/vars/xenial.yml
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.0.1/dcap_installer/ubuntuServer1604/sgx_linux_x64_driver_dcap_4f32b98.bin"


### PR DESCRIPTION
* Start/stop `aesmd` service only if it exists
* Use role vars instead of global group vars to pass the Intel SGX driver URL to Ubuntu 16.04 / 18.04 machines

Fixes https://github.com/Microsoft/openenclave/issues/1565