### PR TITLE
Update libc & libcxx support documents

### DIFF
--- a/docs/LibcSupport.md
+++ b/docs/LibcSupport.md
@@ -4,24 +4,33 @@ Header | Supported | Comments |
 :---:|:---:|:---|
 assert.h | Yes | - |
 complex.h | Partial | **Unsupported functions:** cacos(), cacosh(), cacoshl(), cacosl(), casin(), casinh(), casinhl(), casinl(), csqrt(), csqrtl(), cpow(), cpowf(), cpowl() |
-ctype.h | Yes | - |
+ctype.h | Partial | Only basic support for C/POSIX locale. |
+errno.h | Yes | - |
 fenv.h | Yes | - |
 float.h | Yes | - |
-inttypes.h | partial | **Unsupported functions:** imaxabs(), imaxdiv()|
+inttypes.h | Partial | **Unsupported functions:** imaxabs(), imaxdiv() |
+iso646.h | Yes | - |
+limits.h | Yes | - |
 locale.h | Partial | Only basic support for C/POSIX locale |
 malloc.h | Partial | **Unsupported functions:** malloc_usable_size() |
-math.h | Partial | **Unsupported functions:** acosh(), asinh(), fmal(), lgamma(), lgammaf(), scalbn(), scalbnf(), scalbnl(), sinh(), sinhl(), tgamma() |
+math.h | Partial | **Unsupported functions:** acosh(), asinh(), fmal(), lgamma(), lgammaf(), sinh(), sinhl(), tgamma() |
 setjmp.h | Yes | - |
 signal.h | No | - |
+stdalign.h | No | - |
+stdarg.h | Yes | - |
 stdatomic.h | No | - |
+stdbool.h | Yes | - |
+stddef.h | Yes | - |
+stdint.h | Yes | - |
 stdio.h | Partial | All I/O functions implicitly call out to untrusted host. <br> **Supported functions:** snprintf(), sscanf(),  _vfscanf()*_, vsnprintf(), vsscanf(), sprintf(), vsprintf(), puts(), putchar(), vprintf(), printf(), _fprintf()*_, _getc()*_, _ungetc()*_, _fwrite()*_, _fflush()*_, _fputs()*_, _fputc()*_ <br> _* Only has support for the streams stderr and stdout, and does not set ferror_ |
-stdlib.h | Partial | **Unsupported functions:** div(), imaxabs(), imaxdiv(), ldiv(), lldiv() |
-string.h | Partial | **Unsupported functions:** strerror(), strsignal() |
+stdlib.h | Partial | **Unsupported functions:** div(), ldiv(), lldiv() |
+stdnoreturn.h | No | - |
+string.h | Partial | Only basic support for C/POSIX locale. |
 tgmath.h | Partial | **Unsupported functions:** acosh(), asinh(), fmal(), lgamma(), lgamma_r(), scalbn(), scalbnf(), scalbnl(), sinh(), sinhl(), tgamma() |
 pthread.h | Partial | Synchronization primitives are not secure across calls to host. Threads are still scheduled by the untrusted host process and an enclave cannot rely on threads making forward progress. <br> **Supported functions:** <br> _- General:_ pthread_self(), pthread_equal(), pthread_once() <br> _- Spinlock:_ pthread_spin_init(), pthread_spin_lock(), pthread_spin_unlock(), pthread_spin_destroy() <br> _- Mutex:_ pthread_mutexattr_init(), pthread_mutexattr_settype(), pthread_mutexattr_destroy(), pthread_mutex_init(), pthread_mutex_lock(), pthread_mutex_trylock(), pthread_mutex_unlock(), pthread_mutex_destroy() <br> _- RW Lock:_ pthread_rwlock_init(), pthread_rwlock_rdlock(), pthread_rwlock_wrlock(), pthread_rwlock_unlock(), pthread_rwlock_destroy() <br> _- Cond:_ pthread_cond_init(), pthread_cond_wait(), pthread_cond_timedwait(), pthread_cond_signal(), pthread_cond_broadcast(), pthread_cond_destroy() <br> _- Thread local storage:_ pthread_key_create(), pthread_key_delete(), pthread_setspecific(), pthread_getspecific() |
 threads.h | No | - |
 time.h | Partial | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. <br> **Supported functions:** time(), gettimeofday(), clock_gettime(), nanosleep(). _Please note that clock_gettime() only supports CLOCK_REALTIME_ |
 uchar.h | Yes | - |
