### PR TITLE
Add auto-signing to the samples

### DIFF
--- a/samples/data-sealing/CMakeLists.txt
+++ b/samples/data-sealing/CMakeLists.txt
@@ -43,3 +43,7 @@ add_custom_command(OUTPUT enc3/enclave_b.signed
 add_custom_target(run
   DEPENDS data-sealing_host ${CMAKE_BINARY_DIR}/enc1/enclave_a_v1.signed ${CMAKE_BINARY_DIR}/enc2/enclave_a_v2.signed ${CMAKE_BINARY_DIR}/enc3/enclave_b.signed
   COMMAND data-sealing_host ${CMAKE_BINARY_DIR}/enc1/enclave_a_v1.signed ${CMAKE_BINARY_DIR}/enc2/enclave_a_v2.signed ${CMAKE_BINARY_DIR}/enc3/enclave_b.signed)
+
+# Automatically sign the enclaves
+add_custom_target(sign ALL
+  DEPENDS ${CMAKE_BINARY_DIR}/enc1/enclave_a_v1.signed ${CMAKE_BINARY_DIR}/enc2/enclave_a_v2.signed ${CMAKE_BINARY_DIR}/enc3/enclave_b.signed)

--- a/samples/data-sealing/common/CMakeLists.txt
+++ b/samples/data-sealing/common/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Use the edger8r to generate C bindings from the EDL file.
-add_custom_command(OUTPUT datasealing_t.h datasealing_t.c
+add_custom_command(OUTPUT datasealing_t.h datasealing_t.c datasealing_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/datasealing.edl
   COMMAND openenclave::oeedger8r --trusted ${CMAKE_SOURCE_DIR}/datasealing.edl)
 

--- a/samples/data-sealing/host/CMakeLists.txt
+++ b/samples/data-sealing/host/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_custom_command(OUTPUT datasealing_u.h datasealing_u.c
+add_custom_command(OUTPUT datasealing_u.h datasealing_u.c datasealing_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/datasealing.edl
   COMMAND openenclave::oeedger8r --untrusted ${CMAKE_SOURCE_DIR}/datasealing.edl)
 

--- a/samples/file-encryptor/CMakeLists.txt
+++ b/samples/file-encryptor/CMakeLists.txt
@@ -19,8 +19,10 @@ add_custom_command(OUTPUT private.pem public.pem
 
 # Sign enclave
 add_custom_command(OUTPUT enc/enclave.signed
-  DEPENDS ${CMAKE_BINARY_DIR}/private.pem
+  DEPENDS $<TARGET_FILE:enclave> private.pem
   COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave> -c ${CMAKE_SOURCE_DIR}/enc/file-encryptor.conf -k private.pem)
+
+add_custom_target(sign ALL DEPENDS enc/enclave.signed)
 
 if ((NOT DEFINED ENV{OE_SIMULATION}) OR (NOT $ENV{OE_SIMULATION}))
   add_custom_target(run

--- a/samples/file-encryptor/enc/CMakeLists.txt
+++ b/samples/file-encryptor/enc/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Use the edger8r to generate C bindings from the EDL file.
-add_custom_command(OUTPUT fileencryptor_t.h fileencryptor_t.c
+add_custom_command(OUTPUT fileencryptor_t.h fileencryptor_t.c fileencryptor_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/fileencryptor.edl
   COMMAND openenclave::oeedger8r --trusted ${CMAKE_SOURCE_DIR}/fileencryptor.edl)
 

--- a/samples/file-encryptor/host/CMakeLists.txt
+++ b/samples/file-encryptor/host/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_custom_command(OUTPUT fileencryptor_u.h fileencryptor_u.c
+add_custom_command(OUTPUT fileencryptor_u.h fileencryptor_u.c fileencryptor_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/fileencryptor.edl
   COMMAND openenclave::oeedger8r --untrusted ${CMAKE_SOURCE_DIR}/fileencryptor.edl)
 

--- a/samples/helloworld/CMakeLists.txt
+++ b/samples/helloworld/CMakeLists.txt
@@ -19,8 +19,10 @@ add_custom_command(OUTPUT private.pem public.pem
 
 # Sign enclave
 add_custom_command(OUTPUT enc/enclave.signed
-  DEPENDS ${CMAKE_BINARY_DIR}/private.pem
+  DEPENDS $<TARGET_FILE:enclave> private.pem
   COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave> -c ${CMAKE_SOURCE_DIR}/enc/helloworld.conf -k private.pem)
+
+add_custom_target(enclave_sign ALL DEPENDS enc/enclave.signed)
 
 if ((NOT DEFINED ENV{OE_SIMULATION}) OR (NOT $ENV{OE_SIMULATION}))
   add_custom_target(run

--- a/samples/helloworld/enc/CMakeLists.txt
+++ b/samples/helloworld/enc/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Use the edger8r to generate C bindings from the EDL file.
-add_custom_command(OUTPUT helloworld_t.h helloworld_t.c
+add_custom_command(OUTPUT helloworld_t.h helloworld_t.c helloworld_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/helloworld.edl
   COMMAND openenclave::oeedger8r --trusted ${CMAKE_SOURCE_DIR}/helloworld.edl)
 

--- a/samples/helloworld/host/CMakeLists.txt
+++ b/samples/helloworld/host/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_custom_command(OUTPUT helloworld_u.h helloworld_u.c
+add_custom_command(OUTPUT helloworld_u.h helloworld_u.c helloworld_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/helloworld.edl
   COMMAND openenclave::oeedger8r --untrusted ${CMAKE_SOURCE_DIR}/helloworld.edl)
 

--- a/samples/local_attestation/common/CMakeLists.txt
+++ b/samples/local_attestation/common/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Use the edger8r to generate C bindings from the EDL file.
-add_custom_command(OUTPUT localattestation_t.h localattestation_t.c
+add_custom_command(OUTPUT localattestation_t.h localattestation_t.c localattestation_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/localattestation.edl
   COMMAND openenclave::oeedger8r --trusted ${CMAKE_SOURCE_DIR}/localattestation.edl)
 

--- a/samples/local_attestation/enc1/CMakeLists.txt
+++ b/samples/local_attestation/enc1/CMakeLists.txt
@@ -24,4 +24,4 @@ add_custom_command(OUTPUT enclave_a.signed
   DEPENDS private_a.pem
   COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_a> -c ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf -k private_a.pem)
 
-add_custom_target(enclave_a_signed DEPENDS enclave_a.signed)
+add_custom_target(enclave_a_signed ALL DEPENDS enclave_a.signed)

--- a/samples/local_attestation/enc2/CMakeLists.txt
+++ b/samples/local_attestation/enc2/CMakeLists.txt
@@ -24,4 +24,4 @@ add_custom_command(OUTPUT enclave_b.signed
   DEPENDS private_b.pem
   COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_b> -c ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf -k private_b.pem)
 
-add_custom_target(enclave_b_signed DEPENDS enclave_b.signed)
+add_custom_target(enclave_b_signed ALL DEPENDS enclave_b.signed)

--- a/samples/local_attestation/host/CMakeLists.txt
+++ b/samples/local_attestation/host/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_custom_command(OUTPUT localattestation_u.h localattestation_u.c
+add_custom_command(OUTPUT localattestation_u.h localattestation_u.c localattestation_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/localattestation.edl
   COMMAND openenclave::oeedger8r --untrusted ${CMAKE_SOURCE_DIR}/localattestation.edl)
 

--- a/samples/remote_attestation/common/CMakeLists.txt
+++ b/samples/remote_attestation/common/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Use the edger8r to generate C bindings from the EDL file.
-add_custom_command(OUTPUT remoteattestation_t.h remoteattestation_t.c
+add_custom_command(OUTPUT remoteattestation_t.h remoteattestation_t.c remoteattestation_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/remoteattestation.edl
   COMMAND openenclave::oeedger8r --trusted ${CMAKE_SOURCE_DIR}/remoteattestation.edl)
 

--- a/samples/remote_attestation/enc1/CMakeLists.txt
+++ b/samples/remote_attestation/enc1/CMakeLists.txt
@@ -24,4 +24,4 @@ add_custom_command(OUTPUT enclave_a.signed
   DEPENDS private_a.pem
   COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_a> -c ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf -k private_a.pem)
 
-add_custom_target(enclave_a_signed DEPENDS enclave_a.signed)
+add_custom_target(enclave_a_signed ALL DEPENDS enclave_a.signed)

--- a/samples/remote_attestation/enc2/CMakeLists.txt
+++ b/samples/remote_attestation/enc2/CMakeLists.txt
@@ -24,4 +24,4 @@ add_custom_command(OUTPUT enclave_b.signed
   DEPENDS private_b.pem
   COMMAND openenclave::oesign sign -e $<TARGET_FILE:enclave_b> -c ${CMAKE_CURRENT_SOURCE_DIR}/enc.conf -k private_b.pem)
 
-add_custom_target(enclave_b_signed DEPENDS enclave_b.signed)
+add_custom_target(enclave_b_signed ALL DEPENDS enclave_b.signed)

--- a/samples/remote_attestation/host/CMakeLists.txt
+++ b/samples/remote_attestation/host/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_custom_command(OUTPUT remoteattestation_u.h remoteattestation_u.c
+add_custom_command(OUTPUT remoteattestation_u.h remoteattestation_u.c remoteattestation_args.h
   DEPENDS ${CMAKE_SOURCE_DIR}/remoteattestation.edl
   COMMAND openenclave::oeedger8r --untrusted ${CMAKE_SOURCE_DIR}/remoteattestation.edl)
 


### PR DESCRIPTION
Adds a default sign target to all enclaves so they automatically get signed.
Also adds dependency on oeedger8r for *_args.h so `make clean` deletes them.

Fixes #1631