### PR TITLE
Disable builtins only for enclave code in our build

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -79,10 +79,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
   if (OE_SGX)
       add_compile_options(-mxsave)
   endif()
-
-  # We should only need this for in-enclave code but it's easier
-  # and conservative to specify everywhere
-  add_compile_options(-fno-builtin-malloc -fno-builtin-calloc -fno-builtin)
 elseif (MSVC)
   # MSVC options go here
   if (MSVC_VERSION VERSION_LESS 1910)

--- a/enclave/core/CMakeLists.txt
+++ b/enclave/core/CMakeLists.txt
@@ -133,12 +133,23 @@ target_compile_options(oecore PUBLIC
     -nostdinc
     -fno-stack-protector
     -fvisibility=hidden
-# According to https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
-# "The default without -fpic is ‘initial-exec’; with -fpic the default is ‘global-dynamic’"
-# Enclaves are linked using -pie and therefore global-dynamic is too conservative.
-# Of the two efficient static tls models, inital-exec and local-exec, we choose the most
-# optimal one.
-    -ftls-model=local-exec)
+    # "The default without -fpic is 'initial-exec'; with -fpic the
+    # default is 'global-dynamic'."
+    # https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+    #
+    # Enclaves are linked using -pie and therefore global-dynamic is
+    # too conservative. Of the two efficient static thread-local
+    # storage models, inital-exec and local-exec, we choose the most
+    # optimal one.
+    -ftls-model=local-exec
+    # Disable builtin functions for enclaves, but only in our build.
+    #
+    # We do this to work-around compiler bugs (see #1429) due to our
+    # redefinition of `memmove` to `oe_memmove` causing an undefined
+    # symbol error when a built-in was inlined. However, we only do
+    # this for our code as we don't want to force these flags on the
+    # user. There are valid reasons for an end user to use built-ins.
+    $<BUILD_INTERFACE:-fno-builtin-malloc -fno-builtin-calloc -fno-builtin>)
 
 target_compile_options(oecore INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
 

--- a/tools/oesign/oedump.c
+++ b/tools/oesign/oedump.c
@@ -178,7 +178,7 @@ void dump_enclave_properties(const oe_sgx_enclave_properties_t* props)
     bool debug = props->config.attributes & OE_SGX_FLAGS_DEBUG;
     printf("debug=%u\n", debug);
 
-    printf("xfrm=%x\n", props->config.xfrm);
+    printf("xfrm=%lx\n", props->config.xfrm);
 
     printf(
         "num_heap_pages=%llu\n",


### PR DESCRIPTION
This was an outstanding TODO.