### PR TITLE
Improve oesign CLI arguments parsing

### DIFF
--- a/.check-license.ignore
+++ b/.check-license.ignore
@@ -56,3 +56,5 @@ tests/print/printhost\.stdout
 tests/str/test1\.txt
 tools/oeedger8r/\.merlin
 tools/oeedger8r/main\.ml
+tools/oesign/getopt\.h
+tools/oesign/getopt_long\.c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the Intel SGX DCAP packages on the system that generates the remote report,
   which as of the time of this change is version 1.0.1 and can be found here:
   https://download.01.org/intel-sgx/dcap-1.0.1/dcap_installer/ubuntuServer1604/
+- Revamped `oesign` CLI tool arguments parsing. Instead of relying on the arguments
+  order and name, named parameters are used as such:
+   - The `sign` subcommand accepts the following mandatory flags:
+     - `--enclave-image [-e]`, the enclave image file path
+     - `--config-file [-c]`, the path of the config file with enclave properties
+     - `--key-file [-k]`, the path of the private key file used to digitally sign the enclave image
+   - The `dump` subcommand accepts only the `--enclave-image [-e]` mandatory flag, for the enclave file path.
 
 ### Deprecated
 

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -576,3 +576,34 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 @(#)queue.h	8.5 (Berkeley) 8/20/94
+
+
+License notice for tools/oesign/getopt.h and tools/oesign/getopt_long.c
+--------------------------------
+
+Copyright (c) 2000 The NetBSD Foundation, Inc.
+All rights reserved.
+
+This code is derived from software contributed to The NetBSD Foundation
+by Dieter Baron and Thomas Klausner.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/cmake/add_enclave.cmake
+++ b/cmake/add_enclave.cmake
@@ -87,7 +87,7 @@ function(add_enclave)
   # Sign the enclave using `oesign`.
   if(ENCLAVE_CONFIG)
     add_custom_command(OUTPUT ${SIGNED_LOCATION}
-      COMMAND oesign sign $<TARGET_FILE:${ENCLAVE_TARGET}> ${ENCLAVE_CONFIG} ${ENCLAVE_KEY}
+      COMMAND oesign sign -e $<TARGET_FILE:${ENCLAVE_TARGET}> -c ${ENCLAVE_CONFIG} -k ${ENCLAVE_KEY}
       DEPENDS oesign ${ENCLAVE_TARGET} ${ENCLAVE_CONFIG} ${ENCLAVE_KEY}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   endif()

--- a/cmake/sdk_cmake_targets_readme.md
+++ b/cmake/sdk_cmake_targets_readme.md
@@ -95,7 +95,7 @@ enclave. Example usage is:
 
 ```cmake
 add_custom_command(OUTPUT example_enclave.signed
-  COMMAND openenclave::oesign sign $<TARGET_FILE:example_enclave> ${CMAKE_CURRENT_SOURCE_DIR}/example.conf ${CMAKE_CURRENT_SOURCE_DIR}/key.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:example_enclave> -c ${CMAKE_CURRENT_SOURCE_DIR}/example.conf -k ${CMAKE_CURRENT_SOURCE_DIR}/key.pem)
 ```
 
 Since `oesign` is unaware of CMake information, the

--- a/docs/GettingStartedDocs/buildandsign.md
+++ b/docs/GettingStartedDocs/buildandsign.md
@@ -49,12 +49,12 @@ of the signing process. To do so, you will need to use the oesign tool, which
 takes the following parameters:
 
 ```bash
-Usage: oesign ENCLAVE CONFFILE KEYFILE
+Usage: oesign sign --enclave-image ENCLAVE --config-file CONFFILE --key-file KEYFILE
 ```
 
 For example, to sign the helloworld sample enclave in the output folder:
 ```bash
-/opt/openenclave/bin/oesign helloworld_enc enc.conf private.pem
+/opt/openenclave/bin/oesign sign --enclave-image helloworld_enc --config-file enc.conf --key-file private.pem
 ```
 
 **When signing the enclave, the `KEYFILE` specified must contain a 3072-bit RSA keys

--- a/samples/data-sealing/CMakeLists.txt
+++ b/samples/data-sealing/CMakeLists.txt
@@ -23,12 +23,12 @@ add_custom_command(OUTPUT private_a.pem public_a.pem
 # Sign enclave A v1 with key A
 add_custom_command(OUTPUT enc1/enclave_a_v1.signed
   DEPENDS ${CMAKE_BINARY_DIR}/private_a.pem
-  COMMAND openenclave::oesign sign $<TARGET_FILE:enclave_a_v1> ${CMAKE_SOURCE_DIR}/enc1/data-sealing.conf private_a.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_a_v1> -c ${CMAKE_SOURCE_DIR}/enc1/data-sealing.conf -k private_a.pem)
 
 # Sign enclave A v2 with key A
 add_custom_command(OUTPUT enc2/enclave_a_v2.signed
   DEPENDS ${CMAKE_BINARY_DIR}/private_a.pem
-  COMMAND openenclave::oesign sign $<TARGET_FILE:enclave_a_v2> ${CMAKE_SOURCE_DIR}/enc2/data-sealing.conf private_a.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_a_v2> -c ${CMAKE_SOURCE_DIR}/enc2/data-sealing.conf -k private_a.pem)
 
 # Generate key B
 add_custom_command(OUTPUT private_b.pem public_b.pem
@@ -38,7 +38,7 @@ add_custom_command(OUTPUT private_b.pem public_b.pem
 # Sign enclave B with key B
 add_custom_command(OUTPUT enc3/enclave_b.signed
   DEPENDS ${CMAKE_BINARY_DIR}/private_b.pem
-  COMMAND openenclave::oesign sign $<TARGET_FILE:enclave_b> ${CMAKE_SOURCE_DIR}/enc3/data-sealing.conf private_b.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_b> -c ${CMAKE_SOURCE_DIR}/enc3/data-sealing.conf -k private_b.pem)
 
 add_custom_target(run
   DEPENDS data-sealing_host ${CMAKE_BINARY_DIR}/enc1/enclave_a_v1.signed ${CMAKE_BINARY_DIR}/enc2/enclave_a_v2.signed ${CMAKE_BINARY_DIR}/enc3/enclave_b.signed

--- a/samples/data-sealing/enc1/Makefile
+++ b/samples/data-sealing/enc1/Makefile
@@ -33,7 +33,7 @@ build:
 	$(CXX) -o enclave_a_v1 ecalls.o dispatcher.o keys.o datasealing_t.o $(LDFLAGS)
 
 sign:
-	oesign sign enclave_a_v1 data-sealing.conf private.pem
+	oesign sign -e enclave_a_v1 -c data-sealing.conf -k private.pem
 
 clean:
 	rm -f enclave_a_v1 enclave_a_v1.signed *.o *.pem ../common/datasealing_t.* ../common/datasealing_args.h

--- a/samples/data-sealing/enc2/Makefile
+++ b/samples/data-sealing/enc2/Makefile
@@ -32,7 +32,7 @@ build:
 	$(CXX) -o enclave_a_v2 ecalls.o dispatcher.o keys.o datasealing_t.o $(LDFLAGS)
 
 sign:
-	oesign sign enclave_a_v2 data-sealing.conf private.pem
+	oesign sign -e enclave_a_v2 -c data-sealing.conf -k private.pem
 
 clean:
 	rm -f enclave_a_v2 enclave_a_v2.signed *.o *.pem

--- a/samples/data-sealing/enc3/Makefile
+++ b/samples/data-sealing/enc3/Makefile
@@ -32,7 +32,7 @@ build:
 	$(CXX) -o enclave_b ecalls.o dispatcher.o keys.o datasealing_t.o $(LDFLAGS)
 
 sign:
-	oesign sign enclave_b data-sealing.conf private.pem
+	oesign sign -e enclave_b -c data-sealing.conf -k private.pem
 
 clean:
 	rm -f enclave_b enclave_b.signed *.o *.pem

--- a/samples/file-encryptor/CMakeLists.txt
+++ b/samples/file-encryptor/CMakeLists.txt
@@ -20,7 +20,7 @@ add_custom_command(OUTPUT private.pem public.pem
 # Sign enclave
 add_custom_command(OUTPUT enc/enclave.signed
   DEPENDS ${CMAKE_BINARY_DIR}/private.pem
-  COMMAND openenclave::oesign sign $<TARGET_FILE:enclave> ${CMAKE_SOURCE_DIR}/enc/file-encryptor.conf private.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave> -c ${CMAKE_SOURCE_DIR}/enc/file-encryptor.conf -k private.pem)
 
 if ((NOT DEFINED ENV{OE_SIMULATION}) OR (NOT $ENV{OE_SIMULATION}))
   add_custom_target(run

--- a/samples/file-encryptor/enc/Makefile
+++ b/samples/file-encryptor/enc/Makefile
@@ -33,7 +33,7 @@ build:
 	$(CXX) -o file-encryptorenc ecalls.o encryptor.o keys.o fileencryptor_t.o $(LDFLAGS)
 
 sign:
-	oesign sign file-encryptorenc file-encryptor.conf private.pem
+	oesign sign -e file-encryptorenc -c file-encryptor.conf -k private.pem
 
 clean:
 	rm -f file-encryptorenc file-encryptorenc.signed *.o fileencryptor_t.* fileencryptor_args.h private.pem public.pem

--- a/samples/helloworld/CMakeLists.txt
+++ b/samples/helloworld/CMakeLists.txt
@@ -20,7 +20,7 @@ add_custom_command(OUTPUT private.pem public.pem
 # Sign enclave
 add_custom_command(OUTPUT enc/enclave.signed
   DEPENDS ${CMAKE_BINARY_DIR}/private.pem
-  COMMAND openenclave::oesign sign $<TARGET_FILE:enclave> ${CMAKE_SOURCE_DIR}/enc/helloworld.conf private.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave> -c ${CMAKE_SOURCE_DIR}/enc/helloworld.conf -k private.pem)
 
 if ((NOT DEFINED ENV{OE_SIMULATION}) OR (NOT $ENV{OE_SIMULATION}))
   add_custom_target(run

--- a/samples/helloworld/README.md
+++ b/samples/helloworld/README.md
@@ -254,7 +254,7 @@ build:
 	$(CC) -o helloworldenc helloworld_t.o enc.o $(LDFLAGS)
 
 sign:
-	oesign helloworldenc helloworld.conf private.pem
+	oesign -e helloworldenc -c helloworld.conf -k private.pem
 
 clean:
 	rm -f enc.o helloworldenc helloworldenc.signed private.pem ...

--- a/samples/helloworld/enc/Makefile
+++ b/samples/helloworld/enc/Makefile
@@ -30,7 +30,7 @@ build:
 	$(CC) -o helloworldenc helloworld_t.o enc.o $(LDFLAGS)
 
 sign:
-	oesign sign helloworldenc helloworld.conf private.pem
+	oesign sign -e helloworldenc -c helloworld.conf -k private.pem
 
 clean:
 	rm -f enc.o helloworldenc helloworldenc.signed private.pem public.pem helloworld_t.o helloworld_t.h helloworld_t.c helloworld_args.h

--- a/samples/local_attestation/enc1/CMakeLists.txt
+++ b/samples/local_attestation/enc1/CMakeLists.txt
@@ -22,6 +22,6 @@ add_custom_target(public_key_a DEPENDS public_a.pem)
 # Sign enclave A with key A
 add_custom_command(OUTPUT enclave_a.signed
   DEPENDS private_a.pem
-  COMMAND openenclave::oesign sign $<TARGET_FILE:enclave_a> ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf private_a.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_a> -c ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf -k private_a.pem)
 
 add_custom_target(enclave_a_signed DEPENDS enclave_a.signed)

--- a/samples/local_attestation/enc1/Makefile
+++ b/samples/local_attestation/enc1/Makefile
@@ -51,7 +51,7 @@ build:
 	$(CXX) -o enclave1 attestation.o crypto.o ecalls.o dispatcher.o localattestation_t.o $(LDFLAGS)
 
 sign:
-	oesign sign enclave1 enc.conf private.pem
+	oesign sign -e enclave1 -c enc.conf -k private.pem
 
 clean:
 	rm -f *.o enclave1 enclave1.signed ../common/localattestation_t.* ../common/localattestation_args.h *.pem enc2_pubkey.h

--- a/samples/local_attestation/enc2/CMakeLists.txt
+++ b/samples/local_attestation/enc2/CMakeLists.txt
@@ -22,6 +22,6 @@ add_custom_target(public_key_b DEPENDS public_b.pem)
 # Sign enclave B with key B
 add_custom_command(OUTPUT enclave_b.signed
   DEPENDS private_b.pem
-  COMMAND openenclave::oesign sign $<TARGET_FILE:enclave_b> ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf private_b.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_b> -c ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf -k private_b.pem)
 
 add_custom_target(enclave_b_signed DEPENDS enclave_b.signed)

--- a/samples/local_attestation/enc2/Makefile
+++ b/samples/local_attestation/enc2/Makefile
@@ -51,7 +51,7 @@ build:
 	$(CXX) -o enclave2 attestation.o crypto.o ecalls.o dispatcher.o localattestation_t.o $(LDFLAGS)
 
 sign:
-	oesign sign enclave2 enc.conf private.pem
+	oesign sign -e enclave2 -c enc.conf -k private.pem
 
 clean:
 	rm -f *.o enclave2 enclave2.signed ../common/localattestation_t.* ../common/remoteattestation_args.h *.pem enc1_pubkey.h

--- a/samples/remote_attestation/enc1/CMakeLists.txt
+++ b/samples/remote_attestation/enc1/CMakeLists.txt
@@ -22,6 +22,6 @@ add_custom_target(public_key_a DEPENDS public_a.pem)
 # Sign enclave A with key A
 add_custom_command(OUTPUT enclave_a.signed
   DEPENDS private_a.pem
-  COMMAND openenclave::oesign sign $<TARGET_FILE:enclave_a> ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf private_a.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_a> -c ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf -k private_a.pem)
 
 add_custom_target(enclave_a_signed DEPENDS enclave_a.signed)

--- a/samples/remote_attestation/enc1/Makefile
+++ b/samples/remote_attestation/enc1/Makefile
@@ -51,7 +51,7 @@ build:
 	$(CXX) -o enclave1 attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS)
 
 sign:
-	oesign sign enclave1 enc.conf private.pem
+	oesign sign -e enclave1 -c enc.conf -k private.pem
 
 clean:
 	rm -f *.o enclave1 enclave1.signed ../common/remoteattestation_t.* ../common/remoteattestation_args.h *.pem enc2_pubkey.h

--- a/samples/remote_attestation/enc2/CMakeLists.txt
+++ b/samples/remote_attestation/enc2/CMakeLists.txt
@@ -22,6 +22,6 @@ add_custom_target(public_key_b DEPENDS public_b.pem)
 # Sign enclave B with key B
 add_custom_command(OUTPUT enclave_b.signed
   DEPENDS private_b.pem
-  COMMAND openenclave::oesign sign $<TARGET_FILE:enclave_b> ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf private_b.pem)
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_b> -c ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf -k private_b.pem)
 
 add_custom_target(enclave_b_signed DEPENDS enclave_b.signed)

--- a/samples/remote_attestation/enc2/Makefile
+++ b/samples/remote_attestation/enc2/Makefile
@@ -50,7 +50,7 @@ build:
 	$(CXX) -o enclave2 attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS) 
 
 sign:
-	oesign sign enclave2 enc.conf private.pem
+	oesign sign -e enclave2 -c enc.conf -k private.pem
 
 clean:
 	rm -f *.o enclave2 enclave2.signed remoteattestation_t.* *.pem enc1_pubkey.h

--- a/tools/oesign/CMakeLists.txt
+++ b/tools/oesign/CMakeLists.txt
@@ -1,7 +1,21 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_executable(oesign main.c oedump.c)
+include(CheckSymbolExists)
+
+list(APPEND SOURCES main.c oedump.c)
+
+CHECK_SYMBOL_EXISTS(getopt_long getopt.h HAVE_GETOPT_LONG)
+
+if (NOT HAVE_GETOPT_LONG)
+  list (APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/getopt_long.c)
+endif()
+
+add_executable(oesign ${SOURCES})
+
+if (NOT HAVE_GETOPT_LONG)
+  target_include_directories(oesign PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 target_link_libraries(oesign oehost)
 

--- a/tools/oesign/getopt.h
+++ b/tools/oesign/getopt.h
@@ -1,0 +1,60 @@
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _GETOPT_H_
+#define _GETOPT_H_
+
+extern char* optarg;
+extern int optind, opterr, optopt;
+
+/*
+ * Gnu like getopt_long() and BSD4.4 getsubopt() / optreset extensions
+ */
+#define no_argument 0
+#define required_argument 1
+#define optional_argument 2
+
+struct option
+{
+    /* name of long option */
+    const char* name;
+    /*
+     * one of no_argument, required_argument, and optional_argument:
+     * whether option takes an argument
+     */
+    int has_arg;
+    /* if not NULL, set *flag to val when option found */
+    int* flag;
+    /* if flag not NULL, value to set *flag to; else return value */
+    int val;
+};
+
+int getopt_long(int, char* const*, const char*, const struct option*, int*);
+
+#endif /* !_GETOPT_H_ */

--- a/tools/oesign/getopt_long.c
+++ b/tools/oesign/getopt_long.c
@@ -1,0 +1,536 @@
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "getopt.h"
+
+int opterr = 1;   /* if error message should be printed */
+int optind = 1;   /* index into parent argv vector */
+int optopt = '?'; /* character checked for validity */
+int optreset;     /* reset getopt */
+char* optarg;     /* argument associated with option */
+
+#define BUILD_ASSERT_TYPE(POINTER, TYPE) \
+    ((void)sizeof((int)((POINTER) == (TYPE)(POINTER))))
+#define CONST_CAST(TYPE, POINTER) \
+    (BUILD_ASSERT_TYPE(POINTER, TYPE), (TYPE)(POINTER))
+#define IGNORE_FIRST (*options == '-' || *options == '+')
+#define PRINT_ERROR \
+    ((opterr) && ((*options != ':') || (IGNORE_FIRST && options[1] != ':')))
+#define IS_POSIXLY_CORRECT (getenv("POSIXLY_CORRECT") != NULL)
+#define PERMUTE (!IS_POSIXLY_CORRECT && !IGNORE_FIRST)
+
+#define IN_ORDER (!IS_POSIXLY_CORRECT && *options == '-')
+
+/* return values */
+#define BADCH (int)'?'
+#define BADARG                                                           \
+    ((IGNORE_FIRST && options[1] == ':') || (*options == ':') ? (int)':' \
+                                                              : (int)'?')
+#define INORDER (int)1
+#define EMSG ""
+#define _DIAGASSERT(q) assert(q)
+
+static int getopt_internal(int, char**, const char*);
+static int gcd(int, int);
+static void permute_args(int, int, int, char**);
+
+static const char* place = EMSG; /* option letter processing */
+
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+static FILE* err_file; /* file to use for error output */
+
+/*
+  This is declared to take a `void ' so that the caller is not required
+  to include <stdio.h> first.  However, it is really a `FILE ', and the
+ * manual page documents it as such.
+ */
+void err_set_file(void* fp)
+{
+    if (fp)
+        err_file = fp;
+    else
+        err_file = stderr;
+}
+
+void vwarnx(const char* fmt, va_list ap)
+{
+    if (fmt != NULL)
+    {
+        if (err_file == 0)
+            err_set_file((FILE*)0);
+        fprintf(err_file, "getopt_long: ");
+        vfprintf(err_file, fmt, ap);
+        fprintf(err_file, "\n");
+    }
+}
+
+void warnx(const char* fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vwarnx(fmt, ap);
+    va_end(ap);
+}
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int gcd(int a, int b)
+{
+    int c;
+
+    c = a % b;
+    while (c != 0)
+    {
+        a = b;
+        b = c;
+        c = a % b;
+    }
+
+    return b;
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void permute_args(
+    int panonopt_start,
+    int panonopt_end,
+    int opt_end,
+    char** nargv)
+{
+    int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+    char* swap;
+
+    _DIAGASSERT(nargv != NULL);
+
+    /*
+     * compute lengths of blocks and number and size of cycles
+     */
+    nnonopts = panonopt_end - panonopt_start;
+    nopts = opt_end - panonopt_end;
+    ncycle = gcd(nnonopts, nopts);
+    cyclelen = (opt_end - panonopt_start) / ncycle;
+
+    for (i = 0; i < ncycle; i++)
+    {
+        cstart = panonopt_end + i;
+        pos = cstart;
+        for (j = 0; j < cyclelen; j++)
+        {
+            if (pos >= panonopt_end)
+                pos -= nnonopts;
+            else
+                pos += nopts;
+            swap = nargv[pos];
+            nargv[pos] = nargv[cstart];
+            nargv[cstart] = swap;
+        }
+    }
+}
+
+/*
+ * getopt_internal --
+ *  Parse argc/argv argument vector.  Called by user level routines.
+ *  Returns -2 if -- is found (can be long option or end of options marker).
+ */
+static int getopt_internal(int nargc, char** nargv, const char* options)
+{
+    char* oli; /* option letter list index */
+    int optchar;
+
+    _DIAGASSERT(nargv != NULL);
+    _DIAGASSERT(options != NULL);
+
+    optarg = NULL;
+
+    if (optind == 0)
+        optind = 1;
+
+    if (optreset)
+        nonopt_start = nonopt_end = -1;
+start:
+    if (optreset || !*place)
+    {
+        /* update scanning pointer */
+        optreset = 0;
+        if (optind >= nargc)
+        {
+            /* end of argument vector */
+            place = EMSG;
+            if (nonopt_end != -1)
+            {
+                /* do permutation, if we have to */
+                permute_args(nonopt_start, nonopt_end, optind, nargv);
+                optind -= nonopt_end - nonopt_start;
+            }
+            else if (nonopt_start != -1)
+            {
+                /*
+                 * If we skipped non-options, set optind
+                 * to the first of them.
+                 */
+                optind = nonopt_start;
+            }
+            nonopt_start = nonopt_end = -1;
+            return -1;
+        }
+        if ((*(place = nargv[optind]) != '-') || (place[1] == '\0'))
+        {
+            /* found non-option */
+            place = EMSG;
+            if (IN_ORDER)
+            {
+                /*
+                 * GNU extension:
+                 * return non-option as argument to option 1
+                 */
+                optarg = nargv[optind++];
+                return INORDER;
+            }
+            if (!PERMUTE)
+            {
+                /*
+                 * if no permutation wanted, stop parsing
+                 * at first non-option
+                 */
+                return -1;
+            }
+            /* do permutation */
+            if (nonopt_start == -1)
+                nonopt_start = optind;
+            else if (nonopt_end != -1)
+            {
+                permute_args(nonopt_start, nonopt_end, optind, nargv);
+                nonopt_start = optind - (nonopt_end - nonopt_start);
+                nonopt_end = -1;
+            }
+            optind++;
+            /* process next argument */
+            goto start;
+        }
+        if (nonopt_start != -1 && nonopt_end == -1)
+            nonopt_end = optind;
+        if (place[1] && *++place == '-')
+        {
+            /* found "--" */
+            place++;
+            return -2;
+        }
+    }
+    if ((optchar = (int)*place++) == (int)':' ||
+        (oli = strchr(options + (IGNORE_FIRST ? 1 : 0), optchar)) == NULL)
+    {
+        /* option letter unknown or ':' */
+        if (!*place)
+            ++optind;
+        if (PRINT_ERROR)
+            warnx(illoptchar, optchar);
+        optopt = optchar;
+        return BADCH;
+    }
+    if (optchar == 'W' && oli[1] == ';')
+    {
+        /* -W long-option */
+        if (*place)
+            return -2;
+
+        if (++optind >= nargc)
+        {
+            /* no arg */
+            place = EMSG;
+            if (PRINT_ERROR)
+                warnx(recargchar, optchar);
+            optopt = optchar;
+            return BADARG;
+        }
+        else
+        {
+            /* white space */
+            place = nargv[optind];
+        }
+        /*
+         * Handle -W arg the same as --arg (which causes getopt to
+         * stop parsing).
+         */
+        return -2;
+    }
+    if (*++oli != ':')
+    {
+        /* doesn't take argument */
+        if (!*place)
+            ++optind;
+    }
+    else
+    {
+        /* takes (optional) argument */
+        optarg = NULL;
+        if (*place)
+            /* no white space */
+            optarg = CONST_CAST(char*, place);
+        else if (oli[1] != ':')
+        {
+            /* arg not optional */
+            if (++optind >= nargc)
+            {
+                /* no arg */
+                place = EMSG;
+                if (PRINT_ERROR)
+                    warnx(recargchar, optchar);
+                optopt = optchar;
+                return BADARG;
+            }
+            else
+            {
+                optarg = nargv[optind];
+            }
+        }
+        place = EMSG;
+        ++optind;
+    }
+    /* dump back option letter */
+    return optchar;
+}
+
+#ifdef REPLACE_GETOPT
+/*
+ * getopt --
+ *  Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the real getopt]
+ */
+int getopt(nargc, nargv, options) int nargc;
+char* const* nargv;
+const char* options;
+{
+    int retval;
+
+    _DIAGASSERT(nargv != NULL);
+    _DIAGASSERT(options != NULL);
+
+    retval = getopt_internal(nargc, CONST_CAST(char**, nargv), options);
+    if (retval == -2)
+    {
+        ++optind;
+        /*
+         * We found an option (--), so if we skipped non-options,
+         * we have to permute.
+         */
+        if (nonopt_end != -1)
+        {
+            permute_args(nonopt_start, nonopt_end, optind, nargv);
+            optind -= nonopt_end - nonopt_start;
+        }
+        nonopt_start = nonopt_end = -1;
+        retval = -1;
+    }
+    return retval;
+}
+#endif
+
+/*
+ * getopt_long --
+ *  Parse argc/argv argument vector.
+ */
+int getopt_long(
+    int nargc,
+    char* const* nargv,
+    const char* options,
+    const struct option* long_options,
+    int* idx)
+{
+    int retval;
+
+#define IDENTICAL_INTERPRETATION(_x, _y)                         \
+    (long_options[(_x)].has_arg == long_options[(_y)].has_arg && \
+     long_options[(_x)].flag == long_options[(_y)].flag &&       \
+     long_options[(_x)].val == long_options[(_y)].val)
+
+    _DIAGASSERT(nargv != NULL);
+    _DIAGASSERT(options != NULL);
+    _DIAGASSERT(long_options != NULL);
+    /* idx may be NULL */
+
+    retval = getopt_internal(nargc, CONST_CAST(char**, nargv), options);
+    if (retval == -2)
+    {
+        char *current_argv, *has_equal;
+        size_t current_argv_len;
+        int i, ambiguous, match;
+
+        current_argv = CONST_CAST(char*, place);
+        match = -1;
+        ambiguous = 0;
+
+        optind++;
+        place = EMSG;
+
+        if (*current_argv == '\0')
+        {
+            /*
+             * We found an option (--), so if we skipped
+             * non-options, we have to permute.
+             */
+            if (nonopt_end != -1)
+            {
+                permute_args(
+                    nonopt_start,
+                    nonopt_end,
+                    optind,
+                    CONST_CAST(char**, nargv));
+                optind -= nonopt_end - nonopt_start;
+            }
+            nonopt_start = nonopt_end = -1;
+            return -1;
+        }
+        if ((has_equal = strchr(current_argv, '=')) != NULL)
+        {
+            /* argument found (--option=arg) */
+            current_argv_len = (size_t)(has_equal - current_argv);
+            has_equal++;
+        }
+        else
+        {
+            current_argv_len = strlen(current_argv);
+        }
+
+        for (i = 0; long_options[i].name; i++)
+        {
+            /* find matching long option */
+            if (strncmp(current_argv, long_options[i].name, current_argv_len))
+                continue;
+
+            if (strlen(long_options[i].name) == (unsigned)current_argv_len)
+            {
+                /* exact match */
+                match = i;
+                ambiguous = 0;
+                break;
+            }
+            if (match == -1)
+            {
+                /* partial match */
+                match = i;
+            }
+            else if (!IDENTICAL_INTERPRETATION(i, match))
+                ambiguous = 1;
+        }
+        if (ambiguous)
+        {
+            /* ambiguous abbreviation */
+            if (PRINT_ERROR)
+                warnx(ambig, (int)current_argv_len, current_argv);
+            optopt = 0;
+            return BADCH;
+        }
+        if (match != -1)
+        {
+            /* option found */
+            if (long_options[match].has_arg == no_argument && has_equal)
+            {
+                if (PRINT_ERROR)
+                    warnx(noarg, (int)current_argv_len, current_argv);
+                if (long_options[match].flag == NULL)
+                    optopt = long_options[match].val;
+                else
+                    optopt = 0;
+                return BADARG;
+            }
+            if (long_options[match].has_arg == required_argument ||
+                long_options[match].has_arg == optional_argument)
+            {
+                if (has_equal)
+                    optarg = has_equal;
+                else if (long_options[match].has_arg == required_argument)
+                {
+                    /*
+                     * optional argument doesn't use
+                     * next nargv
+                     */
+                    optarg = nargv[optind++];
+                }
+            }
+            if ((long_options[match].has_arg == required_argument) &&
+                (optarg == NULL))
+            {
+                /*
+                 * Missing argument; leading ':'
+                 * indicates no error should be generated
+                 */
+                if (PRINT_ERROR)
+                    warnx(recargstring, current_argv);
+                if (long_options[match].flag == NULL)
+                    optopt = long_options[match].val;
+                else
+                    optopt = 0;
+                --optind;
+                return BADARG;
+            }
+        }
+        else
+        {
+            /* unknown option */
+            if (PRINT_ERROR)
+                warnx(illoptstring, current_argv);
+            optopt = 0;
+            return BADCH;
+        }
+        if (long_options[match].flag)
+        {
+            *long_options[match].flag = long_options[match].val;
+            retval = 0;
+        }
+        else
+        {
+            retval = long_options[match].val;
+        }
+        if (idx)
+            *idx = match;
+    }
+    return retval;
+#undef IDENTICAL_INTERPRETATION
+}

--- a/tools/oesign/main.c
+++ b/tools/oesign/main.c
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <getopt.h>
 #include <openenclave/internal/elf.h>
 #include <openenclave/internal/mem.h>
 #include <openenclave/internal/properties.h>
@@ -9,6 +10,7 @@
 #include <openenclave/internal/sgxsign.h>
 #include <openenclave/internal/str.h>
 #include <stdarg.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include "../host/sgx/enclave.h"
 
@@ -19,7 +21,7 @@ int oesign(const char*, const char*, const char*);
 OE_PRINTF_FORMAT(1, 2)
 void Err(const char* format, ...)
 {
-    fprintf(stderr, "%s: ", arg0);
+    fprintf(stderr, "%s ERROR: ", arg0);
 
     va_list ap;
     va_start(ap, format);
@@ -461,10 +463,11 @@ static const char _usage_gen[] =
     "    dump  -  Print out the Open Enclave metadata for the specified "
     "enclave.\n"
     "\n"
-    "For help with a specific command, enter \"%s <command> -?\"\n";
+    "For help with a specific command, enter \"%s <command> --help\"\n";
 
 static const char _usage_sign[] =
-    "Usage: %s sign enclave_image config_file key_file\n"
+    "Usage: %s sign --enclave-image [-e] enclave_image "
+    "--config-file [-c] config_file --key-file [-k] key_file\n"
     "\n"
     "Where:\n"
     "    enclave_image -- path of an enclave image file\n"
@@ -506,7 +509,7 @@ static const char _usage_sign[] =
 
 static const char _usage_dump[] =
     "\n"
-    "Usage: %s dump enclave_image\n"
+    "Usage: %s dump --enclave-image [-e] enclave_image\n"
     "\n"
     "Where:\n"
     "    enclave_image -- path of an enclave image file\n"
@@ -631,124 +634,135 @@ done:
     return ret;
 }
 
-int dump_parser(const char* argv[])
+int dump_parser(int argc, const char* argv[])
 {
-    int ret = 1;
-    const char* enclave;
+    int ret = 0;
+    const char* enclave = NULL;
 
-    if (strcmp(argv[2], "-?") == 0)
+    const struct option long_options[] = {
+        {"help", no_argument, NULL, 'h'},
+        {"enclave-image", required_argument, NULL, 'e'},
+        {NULL, 0, NULL, 0},
+    };
+    const char short_options[] = "he:";
+
+    int c;
+    do
     {
-        fprintf(stderr, _usage_dump, argv[0]);
-        exit(1);
-    }
-    else
+        c = getopt_long(
+            argc, (char* const*)argv, short_options, long_options, NULL);
+        if (c == -1)
+        {
+            // all the command-line options are parsed
+            break;
+        }
+
+        switch (c)
+        {
+            case 'h':
+                fprintf(stderr, _usage_dump, argv[0]);
+                goto done;
+            case 'e':
+                enclave = optarg;
+                break;
+            case ':':
+                // Missing option argument
+                ret = 1;
+                goto done;
+            case '?':
+            default:
+                // Invalid option
+                ret = 1;
+                goto done;
+        }
+    } while (1);
+
+    if (enclave == NULL)
     {
-        if (strstr(argv[2], "_enc") != NULL)
-        {
-            enclave = argv[2];
-            /* dump oeinfo and signature information */
-            ret = oedump(enclave);
-        }
-        else
-        {
-            fprintf(stderr, _usage_gen, argv[0], argv[0]);
-            exit(1);
-        }
+        Err("Enclave image flag is missing");
+        ret = 1;
     }
+    if (!ret)
+        /* dump oeinfo and signature information */
+        ret = oedump(enclave);
+
+done:
 
     return ret;
 }
 
 int sign_parser(int argc, const char* argv[])
 {
-    int ret = 1;
-    const char* enclave;
-    const char* conffile;
-    const char* keyfile;
+    int ret = 0;
+    const char* enclave = NULL;
+    const char* conffile = NULL;
+    const char* keyfile = NULL;
 
-    if (strcmp(argv[2], "-?") == 0)
-    {
-        fprintf(stderr, _usage_sign, argv[0]);
-        exit(1);
-    }
-    else if (argc == 5)
-    {
-        if (strstr(argv[2], "enc") != NULL)
-        {
-            enclave = argv[2];
-            if (strstr(argv[3], "conf") != NULL)
-            {
-                /* Collect arguments for signing*/
-                conffile = argv[3];
-                keyfile = argv[4];
-            }
-            else if (strstr(argv[3], "pem") != NULL)
-            {
-                /* Collect arguments for signing*/
-                keyfile = argv[3];
-                conffile = argv[4];
-            }
-            else
-            {
-                fprintf(stderr, _usage_gen, argv[0], argv[0]);
-                exit(1);
-            }
-        }
-        else if (strstr(argv[3], "enc") != NULL)
-        {
-            enclave = argv[3];
-            if (strstr(argv[2], "conf") != NULL)
-            {
-                /* Collect arguments for signing*/
-                conffile = argv[2];
-                keyfile = argv[4];
-            }
-            else if (strstr(argv[2], "pem") != NULL)
-            {
-                /* Collect arguments for signing*/
-                keyfile = argv[2];
-                conffile = argv[4];
-            }
-            else
-            {
-                fprintf(stderr, _usage_gen, argv[0], argv[0]);
-                exit(1);
-            }
-        }
-        else if (strstr(argv[4], "enc") != NULL)
-        {
-            enclave = argv[4];
-            if (strstr(argv[2], "conf") != NULL)
-            {
-                /* Collect arguments for signing*/
-                conffile = argv[2];
-                keyfile = argv[3];
-            }
-            else if (strstr(argv[2], "pem") != NULL)
-            {
-                /* Collect arguments for signing*/
-                keyfile = argv[2];
-                conffile = argv[3];
-            }
-            else
-            {
-                fprintf(stderr, _usage_gen, argv[0], argv[0]);
-                exit(1);
-            }
-        }
-        else
-        {
-            fprintf(stderr, _usage_gen, argv[0], argv[0]);
-            exit(1);
-        }
-    }
-    else
-    {
-        fprintf(stderr, _usage_gen, argv[0], argv[0]);
-        exit(1);
-    }
+    const struct option long_options[] = {
+        {"help", no_argument, NULL, 'h'},
+        {"enclave-image", required_argument, NULL, 'e'},
+        {"config-file", required_argument, NULL, 'c'},
+        {"key-file", required_argument, NULL, 'k'},
+        {NULL, 0, NULL, 0},
+    };
+    const char short_options[] = "he:c:k:";
 
-    ret = oesign(enclave, conffile, keyfile);
+    int c;
+    do
+    {
+        c = getopt_long(
+            argc, (char* const*)argv, short_options, long_options, NULL);
+        if (c == -1)
+        {
+            // all the command-line options are parsed
+            break;
+        }
+
+        switch (c)
+        {
+            case 'h':
+                fprintf(stderr, _usage_sign, argv[0]);
+                goto done;
+            case 'e':
+                enclave = optarg;
+                break;
+            case 'c':
+                conffile = optarg;
+                break;
+            case 'k':
+                keyfile = optarg;
+                break;
+            case ':':
+                // Missing option argument
+                ret = 1;
+                goto done;
+            case '?':
+            default:
+                // Invalid option
+                ret = 1;
+                goto done;
+        }
+    } while (1);
+
+    if (enclave == NULL)
+    {
+        Err("Enclave image flag is missing");
+        ret = 1;
+    }
+    if (conffile == NULL)
+    {
+        Err("Config file flag is missing");
+        ret = 1;
+    }
+    if (keyfile == NULL)
+    {
+        Err("Key file flag is missing");
+        ret = 1;
+    }
+    if (!ret)
+        ret = oesign(enclave, conffile, keyfile);
+
+done:
 
     return ret;
 }
@@ -757,7 +771,7 @@ int arg_handler(int argc, const char* argv[])
 {
     int ret = 1;
     if ((strcmp(argv[1], "dump") == 0))
-        ret = dump_parser(argv);
+        ret = dump_parser(argc, argv);
     else if ((strcmp(argv[1], "sign") == 0))
         ret = sign_parser(argc, argv);
     else


### PR DESCRIPTION
* Add `getopt_long` Windows implementation.
* Improve the `oesign` CLI arguments parsing using `getopt_long`.

  Instead of relying on the arguments order and name, the following mandatory flags are added to the `sign` subcommand:

  * `--enclave-image [-e]`, the enclave image file path.
  * `--config-file [-c]`, the path of the config file with enclave properties.
  * `--key-file [-k]`, the path of the private key file used to digitally sign the enclave image.
&nbsp;

  The `dump` subcommand has been updated as well, and it accepts only the `--enclave-image [-e]` mandatory flag.

  The samples and documentation have been updated for the latest `oesign` changes.

Fixes https://github.com/Microsoft/openenclave/issues/1351
Fixes https://github.com/Microsoft/openenclave/issues/1612