### PR TITLE
Removed logging error messages for OE_INVALID_PARAMETER, OE_BUFFER_TOO_SMALL

### DIFF
--- a/enclave/key.c
+++ b/enclave/key.c
@@ -200,7 +200,7 @@ oe_result_t oe_private_key_write_pem(
         if (*pem_size < size)
         {
             *pem_size = size;
-            OE_RAISE(OE_BUFFER_TOO_SMALL);
+            OE_RAISE_NO_TRACE(OE_BUFFER_TOO_SMALL);
         }
 
         OE_CHECK(oe_memcpy_s(pem_data, *pem_size, buf, size));
@@ -285,7 +285,7 @@ oe_result_t oe_public_key_write_pem(
         if (*pem_size < size)
         {
             *pem_size = size;
-            OE_RAISE(OE_BUFFER_TOO_SMALL);
+            OE_RAISE_NO_TRACE(OE_BUFFER_TOO_SMALL);
         }
 
         OE_CHECK(oe_memcpy_s(pem_data, *pem_size, buf, size));
@@ -305,7 +305,7 @@ oe_result_t oe_private_key_free(oe_private_key_t* private_key, uint64_t magic)
     if (private_key)
     {
         if (!oe_private_key_is_valid(private_key, magic))
-            OE_RAISE(OE_INVALID_PARAMETER);
+            OE_RAISE_NO_TRACE(OE_INVALID_PARAMETER);
 
         oe_private_key_release(private_key, magic);
     }

--- a/host/crypto/openssl/cert.c
+++ b/host/crypto/openssl/cert.c
@@ -592,7 +592,7 @@ oe_result_t oe_cert_chain_free(oe_cert_chain_t* chain)
 
     /* Check the parameter */
     if (_cert_chain_is_valid(impl))
-        OE_RAISE(OE_INVALID_PARAMETER);
+        OE_RAISE_NO_TRACE(OE_INVALID_PARAMETER);
 
     /* Release the stack of certificates */
     sk_X509_pop_free(impl->sk, X509_free);
@@ -988,7 +988,7 @@ oe_result_t oe_cert_find_extension(
             if ((size_t)str->length > *size)
             {
                 *size = (size_t)str->length;
-                OE_RAISE(OE_BUFFER_TOO_SMALL);
+                OE_RAISE_NO_TRACE(OE_BUFFER_TOO_SMALL);
             }
 
             if (data)

--- a/host/crypto/openssl/key.c
+++ b/host/crypto/openssl/key.c
@@ -197,7 +197,7 @@ oe_result_t oe_private_key_write_pem(
         if (*size < mem->length)
         {
             *size = mem->length;
-            OE_RAISE(OE_BUFFER_TOO_SMALL);
+            OE_RAISE_NO_TRACE(OE_BUFFER_TOO_SMALL);
         }
 
         /* Copy result to output buffer */
@@ -285,7 +285,7 @@ oe_result_t oe_private_key_free(oe_private_key_t* key, uint64_t magic)
 
         /* Check parameter */
         if (!oe_private_key_is_valid(impl, magic))
-            OE_RAISE(OE_INVALID_PARAMETER);
+            OE_RAISE_NO_TRACE(OE_INVALID_PARAMETER);
 
         /* Release the key */
         EVP_PKEY_free(impl->pkey);


### PR DESCRIPTION
This change is to remove unnecessary logging to avoid confusion when examining logging produced from test runs. 