### PR TITLE
Avoid hard-coded paths in oe-gdb script.

### DIFF
--- a/debugger/CMakeLists.txt
+++ b/debugger/CMakeLists.txt
@@ -4,6 +4,8 @@
 add_subdirectory(ptraceLib)
 add_subdirectory(pythonExtension)
 
-configure_file(oe-gdb ${OE_BINDIR}/oe-gdb)
+# Copy oe-gdb to build/output/bin so that it can be used
+# for debugging enclaves built as part of OE SDK.
+file(COPY oe-gdb DESTINATION ${OE_BINDIR})
 
-install (PROGRAMS ${OE_BINDIR}/oe-gdb DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(PROGRAMS oe-gdb DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/debugger/CMakeLists.txt
+++ b/debugger/CMakeLists.txt
@@ -4,19 +4,6 @@
 add_subdirectory(ptraceLib)
 add_subdirectory(pythonExtension)
 
-
-# During build do an install of debugger to the output folder
-set(CMAKE_INSTALL_PREFIX_BAK ${CMAKE_INSTALL_PREFIX})
-
-set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/output)
 configure_file(oe-gdb ${OE_BINDIR}/oe-gdb)
 
-# Reset variables
-set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX_BAK})
-
-# Patch oe-gdb script based on install location.
-configure_file(oe-gdb oe-gdb-for-install)
-
-# Install and rename oe-gdb-for-install
-install (PROGRAMS ${CMAKE_BINARY_DIR}/debugger/oe-gdb-for-install DESTINATION ${CMAKE_INSTALL_BINDIR}
-         RENAME oe-gdb)
+install (PROGRAMS ${OE_BINDIR}/oe-gdb DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/debugger/oe-gdb
+++ b/debugger/oe-gdb
@@ -4,7 +4,10 @@
 # Licensed under the MIT License.
 
 # Get path of the oe-gdb script
-OE_GDB_DIR=$(dirname "$0")
+# See https://mywiki.wooledge.org/BashFAQ/028 for complexities involved
+# in determining location of a bash script. ${BASH_SOURCE}, though not perfect,
+# is an acceptable solution for oe-gdb.
+OE_GDB_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 # Get the path to the debugger libraries relative to the oe-gdb path.
 # Normalize the path by cd-ing and doing a pwd -P.

--- a/debugger/oe-gdb
+++ b/debugger/oe-gdb
@@ -3,5 +3,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-export PYTHONPATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/openenclave/debugger/gdb-sgx-plugin
-LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/openenclave/debugger/liboe_ptrace.so gdb -iex "directory ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/openenclave/debugger/gdb-sgx-plugin" -iex "source ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/openenclave/debugger/gdb-sgx-plugin/gdb_sgx_plugin.py" -iex "set environment LD_PRELOAD" -iex "add-auto-load-safe-path /usr/lib" "$@"
+# Get path of the oe-gdb script
+OE_GDB_DIR=$(dirname "$0")
+
+# Get the path to the debugger libraries relative to the oe-gdb path.
+# Normalize the path by cd-ing and doing a pwd -P.
+OE_GDB_LIB_DIR=$(cd "$OE_GDB_DIR/../lib/openenclave/debugger" || exit; pwd -P)
+
+OE_GDB_PLUGIN_DIR=$OE_GDB_LIB_DIR/gdb-sgx-plugin
+OE_GDB_PTRACE_PATH=$OE_GDB_LIB_DIR/liboe_ptrace.so
+
+export PYTHONPATH=$OE_GDB_PLUGIN_DIR
+LD_PRELOAD=$OE_GDB_PTRACE_PATH gdb -iex "directory $OE_GDB_PLUGIN_DIR" -iex "source $OE_GDB_PLUGIN_DIR/gdb_sgx_plugin.py" -iex "set environment LD_PRELOAD" -iex "add-auto-load-safe-path /usr/lib" "$@"


### PR DESCRIPTION
oe-gdb uses hard-coded paths to setup plugins for gdb.
These paths are locked during cmake configure time based on
CMAKE_INSTALL_PREFIX value.
With such a scheme,
   make install DESTDIR=install-path
would not work; oe-gdb needs to use install-path; but it has
already been locked to CMAKE_INSTALL_PREFIX.

With this PR, oe-gdb relies on the install directory layout
to access gdb libraries. This will work no matter where OE
is installed.

Addresses #1582