### PR TITLE
Added licenses directory to package.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,3 +218,6 @@ if (UNIX)
   add_subdirectory(pkgconfig)
   add_subdirectory(samples)
 endif()
+
+install(FILES LICENSE THIRD_PARTY_NOTICES
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/openenclave/licenses)


### PR DESCRIPTION
When installing the package, this change will put the LICENSE and THIRD_PARTY_NOTICES files into /opt/openenclave/share/openenclave/licenses/ 

Fixes #1609