-wchar.h | Partial | **Supported functions:** wcscoll(), wcsxfrm() |
+wchar.h | Partial | Only basic support for C/POSIX locale. <br> **Unsupported functions:** <br> - All I/O (e.g. swprintf()) <br> - All multi-byte & wide string conversions (e.g. mbrtowc()) |
 wctype.h | Yes | - |
 

--- a/docs/LibcxxSupport.md
+++ b/docs/LibcxxSupport.md
@@ -1,63 +1,194 @@
 # Open Enclave Support for libcxx
 
+## Concepts Library
 Header | Supported | Comments |
 :---:|:---:|:---|
-algorithm | Partial | **Supported functions:** find(), find_first_of(), count(), mismatch(), equal(), search(), copy(), move(), transform(), replace(), fill(), generate(), remove(), unique(), reverse(), min(), max(), sort(), lower_bound() |
-array | Yes | - |
-bitset | Partial | **Supported functions:** base(), bitset(), reset(), set(), to_string(), test() |
-cassert | Yes | - |
-cctype | Partial | **Unsupported functions:** isalnum(), isaplha(), iscntrl(), isgraph(), isspace(), isblank(), isprint(), ispunct() |
-cfenv | No | - |
-charconv | No | - |
-chrono | Partial | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. <br> **Supported classes:** system_clock, treat_as_floating_point, duration_values |
-clocale | Partial | Only basic support for C/POSIX locale |
-cmath | Partial | **Supported functions:** abs(), nan(), exp(), log(), sin(), tan(), asin(), erf(), trunc(), round(), rint(), modf() |
-codecvt | Yes | - |
-compare | No | - |
-complex | Yes | - |
-condition_variable | Yes | - |
+concepts | No | Header is not provided, C++20 is not yet supported. |
+
+## Coroutines Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+coroutines | No | Header is not provided, C++20 is not yet supported. |
+
+## Utilities Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+any | No | C++17 is not yet supported. |
+bitset | Yes | - |
+compare | No | C++20 is not yet supported. |
 csetjmp | Yes | - |
-csignal | Yes | - |
-cstdarg | No | - |
+csignal | No | - |
+cstdarg | Yes | - |
 cstddef | Yes | - |
-cstdint | Yes | - |
-cstdio | Partial | All I/O functions implicitly call out to untrusted host. <br> **Unsupported functions:** ferror(), vscanf() |
 cstdlib | Partial | **Unsupported functions:** at_quick_exit(), quick_exit() |
-cstring | Partial | **Unsupported functions:** strcpy(), strcat(), strncat(), strchr(), strcspn(), strspn() |
-ctime | Yes | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. <br> **Supported functions:** time(), gettimeofday(), clock_gettime(), nanosleep(). _Please note that clock_gettime() only supports CLOCK_REALTIME_ |
-cwchar | Partial | **Unsupported functions:** wscanf(), wprintf() |
-cwctype | Yes | - |
-cuchar | No | - |
-exception | Partial | **Unsupported functions:** throw_with_nested(), rethrow_if_nested() |
+ctime | Partial | All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. <br> **Supported functions:** time(), gettimeofday(), clock_gettime(), nanosleep(). _Please note that clock_gettime() only supports CLOCK_REALTIME_ |
+chrono | Partial | Supported as part of C++11. All time functions implicitly call out to untrusted host for time values. The resulting time values should not be used for security purposes. <br> **Supported classes:** system_clock, treat_as_floating_point, duration_values |
 functional | No | - |
