### PR TITLE
Apply Spectre mitigations automatically in the CMake package

### DIFF
--- a/3rdparty/mbedtls/CMakeLists.txt
+++ b/3rdparty/mbedtls/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-set(MBEDTLS_WRAP_CFLAGS "-nostdinc -I${PROJECT_SOURCE_DIR}/include/openenclave/corelibc -I${PROJECT_SOURCE_DIR}/include -DOE_NEED_STDC_NAMES -fPIE -fno-builtin-udivti3 ${SPECTRE_MITIGATION_FLAGS} -ftls-model=local-exec")
+string(REPLACE ";" "  " MBEDTLS_SPECTRE_MITIGATION_FLAGS "${OE_SPECTRE_MITIGATION_FLAGS}")
+set(MBEDTLS_WRAP_CFLAGS "-nostdinc -I${PROJECT_SOURCE_DIR}/include/openenclave/corelibc -I${PROJECT_SOURCE_DIR}/include -DOE_NEED_STDC_NAMES -fPIE -fno-builtin-udivti3 ${MBEDTLS_SPECTRE_MITIGATION_FLAGS} -ftls-model=local-exec")
 
 if (USE_CLANGW)
   set(MBEDTLS_WRAP_CFLAGS "-target x86_64-pc-linux ${MBEDTLS_WRAP_CFLAGS}")

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -56,12 +56,13 @@ check_c_compiler_flag("${SPECTRE_MITIGATION_FLAGS}" SPECTRE_MITIGATION_C_FLAGS_S
 check_cxx_compiler_flag("${SPECTRE_MITIGATION_FLAGS}" SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
 if (SPECTRE_MITIGATION_C_FLAGS_SUPPORTED AND SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
   message(STATUS "Spectre 1 mitigations supported")
-  add_compile_options(${SPECTRE_MITIGATION_FLAGS})
-  # Allows reuse in cases where ExternalProject is used and global compile flags wouldn't propagate.
-  string(REPLACE ";" "  " SPECTRE_MITIGATION_FLAGS "${SPECTRE_MITIGATION_FLAGS}")
+  set(OE_SPECTRE_MITIGATION_FLAGS "${SPECTRE_MITIGATION_FLAGS}")
+  # TODO: We really should specify this only on the `oecore` target;
+  # however, the third-party mbed TLS build needs it set to, so we
+  # have to keep this here for now.
+  add_compile_options(${OE_SPECTRE_MITIGATION_FLAGS})
 else ()
   message(WARNING "Spectre 1 mitigations NOT supported")
-  set(SPECTRE_MITIGATION_FLAGS "")
 endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)

--- a/cmake/openenclave-config.cmake.in
+++ b/cmake/openenclave-config.cmake.in
@@ -13,8 +13,9 @@ set_and_check(OE_BINDIR "@PACKAGE_CMAKE_INSTALL_BINDIR@")
 set_and_check(OE_DATADIR "@PACKAGE_CMAKE_INSTALL_DATADIR@")
 set_and_check(OE_INCLUDEDIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 
-# Use these flags if your compiler supports them.
-set(OE_SPECTRE_MITIGATION_FLAGS "@SPECTRE_MITIGATION_FLAGS@")
+# Check for compiler flags
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 
 # Dependencies.
 include(CMakeFindDependencyMacro)
@@ -27,3 +28,11 @@ set_target_properties(openenclave::oeedger8r PROPERTIES IMPORTED_LOCATION ${OE_B
 
 # Include the automatically exported targets.
 include("${CMAKE_CURRENT_LIST_DIR}/openenclave-targets.cmake")
+
+# Apply Spectre mitigations if available.
+set(OE_SPECTRE_MITIGATION_FLAGS "@SPECTRE_MITIGATION_FLAGS@")
+check_c_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED)
+check_cxx_compiler_flag("${OE_SPECTRE_MITIGATION_FLAGS}" OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+if (OE_SPECTRE_MITIGATION_C_FLAGS_SUPPORTED AND OE_SPECTRE_MITIGATION_CXX_FLAGS_SUPPORTED)
+  target_compile_options(openenclave::oecore INTERFACE ${OE_SPECTRE_MITIGATION_FLAGS})
+endif ()


### PR DESCRIPTION
This slightly duplicates code in our build, but it is necessary because the compiler used to generate the package can be different than the compiler used by the consumer of the package.

This code checks if the given Spectre mitigation compiler flags are available, and if so, it enables them unconditionally for all code linking against `openenclave::oecore` (that is, all enclaves).

This resolves #1596 (by removing the need to document the flags as we now apply them opportunistically).