### PR TITLE
Explicitly choose the most optimal, and supported tls-model.

### DIFF
--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-set(MBEDTLS_WRAP_CFLAGS "-nostdinc -I${PROJECT_SOURCE_DIR}/include/openenclave/corelibc -I${PROJECT_SOURCE_DIR}/include -DOE_NEED_STDC_NAMES -fPIE -fno-builtin-udivti3 ${SPECTRE_MITIGATION_FLAGS}")
+set(MBEDTLS_WRAP_CFLAGS "-nostdinc -I${PROJECT_SOURCE_DIR}/include/openenclave/corelibc -I${PROJECT_SOURCE_DIR}/include -DOE_NEED_STDC_NAMES -fPIE -fno-builtin-udivti3 ${SPECTRE_MITIGATION_FLAGS} -ftls-model=local-exec")
 
 if (USE_CLANGW)
   set(MBEDTLS_WRAP_CFLAGS "-target x86_64-pc-linux ${MBEDTLS_WRAP_CFLAGS}")

--- a/3rdparty/musl/CMakeLists.txt
+++ b/3rdparty/musl/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 #
 # The build command here is just a set of copy instructions to setup
 # `oelibc_includes`. See that CMake target for compile options.
-set(MUSL_CFLAGS "-DSYSCALL_NO_INLINE")
+set(MUSL_CFLAGS "-DSYSCALL_NO_INLINE -ftls-model=local-exec")
 set(MUSL_CC ${CMAKE_C_COMPILER})
 set(MUSL_CXX ${CMAKE_CXX_COMPILER})
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for thread local variables
    - Both GNU __thread and C++11 thread_local
    - Both hardware and simulation mode
-   - Local-Exec and Initial-Exec thread-local storage models
+   - Enclaves are compiled using local-exec thread-local model (-ftls-model=local-exec)
 - Added `oe_get_public_key` and `oe_get_public_key_by_policy` host functions,
   which allow the host to get a public key derived from an enclave's identity.
 - Added v2 versions of the following APIs that instead of passing in buffers now

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -132,7 +132,13 @@ target_compile_options(oecore PUBLIC
     -fPIE
     -nostdinc
     -fno-stack-protector
-    -fvisibility=hidden)
+    -fvisibility=hidden
+# According to https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# "The default without -fpic is ‘initial-exec’; with -fpic the default is ‘global-dynamic’"
+# Enclaves are linked using -pie and therefore global-dynamic is too conservative.
+# Of the two efficient static tls models, inital-exec and local-exec, we choose the most
+# optimal one.
+    -ftls-model=local-exec)
 
 target_compile_options(oecore INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -22,10 +22,10 @@ set(ENCLAVE_CXXINCLUDES
     "-I\${includedir}/openenclave/3rdparty/libcxx ${ENCLAVE_CINCLUDES}")
 
 set(ENCLAVE_CFLAGS_CLANG
-    "-nostdinc -m64 -fPIE -mllvm -x86-speculative-load-hardening")
+    "-nostdinc -m64 -fPIE -ftls-model=local-exec -mllvm -x86-speculative-load-hardening")
 
 set(ENCLAVE_CFLAGS_GCC
-    "-nostdinc -m64 -fPIE")
+    "-nostdinc -m64 -fPIE -ftls-model=local-exec")
 
 ##==============================================================================
 ##

--- a/tests/thread_local/host/host.cpp
+++ b/tests/thread_local/host/host.cpp
@@ -63,9 +63,11 @@ int main(int argc, const char* argv[])
 
 // There are originally 7 exported thread-local variables. Since we
 // are compiling with -fPIE, the relocations for these thread-locals
-// are optimized to three.
+// are optimized to three. Furthermore, compiling with
+// -ftls-model=local-exec optimizes away all these relocations.
 #if __linux__
-        OE_TEST(num_thread_local_relocs == 3);
+        OE_TEST(num_thread_local_relocs == 0);
+
 #else
 // If the host is Windows, we are locking down the case where
 // the enclave was created on Windows as well. LLVM's ld (ld.lld)


### PR DESCRIPTION
The default without -fPIC is 'initial-exec'; with -fPIC is 'global-dynamic'.
Dynamic models are not applicable for enclaves (we don't support multi-module loading),
and therefore are not supported.

The two available models are 'initial-exec' and 'local-exec'.
We choose the most optimal model: 'local-exec'.

Without explicitly choosing the thread-local model, the linker may not always be able to optimize away the "global-exec" (default) threading-model. This could result in enclaves that cannot be loaded.
