### PR TITLE
[CI] Discard old Bors Jenkins builds

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -136,6 +136,13 @@ def win2016CrossCompile(String build_type) {
     }
 }
 
+
+properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '90',
+                                      artifactNumToKeepStr: '180',
+                                      daysToKeepStr: '90',
+                                      numToKeepStr: '180')),
+            [$class: 'JobRestrictionProperty']])
+
 parallel "Check Developer Experience Ubuntu 16.04" :            { checkDevFlows('16.04') },
          "Check Developer Experience Ubuntu 18.04" :            { checkDevFlows('18.04') },
          "Check CI" :                                           { checkCI() },


### PR DESCRIPTION
This allows us to reduce the Jenkins server cluttering.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>