-future | Yes | - |
-fstream | Yes | All I/O functions implicitly call out to untrusted host. |
-initializer_list | Yes | - |
-iomanip | Partial | **Unsupported functions:** get_money(), put_money(), get_time(), put_time() |
-ios | Partial | **Unsupported functions:** nounitbuf(), nouppercase(), noshowpos(), noshowpoint(), noshowbase(), noboolalpha() |
-istream | Yes | - |
-iterator | Partial | **Unsupported functions:** make_reverse_iterator(), make_move_iterator(), front_inserter(), back_inserter(), inserter(), begin(), cbegin(), rbegin(), crbegin() |
+initializer_list | Yes | Supported as part of C++11. |
+optional | No | C++17 is not yet supported. |
+tuple | Partial | Supported as part of C++11, known issues with apply() template. |
+type_traits | Yes | Supported as part of C++11. |
+typeindex | Yes | Supported as part of C++11. |
+typeinfo | Yes | - |
+utility | Partial | **Unsupported template:** as_const. |
+variant | No | C++17 is not yet supported. |
+version | No | C++20 is not yet supported. |
+
+#### Dynamic Memory Management
+Header | Supported | Comments |
+:---:|:---:|:---|
 new | Yes | - |
-numeric | Partial | **Unsupported functions:** accumulate(), inner_product(), adjacent_difference(), partial_sum() |
-mutex | Yes | - |
-optional | Yes | - |
-ostream | Partial | **Unsupported function:** endl() |
-queue | Yes | - |
-random | Partial | **Unsupported functions:** generate_canonical() |
-ratio | Yes | - |
-regex | No | - |
-set | Yes | - |
-sstream | Yes | - |
-stddef | Yes |  - |
-streambuf | Yes | - |
+memory | Partial | Supported as part of C++11, so features such uninitialized_move and destroy_at are not yet supported. |
+scoped_allocator | Yes | - |
+memory_resource | No | Header is not provided, C++17 is not yet supported. |
+
+#### Numeric Limits
+Header | Supported | Comments |
+:---:|:---:|:---|
+cfloat | Yes | - |
+cinttypes | Partial | Supported as part of C++11. <br> **Unsupported functions:** imaxabs(), imaxdiv() |
+climits | Yes | - |
+cstdint | Yes | Supported as part of C++11. |
+limits | Yes | - |
+
+#### Error Handling
+Header | Supported | Comments |
+:---:|:---:|:---|
+cassert | Yes | - |
+exception | Yes | Supported as part of C++11. |
+stdexcept | Yes | - |
 system_error | Yes | - |
-thread | No | - |
-tuple | Partial | **Supported function:** tie() |
-typeindex | Yes | - |
-typeinfo | No | - |
-type_traits | No | - |
-unordered_map | Yes | - |
-unordered_set | Yes | - |
-utility | Partial | **Unsupported function:** make_pair() |
+cerrno | Yes | - |
+contract | No | Header is not provided, C++20 is not yet supported. |
+
+## Strings Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+cctype | Partial | Only basic support for C/POSIX locale. |
+charconv | No | C++17 is not yet supported. |
+cuchar | No | Header is not provided. |
+cwchar | Partial | Only basic support for C/POSIX locale. <br> **Unsupported functions:** <br> - All I/O (e.g. swprintf()). <br> - All multi-byte & wide string conversions (e.g. mbrtowc()). |
+cwctype | Partial | Only basic support for C/POSIX locale. |
+cstring | Partial | Only basic support for C/POSIX locale. |
+string | Yes | Supported as part of C++11. |
+string_view | No | C++17 is not yet supported. |
+
+## Containers Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+array | Yes | Supported as part of C++11. |
+deque | Yes | - |
+forward_list | Yes | - |
+list | Yes | - |
+map | Yes | Supported as part of C++11. |
+queue | Yes | - |
+set | Yes | Supported as part of C++11. |
+stack | Yes | - |
+unordered_map | Yes | Supported as part of C++11. |
+unordered_set | Yes | Supported as part of C++11. |
 vector | Yes | - |
