### PR TITLE
Replace static function names to have _ instead of _oe_

### DIFF
--- a/common/sgx/report.c
+++ b/common/sgx/report.c
@@ -9,7 +9,7 @@
 #include <openenclave/internal/utils.h>
 #include "../common.h"
 
-static oe_result_t _oe_parse_sgx_report_body(
+static oe_result_t _parse_sgx_report_body(
     const sgx_report_body_t* report_body,
     bool remote,
     oe_report_t* parsed_report)
@@ -98,13 +98,13 @@ oe_result_t oe_parse_report(
     {
         sgx_report = (const sgx_report_t*)header->report;
         OE_CHECK(
-            _oe_parse_sgx_report_body(&sgx_report->body, false, parsed_report));
+            _parse_sgx_report_body(&sgx_report->body, false, parsed_report));
         result = OE_OK;
     }
     else if (header->report_type == OE_REPORT_TYPE_SGX_REMOTE)
     {
         sgx_quote = (const sgx_quote_t*)header->report;
-        OE_CHECK(_oe_parse_sgx_report_body(
+        OE_CHECK(_parse_sgx_report_body(
             &sgx_quote->report_body, true, parsed_report));
         result = OE_OK;
     }
@@ -117,7 +117,7 @@ done:
     return result;
 }
 
-static oe_result_t _oe_sgx_get_target_info(
+static oe_result_t _sgx_get_target_info(
     const uint8_t* report,
     size_t report_size,
     void* target_info_buffer,
@@ -176,7 +176,7 @@ oe_result_t oe_get_target_info_v1(
     {
         case OE_REPORT_TYPE_SGX_LOCAL:
         case OE_REPORT_TYPE_SGX_REMOTE:
-            result = _oe_sgx_get_target_info(
+            result = _sgx_get_target_info(
                 report, report_size, target_info_buffer, target_info_size);
             if (result == OE_BUFFER_TOO_SMALL)
                 OE_CHECK_NO_TRACE(result);

--- a/docs/DevelopmentGuide.md
+++ b/docs/DevelopmentGuide.md
@@ -75,7 +75,10 @@ Naming conventions we use that are not automated include:
    `mem_ctx`).
 5. Prefix names with `_` to indicate internal and private fields or methods
    (e.g. `_internal_field, _internal_method()`).
-6. Prefix `struct` definitions with `_`, and always create a `typedef` with the
+6. The single underscore (`_` ) is reserved for local definitions (static,
+   file-scope definitions).
+   e.g. static oe_result_t _parse_sgx_report_body(..).
+7. Prefix `struct` definitions with `_`, and always create a `typedef` with the
    suffix `_t`:
 ```c
 typedef struct _oe_private_key
@@ -84,7 +87,7 @@ typedef struct _oe_private_key
     mbedtls_pk_context pk;
 } oe_private_key_t;
 ```
-7. Prefix Open Enclave specific names in the global namespace with `oe_` (e.g.
+8. Prefix Open Enclave specific names in the global namespace with `oe_` (e.g.
    `oe_result_t, oe_call_enclave`).
 
 Above all, if a file happens to differ in style from these guidelines (e.g.

--- a/enclave/core/printf.c
+++ b/enclave/core/printf.c
@@ -583,7 +583,7 @@ static size_t _write(oe_out_t* out_, const void* buf, size_t count)
     return count;
 }
 
-static void _oe_out_str_init(oe_out_str_t* out, char* str, size_t size)
+static void _out_str_init(oe_out_str_t* out, char* str, size_t size)
 {
     out->base.write = _write;
     out->str = str;
@@ -621,7 +621,7 @@ int oe_vsnprintf(char* str, size_t size, const char* fmt, oe_va_list ap)
     if (!str && size != 0)
         return -1;
 
-    _oe_out_str_init(&out, str, size);
+    _out_str_init(&out, str, size);
 
     return _vprintf(&out.base, fmt, ap);
 }

--- a/enclave/core/sgx/cpuid.c
+++ b/enclave/core/sgx/cpuid.c
@@ -8,7 +8,7 @@
 #include <openenclave/internal/cpuid.h>
 #include <openenclave/internal/raise.h>
 
-static uint32_t _oe_cpuid_table[OE_CPUID_LEAF_COUNT][OE_CPUID_REG_COUNT];
+static uint32_t _cpuid_table[OE_CPUID_LEAF_COUNT][OE_CPUID_REG_COUNT];
 
 /*
 **==============================================================================
@@ -32,9 +32,9 @@ oe_result_t oe_initialize_cpuid(uint64_t arg_in)
             oe_abort();
 
         OE_CHECK(oe_memcpy_s(
-            _oe_cpuid_table,
+            _cpuid_table,
             OE_CPUID_LEAF_COUNT * OE_CPUID_REG_COUNT *
-                sizeof(_oe_cpuid_table[0][0]),
+                sizeof(_cpuid_table[0][0]),
             args->cpuid_table,
             OE_CPUID_LEAF_COUNT * OE_CPUID_REG_COUNT *
                 sizeof(args->cpuid_table[0][0])));
@@ -83,10 +83,10 @@ int oe_emulate_cpuid(uint64_t* rax, uint64_t* rbx, uint64_t* rcx, uint64_t* rdx)
         if ((cpuid_leaf == 4) && (cpuid_sub_leaf != 0))
             return -1;
 
-        *rax = _oe_cpuid_table[cpuid_leaf][OE_CPUID_RAX];
-        *rbx = _oe_cpuid_table[cpuid_leaf][OE_CPUID_RBX];
-        *rcx = _oe_cpuid_table[cpuid_leaf][OE_CPUID_RCX];
-        *rdx = _oe_cpuid_table[cpuid_leaf][OE_CPUID_RDX];
+        *rax = _cpuid_table[cpuid_leaf][OE_CPUID_RAX];
+        *rbx = _cpuid_table[cpuid_leaf][OE_CPUID_RBX];
+        *rcx = _cpuid_table[cpuid_leaf][OE_CPUID_RCX];
+        *rdx = _cpuid_table[cpuid_leaf][OE_CPUID_RDX];
         return 0;
     }
     return -1;

--- a/enclave/core/sgx/errno.c
+++ b/enclave/core/sgx/errno.c
@@ -3,9 +3,9 @@
 
 #include <openenclave/corelibc/errno.h>
 
-static __thread int _oe_errno = 0;
+static __thread int _errno = 0;
 
 int* __oe_errno_location(void)
 {
-    return &_oe_errno;
+    return &_errno;
 }

--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -70,7 +70,7 @@ done:
     return result;
 }
 
-static oe_result_t _oe_get_local_report(
+static oe_result_t _get_local_report(
     const void* report_data,
     size_t report_data_size,
     const void* opt_params,
@@ -119,7 +119,7 @@ done:
     return result;
 }
 
-static oe_result_t _oe_get_sgx_target_info(sgx_target_info_t* target_info)
+static oe_result_t _get_sgx_target_info(sgx_target_info_t* target_info)
 {
     oe_result_t result = OE_UNEXPECTED;
     oe_get_qetarget_info_args_t* args =
@@ -144,7 +144,7 @@ done:
     return result;
 }
 
-static oe_result_t _oe_get_quote(
+static oe_result_t _get_quote(
     const sgx_report_t* sgx_report,
     uint8_t* quote,
     size_t* quote_size)
@@ -214,12 +214,12 @@ oe_result_t oe_get_remote_report(
      * requires privacy. The trust decision is one of integrity verification
      * on the part of the report recipient.
      */
-    OE_CHECK(_oe_get_sgx_target_info(&sgx_target_info));
+    OE_CHECK(_get_sgx_target_info(&sgx_target_info));
 
     /*
      * Get enclave's local report passing in the quoting enclave's target info.
      */
-    OE_CHECK(_oe_get_local_report(
+    OE_CHECK(_get_local_report(
         report_data,
         report_data_size,
         &sgx_target_info,
@@ -230,7 +230,7 @@ oe_result_t oe_get_remote_report(
     /*
      * OCall: Get the quote for the local report.
      */
-    result = _oe_get_quote(&sgx_report, report_buffer, report_buffer_size);
+    result = _get_quote(&sgx_report, report_buffer, report_buffer_size);
     if (result == OE_BUFFER_TOO_SMALL)
         OE_CHECK_NO_TRACE(result);
     else
@@ -297,7 +297,7 @@ oe_result_t oe_get_report_v1(
     else
     {
         // If no flags are specified, default to locally attestable report.
-        result = _oe_get_local_report(
+        result = _get_local_report(
             report_data,
             report_data_size,
             opt_params,
@@ -410,7 +410,7 @@ oe_result_t _handle_get_sgx_report(uint64_t arg_in)
     // enclave to put whatever data it wants in a report. The data field is
     // intended to be used for digital signatures and is not allowed to be
     // tampered with by the host.
-    OE_CHECK(_oe_get_local_report(
+    OE_CHECK(_get_local_report(
         NULL,
         0,
         (enc_arg.opt_params_size != 0) ? enc_arg.opt_params : NULL,

--- a/enclave/sgx/report.c
+++ b/enclave/sgx/report.c
@@ -17,7 +17,7 @@
 
 OE_STATIC_ASSERT(OE_REPORT_DATA_SIZE == sizeof(sgx_report_data_t));
 
-static oe_result_t _oe_get_report_key(
+static oe_result_t _get_report_key(
     const sgx_report_t* sgx_report,
     sgx_key_t* sgx_key)
 {
@@ -72,7 +72,7 @@ oe_result_t oe_verify_report(
     {
         sgx_report = (sgx_report_t*)header->report;
 
-        OE_CHECK(_oe_get_report_key(sgx_report, &sgx_key));
+        OE_CHECK(_get_report_key(sgx_report, &sgx_key));
 
         OE_CHECK(oe_aes_cmac_sign(
             (uint8_t*)&sgx_key,

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -289,7 +289,7 @@ static oe_result_t _calculate_enclave_size(
     return result;
 }
 
-static oe_result_t _oe_add_data_pages(
+static oe_result_t _add_data_pages(
     oe_sgx_load_context_t* context,
     oe_enclave_t* enclave,
     const oe_sgx_enclave_properties_t* props,
@@ -569,8 +569,8 @@ oe_result_t oe_sgx_build_enclave(
     OE_CHECK(oeimage.add_pages(&oeimage, context, enclave, &vaddr));
 
     /* Add data pages */
-    OE_CHECK(_oe_add_data_pages(
-        context, enclave, &props, oeimage.entry_rva, &vaddr));
+    OE_CHECK(
+        _add_data_pages(context, enclave, &props, oeimage.entry_rva, &vaddr));
 
     /* Ask the platform to initialize the enclave and finalize the hash */
     OE_CHECK(oe_sgx_initialize_enclave(

--- a/host/sgx/loadelf.c
+++ b/host/sgx/loadelf.c
@@ -24,7 +24,7 @@
 #include "enclave.h"
 #include "sgxload.h"
 
-static oe_result_t _oe_free_elf_image(oe_enclave_image_t* image)
+static oe_result_t _free_elf_image(oe_enclave_image_t* image)
 {
     if (image->u.elf.elf.data)
     {
@@ -54,9 +54,7 @@ static int _compare_segments(const void* s1, const void* s2)
     return (int)(seg1->vaddr - seg2->vaddr);
 }
 
-static oe_result_t _oe_load_elf_image(
-    const char* path,
-    oe_enclave_image_t* image)
+static oe_result_t _load_elf_image(const char* path, oe_enclave_image_t* image)
 {
     oe_result_t result = OE_UNEXPECTED;
     size_t i;
@@ -382,7 +380,7 @@ done:
 
     if (result != OE_OK)
     {
-        _oe_free_elf_image(image);
+        _free_elf_image(image);
     }
     return result;
 }
@@ -421,7 +419,7 @@ static oe_result_t _unload(oe_enclave_image_t* image)
         free(image->u.elf.reloc_data);
     }
 
-    return _oe_free_elf_image(image);
+    return _free_elf_image(image);
 }
 
 // ------------------------------------------------------------------
@@ -783,7 +781,7 @@ oe_result_t oe_load_elf_enclave_image(
     memset(image, 0, sizeof(oe_enclave_image_t));
 
     /* Load the program segments into memory */
-    OE_CHECK(_oe_load_elf_image(path, image));
+    OE_CHECK(_load_elf_image(path, image));
 
     /* Load the relocations into memory (zero-padded to next page size) */
     if (elf64_load_relocations(

--- a/host/sgx/loadpe.c
+++ b/host/sgx/loadpe.c
@@ -33,7 +33,7 @@
         ((PIMAGE_NT_HEADERS)(ntheader))->FileHeader.SizeOfOptionalHeader))
 #endif
 
-static oe_result_t _oe_get_nt_header(
+static oe_result_t _get_nt_header(
     char* image_base,
     PIMAGE_NT_HEADERS* nt_header)
 {
@@ -281,7 +281,7 @@ oe_result_t oe_load_pe_enclave_image(
         (char*)((uint64_t)image->u.pe.module & (uint64_t)-OE_PAGE_SIZE);
 
     /* get nt header */
-    OE_CHECK(_oe_get_nt_header(image->image_base, &nt_header));
+    OE_CHECK(_get_nt_header(image->image_base, &nt_header));
 
     image->u.pe.nt_header = nt_header;
     image->image_size = nt_header->OptionalHeader.SizeOfImage;

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -18,7 +18,7 @@
 
 OE_STATIC_ASSERT(OE_REPORT_DATA_SIZE == sizeof(sgx_report_data_t));
 
-static oe_result_t _oe_get_local_report(
+static oe_result_t _get_local_report(
     oe_enclave_t* enclave,
     const void* opt_params,
     size_t opt_params_size,
@@ -78,7 +78,7 @@ done:
     return result;
 }
 
-static oe_result_t _oe_get_remote_report(
+static oe_result_t _get_remote_report(
     oe_enclave_t* enclave,
     const void* opt_params,
     size_t opt_params_size,
@@ -119,7 +119,7 @@ static oe_result_t _oe_get_remote_report(
     if (sgx_report == NULL)
         OE_RAISE(OE_OUT_OF_MEMORY);
 
-    OE_CHECK(_oe_get_local_report(
+    OE_CHECK(_get_local_report(
         enclave,
         sgx_target_info,
         sizeof(*sgx_target_info),
@@ -182,7 +182,7 @@ oe_result_t oe_get_report_v1(
 
     if (flags & OE_REPORT_FLAGS_REMOTE_ATTESTATION)
     {
-        OE_CHECK(_oe_get_remote_report(
+        OE_CHECK(_get_remote_report(
             enclave,
             opt_params,
             opt_params_size,
@@ -192,7 +192,7 @@ oe_result_t oe_get_report_v1(
     else
     {
         // If no flags are specified, default to locally attestable report.
-        OE_CHECK(_oe_get_local_report(
+        OE_CHECK(_get_local_report(
             enclave,
             opt_params,
             opt_params_size,


### PR DESCRIPTION
Fixes Issue #1189 - static functions/globals that have _oe_ prefix modified to only have the underscore (_) as prefix. Also clarified DevelopmentGuide.md