### PR TITLE
Switch from -fPIC to -fPIE semantics for enclaves

### DIFF
--- a/3rdparty/libcxx/CMakeLists.txt
+++ b/3rdparty/libcxx/CMakeLists.txt
@@ -48,9 +48,6 @@ maybe_build_using_clangw(libcxx)
 
 add_dependencies(libcxx libcxx_includes)
 
-set_target_properties(libcxx PROPERTIES
-  POSITION_INDEPENDENT_CODE ON)
-
 target_compile_options(libcxx PRIVATE -Wno-error)
 
 target_compile_definitions(libcxx

--- a/3rdparty/libcxxrt/CMakeLists.txt
+++ b/3rdparty/libcxxrt/CMakeLists.txt
@@ -17,9 +17,6 @@ add_library(libcxxrt OBJECT
 
 maybe_build_using_clangw(libcxxrt)
 
-set_target_properties(libcxxrt PROPERTIES
-  POSITION_INDEPENDENT_CODE ON)
-
 target_compile_options(libcxxrt PRIVATE -Wno-error)
 
 target_compile_definitions(libcxxrt PRIVATE -D_GNU_SOURCE)

--- a/3rdparty/libunwind/CMakeLists.txt
+++ b/3rdparty/libunwind/CMakeLists.txt
@@ -107,8 +107,6 @@ add_library(libunwind OBJECT
   # Add dependency to libunwind.h generation.
   ${CMAKE_CURRENT_BINARY_DIR}/libunwind.h)
 
-set_target_properties(libunwind PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
 maybe_build_using_clangw(libunwind)
 
 set_source_files_properties(Gstep.c PROPERTIES COMPILE_FLAGS "-Werror")

--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-set(MBEDTLS_WRAP_CFLAGS "-nostdinc -I${PROJECT_SOURCE_DIR}/include/openenclave/corelibc -I${PROJECT_SOURCE_DIR}/include -DOE_NEED_STDC_NAMES -fPIC -fno-builtin-udivti3 ${SPECTRE_MITIGATION_FLAGS}")
+set(MBEDTLS_WRAP_CFLAGS "-nostdinc -I${PROJECT_SOURCE_DIR}/include/openenclave/corelibc -I${PROJECT_SOURCE_DIR}/include -DOE_NEED_STDC_NAMES -fPIE -fno-builtin-udivti3 ${SPECTRE_MITIGATION_FLAGS}")
 
 if (USE_CLANGW)
   set(MBEDTLS_WRAP_CFLAGS "-target x86_64-pc-linux ${MBEDTLS_WRAP_CFLAGS}")

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 #
 # The build command here is just a set of copy instructions to setup
 # `oelibc_includes`. See that CMake target for compile options.
-set(MUSL_CFLAGS "-fPIC -DSYSCALL_NO_INLINE")
+set(MUSL_CFLAGS "-DSYSCALL_NO_INLINE")
 set(MUSL_CC ${CMAKE_C_COMPILER})
 set(MUSL_CXX ${CMAKE_CXX_COMPILER})
 

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -123,8 +123,13 @@ if (CMAKE_C_COMPILER_ID MATCHES GNU)
     target_compile_options(oecore PRIVATE -Wjump-misses-init)
 endif ()
 
+# NOTE: All code inside an enclave must be compile with "position
+# independent executable" semantics via -fPIE, and linked with -pie.
+# Hence the PUBLIC (and INTERFACE) use of these flags instead of -fPIC
+# or POSITION_INDEPENDENT_CODE, which would use the incorrect flag as
+# enclaves actually are executables.
 target_compile_options(oecore PUBLIC
-    -fPIC
+    -fPIE
     -nostdinc
     -fno-stack-protector
     -fvisibility=hidden)
@@ -148,7 +153,7 @@ if(USE_DEBUG_MALLOC)
     message("USE_DEBUG_MALLOC is set, building oecore with memory leak detection.")
 endif()
 
-# addl link-options for enclave apps
+# Interface link flags for enclaves.
 target_link_libraries(oecore INTERFACE
     -nostdlib -nodefaultlibs -nostartfiles
     -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id)

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -22,10 +22,10 @@ set(ENCLAVE_CXXINCLUDES
     "-I\${includedir}/openenclave/3rdparty/libcxx ${ENCLAVE_CINCLUDES}")
 
 set(ENCLAVE_CFLAGS_CLANG
-    "-nostdinc -m64 -fPIC -mllvm -x86-speculative-load-hardening")
+    "-nostdinc -m64 -fPIE -mllvm -x86-speculative-load-hardening")
 
 set(ENCLAVE_CFLAGS_GCC
-    "-nostdinc -m64 -fPIC")
+    "-nostdinc -m64 -fPIE")
 
 ##==============================================================================
 ##

--- a/tests/thread_local/host/host.cpp
+++ b/tests/thread_local/host/host.cpp
@@ -61,10 +61,11 @@ int main(int argc, const char* argv[])
                 ++num_thread_local_relocs;
         }
 
-// There are 7 exported thread-local variables.
-// 1 reloc for each exported variable.
+// There are originally 7 exported thread-local variables. Since we
+// are compiling with -fPIE, the relocations for these thread-locals
+// are optimized to three.
 #if __linux__
-        OE_TEST(num_thread_local_relocs == 7);
+        OE_TEST(num_thread_local_relocs == 3);
 #else
 // If the host is Windows, we are locking down the case where
 // the enclave was created on Windows as well. LLVM's ld (ld.lld)


### PR DESCRIPTION
This ensures we're compiling all enclave code (including third-party libraries) with -fPIE instead of -fPIC, and linking with -pie.

This resolves #1567 and #1168.