### PR TITLE
Filtered out certain error loggings to make logging result less confuing

### DIFF
--- a/common/sgx/qeidentity.c
+++ b/common/sgx/qeidentity.c
@@ -178,7 +178,8 @@ oe_result_t oe_enforce_qe_identity(sgx_report_body_t* qe_report_body)
     result = OE_OK;
 
 done:
-    oe_cert_chain_free(&pck_cert_chain);
+    if (pck_cert_chain.impl[0] != 0)
+        oe_cert_chain_free(&pck_cert_chain);
     return result;
 }
 #endif

--- a/common/sgx/report.c
+++ b/common/sgx/report.c
@@ -133,7 +133,7 @@ static oe_result_t _oe_sgx_get_target_info(
     if (target_info_buffer == NULL || *target_info_size < sizeof(*info))
     {
         *target_info_size = sizeof(*info);
-        OE_RAISE(OE_BUFFER_TOO_SMALL);
+        OE_RAISE_NO_TRACE(OE_BUFFER_TOO_SMALL);
     }
 
     OE_CHECK(oe_memset_s(info, sizeof(*info), 0, sizeof(*info)));
@@ -176,8 +176,12 @@ oe_result_t oe_get_target_info_v1(
     {
         case OE_REPORT_TYPE_SGX_LOCAL:
         case OE_REPORT_TYPE_SGX_REMOTE:
-            OE_CHECK(_oe_sgx_get_target_info(
-                report, report_size, target_info_buffer, target_info_size));
+            result = _oe_sgx_get_target_info(
+                report, report_size, target_info_buffer, target_info_size);
+            if (result == OE_BUFFER_TOO_SMALL)
+                OE_CHECK_NO_TRACE(result);
+            else
+                OE_CHECK(result);
             break;
         default:
             OE_RAISE(OE_INVALID_PARAMETER);

--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -101,7 +101,7 @@ static oe_result_t _oe_get_local_report(
     if (report_buffer == NULL || *report_buffer_size < sizeof(sgx_report_t))
     {
         *report_buffer_size = sizeof(sgx_report_t);
-        OE_RAISE(OE_BUFFER_TOO_SMALL);
+        OE_RAISE_NO_TRACE(OE_BUFFER_TOO_SMALL);
     }
 
     OE_CHECK(sgx_create_report(
@@ -230,7 +230,11 @@ oe_result_t oe_get_remote_report(
     /*
      * OCall: Get the quote for the local report.
      */
-    OE_CHECK(_oe_get_quote(&sgx_report, report_buffer, report_buffer_size));
+    result = _oe_get_quote(&sgx_report, report_buffer, report_buffer_size);
+    if (result == OE_BUFFER_TOO_SMALL)
+        OE_CHECK_NO_TRACE(result);
+    else
+        OE_CHECK(result);
 
     /*
      * Check that the entire report body in the returned quote matches the local
@@ -282,25 +286,29 @@ oe_result_t oe_get_report_v1(
 
     if (flags & OE_REPORT_FLAGS_REMOTE_ATTESTATION)
     {
-        OE_CHECK(oe_get_remote_report(
+        result = oe_get_remote_report(
             report_data,
             report_data_size,
             opt_params,
             opt_params_size,
             report_buffer,
-            report_buffer_size));
+            report_buffer_size);
     }
     else
     {
         // If no flags are specified, default to locally attestable report.
-        OE_CHECK(_oe_get_local_report(
+        result = _oe_get_local_report(
             report_data,
             report_data_size,
             opt_params,
             opt_params_size,
             report_buffer,
-            report_buffer_size));
+            report_buffer_size);
     }
+    if (result == OE_BUFFER_TOO_SMALL)
+        OE_CHECK_NO_TRACE(result);
+    else
+        OE_CHECK(result);
 
     header->version = OE_REPORT_HEADER_VERSION;
     header->report_type = (flags & OE_REPORT_FLAGS_REMOTE_ATTESTATION)

--- a/host/sgx/quote.c
+++ b/host/sgx/quote.c
@@ -203,7 +203,7 @@ oe_result_t sgx_get_quote(
         if (*quote_size < size)
         {
             *quote_size = size;
-            OE_RAISE(OE_BUFFER_TOO_SMALL);
+            OE_CHECK_NO_TRACE(OE_BUFFER_TOO_SMALL);
         }
 
         // Return correct size of the quote.

--- a/samples/data-sealing/common/dispatcher.cpp
+++ b/samples/data-sealing/common/dispatcher.cpp
@@ -201,7 +201,7 @@ int ecall_dispatcher::unseal_data(
     // validate signature
     if (memcmp(signature, m_sealed_data->signature, SIGNATURE_LEN) != 0)
     {
-        TRACE_ENCLAVE("signature validation failed");
+        TRACE_ENCLAVE("signature mismatched");
         ret = ERROR_SIGNATURE_VERIFY_FAIL;
         goto exit;
     }

--- a/samples/data-sealing/host/host.cpp
+++ b/samples/data-sealing/host/host.cpp
@@ -71,8 +71,8 @@ int unseal_data_and_verify_result(
         target_enclave, &ret, sealed_data, sealed_data_size, &data, &data_size);
     if ((result != OE_OK) || (ret != 0))
     {
-        cout << "Host: unseal_data failed with " << oe_result_str(result)
-             << " ret = " << ret << endl;
+        cout << "Host: ecall unseal_data returned " << oe_result_str(result)
+             << " ret = " << ret << (ret ? " (failed)" : "(success)") << endl;
         goto exit;
     }
 
@@ -169,9 +169,10 @@ oe_result_t seal_unseal_by_policy(
     // product
     // For POLICY_PRODUCT: this is expected to succeed. POLICY_PRODUCT sealing
     // policy ensures sealed data could be unsealed by enclaves from the product
-    cout
-        << "\n\nHost: Unseal data in an different enclave from the same product"
-        << endl;
+    cout << "\n\nHost: Unseal data in an different enclave from the same "
+            "product:"
+         << "Seal policy is " << GET_POLICY_NAME(policy) << "--> failure is "
+         << ((policy == POLICY_UNIQUE) ? "expected" : "not expected") << endl;
     ret = unseal_data_and_verify_result(
         enclave_a_v2,
         sealed_data,
@@ -205,7 +206,7 @@ oe_result_t seal_unseal_by_policy(
     // Unsealing the data in an enclave with a different product identity is
     // expected to fail
     cout << "\n\nHost: Unseal data in a different enclave from a diffent "
-            "product: expect to fail"
+            "product: failure is expected"
          << endl;
     ret = unseal_data_and_verify_result(
         enclave_b,


### PR DESCRIPTION
Changes included in this PR:

1.Filtered out OE_BUFFER_TOO_SMALL from the get_quote/get_report related routine's logging call, this is to eliminate the confusion caused by this message on successful call.
2. Skipped call to oe_cert_chain_free() when the input is not a valid key, which removed unnecessary error logging
3. Added a few debug messages to make the output of the data_sealing samples less confusing

With above changes, the logging from running all SDK samples look much more clear