-version | No | - |
+span | No | C++20 is not yet supported. |
+
+## Iterators Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+iterator | Yes | - |
+
+## Ranges Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+ranges | No | Header is not provided, C++20 is not yet supported. |
+
+## Algorithms Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+algorithm | Yes | Supported as part of C++11. |
+
+## Numerics Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+bit | No | Header is not provided, C++20 is not yet supported. |
+cfenv | Yes | Supported as part of C++11. |
+cmath | Partial | **Unsupported functions:** acosh(), asinh(), fmal(), lgamma(), lgammaf(), sinh(), sinhl(), tgamma(). |
+complex | Yes | - |
+numeric | Yes | Supported as part of C++11. |
+random | Partial | Supported as part of C++11. <br> **Unsupported class:** random_device. |
+ratio | Yes | Supported as part of C++11. |
+valarray | Yes | - |
+
+## Input/output Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+cstdio | Partial | All I/O functions implicitly call out to untrusted host. <br> **Supported functions:** snprintf(), sscanf(),  _vfscanf()*_, vsnprintf(), vsscanf(), sprintf(), vsprintf(), puts(), putchar(), vprintf(), printf(), _fprintf()*_, _getc()*_, _ungetc()*_, _fwrite()*_, _fflush()*_, _fputs()*_, _fputc()*_. <br> _* Only has support for the streams stderr and stdout, and does not set ferror_. | |
+fstream | No | - |
+iomanip | Partial | **Unsupported functions:** get_money(), put_money(), get_time(), put_time() |
+ios | Yes | Only basic support for C/POSIX locale. |
+iosfwd | Partial | See other headers for which forward declarations are supported. |
+iostream | Yes | - |
+istream | Yes | - |
+ostream | Yes | - |
+strstream | No | Header is provided, but deprecated as of C++98. |
+sstream | Yes | - |
+streambuf | Yes | - |
+syncstream | No | Header is not provided, C++20 is not yet supported. |
+
+## Localization Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+clocale | Partial | Only basic support for C/POSIX locale. |
+codecvt | Partial |  Only basic support for C locale. Supported as part of C++11. |
+locale | Partial | Only basic support for C locale. |
+
+## Regular Expressions Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+regex | No | - |
+
+## Atomic Operations Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+atomic | Yes | Supported as part of C++11. |
+
+## Thread Support Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+condition_variable | Partial | Supported as part of C++11. Synchronization primitives are not secure across calls to host. Threads are still scheduled by the untrusted host process and an enclave cannot rely on threads making forward progress. |
+future | Partial | Supported as part of C++11. Asynchronous invocations are not secure across calls to host. Threads are still scheduled by the untrusted host process and an enclave cannot rely on threads making forward progress. |
+mutex | Partial | Supported as part of C++11. Synchronization primitives are not secure across calls to host. Threads are still scheduled by the untrusted host process and an enclave cannot rely on threads making forward progress. <br> **Unsupported classes:** timed_mutex, recursive_timed_mutex. |
+shared_mutex | No | - |
+thread | No | - |
+
+## Filesystem Library
+Header | Supported | Comments |
+:---:|:---:|:---|
+filesystem | No | - |
+
+## C Compatibility Headers
+Header | Provided | Comments |
+:---:|:---:|:---|
+assert.h | No | - |
+complex.h | Yes | Empty header, includes &lt;complex&gt;. <br> &lt;ccomplex&gt; is also provided. |
+ctype.h | Yes | - |
+errno.h | Yes | - |
+fenv.h | No | - |
+float.h | Yes | - |
+inttypes.h | Yes | - |
+iso646.h | No | Meaningless in C++, although &lt;ciso646&gt; is provided instead. |
+limits.h | Yes | - |
+locale.h | Yes | - |
+math.h | Yes | - |
+setjmp.h | Yes | - |
+signal.h | No | - |
+stdalign.h | No | Meaningless in C++. |
+stdarg.h | No | - |
+stdbool.h | Yes | Meaningless in C++. |
+stddef.h | Yes | - |
+stdint.h | Yes | - |
+stdio.h | Yes | - |
+stdlib.h | Yes | - |
+string.h | Yes | - |
+time.h | No | - |
+tgmath.h | Yes | Empty header, includes &lt;complex&gt; and &lt;cmath&gt;. <br> &lt;ctgmath&gt; is also provided. |
+uchar.h | No | - |
+wchar.h | Yes | - |
+wctype.h | Yes | - |


### PR DESCRIPTION
- Address consistency issues between LibcxxSupported.md and LibcSupported.md

- Scrub LibcSupported.md and LibcxxSupported.md for consistency with current test coverage.

- Format LibcxxSupported.md by functional areas.

Fixes #1544.