### PR TITLE
Build OE libraries with more secure flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename `oe-gdb` to `oegdb` for consistency with other tools, such as `oesign`.
+- Update pkg-config and CMake exports to include the following hardening build
+  flags by default:
+    - Enclaves will:
+       - Compile with `-fPIE` instead of `-fPIC`.
+       - Link with `-Wl,-z,noexecstack`, `-Wl,-z,now`.
+    - Host apps will:
+       - Compile with `-D_FORTIFY_SOURCE=2` (only effective if compiling under
+         GCC with `-O2` specified) and `-fstack-protector-strong`.
+       - Link with `-Wl,-z,noexecstack`.
+       - Note that `-Wl,-z,now` is _not_ enabled by default, but app authors
+         should enable it themselves after assessing its startup impact.
 
 [v0.5.0] - 2019-4-9
 -------------------

--- a/common/oe_host_string.h
+++ b/common/oe_host_string.h
@@ -49,9 +49,11 @@ int oe_strerror_r(int errnum, char* buf, size_t buflen)
 {
 #if defined(__GNUC__)
     /* GNUC version of strerror_r returns char* instead
-     * caller is responsible for validating the output buf
+     * caller is responsible for validating the output buf.
+     * It should never return NULL.
      */
-    strerror_r(errnum, buf, buflen);
+    if (!strerror_r(errnum, buf, buflen))
+        return -1;
     return 0;
 #else
     return strerror_r(errnum, buf, buflen);

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -173,7 +173,9 @@ endif()
 # Interface link flags for enclaves.
 target_link_libraries(oecore INTERFACE
     -nostdlib -nodefaultlibs -nostartfiles
-    -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id)
+    -Wl,--no-undefined,-Bstatic,-Bsymbolic,--export-dynamic,-pie,--build-id
+    -Wl,-z,noexecstack
+    -Wl,-z,now)
 
 set_property(TARGET oecore PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${OE_LIBDIR}/openenclave/enclave)
 install (TARGETS oecore EXPORT openenclave-targets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/openenclave/enclave)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -171,9 +171,12 @@ if (USE_DEBUG_MALLOC)
 endif ()
 
 if (UNIX)
-  target_compile_options(oehost PRIVATE
-    -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS})
-  target_compile_definitions(oehost PRIVATE _GNU_SOURCE)
+  target_compile_options(oehost
+     PRIVATE -Wno-attributes -Wmissing-prototypes -fPIC ${PLATFORM_FLAGS}
+     PUBLIC -fstack-protector-strong)
+  target_compile_definitions(oehost
+     PRIVATE _GNU_SOURCE
+     PUBLIC _FORTIFY_SOURCE=2)
 endif ()
 
 if (CMAKE_C_COMPILER_ID MATCHES GNU)
@@ -191,7 +194,9 @@ add_library(oehostapp INTERFACE)
 target_link_libraries(oehostapp INTERFACE oehost)
 
 if (UNIX)
-  target_link_libraries(oehostapp INTERFACE -rdynamic)
+  target_link_libraries(oehostapp INTERFACE
+      -rdynamic
+      -Wl,-z,noexecstack)
 endif ()
 
 # Install targets

--- a/pkgconfig/CMakeLists.txt
+++ b/pkgconfig/CMakeLists.txt
@@ -50,6 +50,8 @@ set(ENCLAVE_CLIBS_1
   -Wl,--export-dynamic
   -Wl,-pie
   -Wl,--build-id
+  -Wl,-z,noexecstack
+  -Wl,-z,now
   -L\${libdir}/openenclave/enclave
   -loeenclave
   -lmbedx509
@@ -71,11 +73,13 @@ list(JOIN ENCLAVE_CXXLIBS_LIST " " ENCLAVE_CXXLIBS)
 
 set(HOST_INCLUDES "-I\${includedir}")
 
-list(JOIN SPECTRE_MITIGATION_FLAGS " " HOST_CFLAGS_CLANG)
+set(HOST_CFLAGS_CLANG_LIST -fstack-protector-strong ${SPECTRE_MITIGATION_FLAGS})
+list(JOIN HOST_CFLAGS_CLANG_LIST " " HOST_CFLAGS_CLANG)
 
 set(HOST_CXXFLAGS_CLANG ${HOST_CFLAGS_CLANG})
 
-set(HOST_CFLAGS_GCC "")
+set(HOST_CFLAGS_GCC_LIST -fstack-protector-strong -D_FORTIFY_SOURCE=2)
+list(JOIN HOST_CFLAGS_GCC_LIST " " HOST_CFLAGS_GCC)
 
 set(HOST_CXXFLAGS_GCC ${HOST_CFLAGS_GCC})
 
@@ -91,7 +95,7 @@ else()
     set(SGX_LIBS "")
 endif()
 
-set(HOST_CLIBS "-rdynamic -L\${libdir}/openenclave/host -loehost -ldl -lpthread ${SGX_LIBS}")
+set(HOST_CLIBS "-rdynamic -Wl,-z,noexecstack -L\${libdir}/openenclave/host -loehost -ldl -lpthread ${SGX_LIBS}")
 
 set(HOST_CXXLIBS "${HOST_CLIBS}")
 


### PR DESCRIPTION
Apply recommended security hardening flags to build of oehostapp and oecore
libs. This includes:

- Compile host apps with `-D_FORTIFY_SOURCE=2` and `-fstack-protector-strong`.
- Link both enclaves and host apps with `-z,noexecstack`.
- Link enclaves with `-z,now` in addition.
- Update pkg-config to apply these by default for samples.
- Update host and enclave/core CMakeLists.txt to export these flags.
- Update CHANGELOG.md to reflect this.

Fixes #1600