### PR TITLE
Fix name of installed script for oe-gdb

### DIFF
--- a/debugger/CMakeLists.txt
+++ b/debugger/CMakeLists.txt
@@ -17,5 +17,6 @@ set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX_BAK})
 # Patch oe-gdb script based on install location.
 configure_file(oe-gdb oe-gdb-for-install)
 
-# Install oe-gdb script upon install-time
-install (PROGRAMS ${CMAKE_BINARY_DIR}/debugger/oe-gdb-for-install DESTINATION ${CMAKE_INSTALL_BINDIR})
+# Install and rename oe-gdb-for-install
+install (PROGRAMS ${CMAKE_BINARY_DIR}/debugger/oe-gdb-for-install DESTINATION ${CMAKE_INSTALL_BINDIR}
+         RENAME oe-gdb)


### PR DESCRIPTION
This is a quick fix so that the installed script is called "oe-gdb" instead of "oe-gdb-for-install".
This fix will allow further testing of the package; but we need a proper fix so that oe-gdb script will work with
make install DESTDIR=path
