### PR TITLE
Disable unattendend upgrades for packer generated VHDs

### DIFF
--- a/.jenkins/provision/templates/packer/packer.json
+++ b/.jenkins/provision/templates/packer/packer.json
@@ -56,6 +56,8 @@
     {
      "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
      "inline": [
+       "systemctl disable apt-daily-upgrade.timer",
+       "systemctl disable apt-daily.timer",
        "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
      ],
      "inline_shebang": "/bin/sh -x",


### PR DESCRIPTION
Sometimes when we register new Jenkins slaves , ansible task fails to get apt lock in order to install packages because unattended-upgrades are running right after boot.

```
TASK [linux/jenkins : Jenkins | Install Java JRE needed by Jenkins] ************
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (10 retries left).
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (9 retries left).
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (8 retries left).
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (7 retries left).
changed: [libcxx-251-1604-1.eastus.cloudapp.azure.com]
changed: [libcxx-251-1604-2.eastus.cloudapp.azure.com]
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (6 retries left).
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (5 retries left).
changed: [libcxx-251-1804-1.westeurope.cloudapp.azure.com]
changed: [libcxx-251-1804-2.westeurope.cloudapp.azure.com]
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (4 retries left).
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (3 retries left).
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (2 retries left).
FAILED - RETRYING: Jenkins | Install Java JRE needed by Jenkins (1 retries left).
changed: [libcxx-251-1804-3.westeurope.cloudapp.azure.com]
fatal: [libcxx-251-1604-3.eastus.cloudapp.azure.com]: FAILED! => {"attempts": 10, "cache_update_time": 1553836780, "cache_updated": true, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'openjdk-8-jre'' failed: E: Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource temporarily unavailable)\nE: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?\n", "rc": 100, "stderr": "E: Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource temporarily unavailable)\nE: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?\n", "stderr_lines": ["E: Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource temporarily unavailable)", "E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?"], "stdout": "", "stdout_lines": []}
```

This commit disables auto updates for the VHDs generated by us.