### PR TITLE
Fix samples test script

### DIFF
--- a/samples/test-samples.cmake
+++ b/samples/test-samples.cmake
@@ -11,7 +11,8 @@ set(SAMPLES_LIST helloworld file-encryptor)
 
 if ($ENV{OE_SIMULATION})
   message(WARNING "Running only sample simulation tests due to OE_SIMULATION=$ENV{OE_SIMULATION}!")
-  # This is not a failure condition, so we return with a success status.
+  # Set because testing environment variables in CMake is annoying.
+  set(SIMULATION ON)
 else ()
   # All the other tests require that we are not running in simulation.
 
@@ -54,7 +55,7 @@ foreach (SAMPLE ${SAMPLES_LIST})
     COMMAND ${CMAKE_COMMAND} --build ${SOURCE_DIR}/${SAMPLE}
     WORKING_DIRECTORY ${SAMPLE_BUILD_DIR})
 
-  if (NOT $ENV{OE_SIMULATION})
+  if (NOT SIMULATION)
     # Build with the CMake package
     message(STATUS "Samples test '${SAMPLE}' with CMake running...")
     execute_process(


### PR DESCRIPTION
This was accidentally broken when Paul and I changed a tiny bit of seemingly unneeded logic for testing if simulation mode is enabled. Unfortunately, testing environment variables in CMake does not play well
with its logic operators, and so while `if ($ENV{SIM})` behaved as expected, the very similar `if (NOT $ENV{SIM})` behaved completely unexpectedly. This bug temporarily disabled the testing of non-simulation samples in CI.