### PR TITLE
[CI/CD] Added VHD_URL parameter for deployment templates.

### DIFF
--- a/.jenkins/Nightly_packages_testing.Jenkinsfile
+++ b/.jenkins/Nightly_packages_testing.Jenkinsfile
@@ -4,9 +4,9 @@ oe = new jenkins.common.Openenclave()
 XENIAL_RG = "oe-deb-test-${BUILD_NUMBER}-1604"
 BIONIC_RG = "oe-deb-test-${BUILD_NUMBER}-1804"
 
-def ACCDeployVM(String agent_name, String agent_type, String region, String resource_group) {
+def ACCDeployVM(String agent_name, String agent_type, String region, String resource_group, String vhd_url) {
     stage("Deploy ${agent_name}") {
-        withEnv(["REGION=${region}", "RESOURCE_GROUP=${resource_group}", "AGENT_NAME=${agent_name}", "AGENT_TYPE=${agent_type}"]) {
+        withEnv(["REGION=${region}", "RESOURCE_GROUP=${resource_group}", "AGENT_NAME=${agent_name}", "AGENT_TYPE=${agent_type}", "VHD_URL=${vhd_url}"]) {
             oe.azureEnvironment("./deploy-agent.sh")
         }
     }
@@ -35,8 +35,8 @@ def AccDebTesting(String version, String region, String deb_url) {
 }
 
 try {
-    parallel "Deploy Ubuntu 16.04" :    { ACCDeployVM(XENIAL_RG, "xenial", "eastus", XENIAL_RG) },
-             "Deploy Ubuntu 18.04" :    { ACCDeployVM(BIONIC_RG, "bionic", "westeurope", BIONIC_RG) }
+    parallel "Deploy Ubuntu 16.04" :    { ACCDeployVM(XENIAL_RG, "xenial", "eastus", XENIAL_RG, "${VHD_URL_XENIAL}") },
+             "Deploy Ubuntu 18.04" :    { ACCDeployVM(BIONIC_RG, "bionic", "westeurope", BIONIC_RG, "${VHD_URL_BIONIC}") }
 
     parallel "OE 16.04 Testing" :       { AccDebTesting("1604", "eastus", "${OE_1604_DEB_URL}") },
              "OE 18.04 Testing" :       { AccDebTesting("1804", "westeurope", "${OE_1804_DEB_URL}") }

--- a/.jenkins/libcxx_tests.Jenkinsfile
+++ b/.jenkins/libcxx_tests.Jenkinsfile
@@ -21,9 +21,9 @@ String hostsList(String label, String region) {
     return result
 }
 
-def ACCDeployVM(String agent_name, String agent_type, String region, String resource_group) {
+def ACCDeployVM(String agent_name, String agent_type, String region, String resource_group, String vhd_url) {
     stage("Deploy ${agent_name}") {
-        withEnv(["REGION=${region}", "RESOURCE_GROUP=${resource_group}", "AGENT_NAME=${agent_name}", "AGENT_TYPE=${agent_type}"]) {
+        withEnv(["REGION=${region}", "RESOURCE_GROUP=${resource_group}", "AGENT_NAME=${agent_name}", "AGENT_TYPE=${agent_type}", "VHD_URL=${vhd_url}"]) {
             oe.azureEnvironment("./deploy-agent.sh")
         }
     }
@@ -74,8 +74,8 @@ def ACClibcxxTest(String label, String compiler, String build_type) {
 
 try {
     for (int i = 1 ; i <= AGENT_NUM ; i++ ) {
-        parallel "Deploy Ubuntu 16.04 #${i}" :  { ACCDeployVM("${XENIAL_LABEL}-${i}".toLowerCase(), "xenial" , "eastus", XENIAL_RG) },
-                 "Deploy Ubuntu 18.04 #${i}" :  { ACCDeployVM("${BIONIC_LABEL}-${i}".toLowerCase(), "bionic", "westeurope", BIONIC_RG) }
+        parallel "Deploy Ubuntu 16.04 #${i}" :  { ACCDeployVM("${XENIAL_LABEL}-${i}".toLowerCase(), "xenial" , "eastus", XENIAL_RG, "${VHD_URL_XENIAL}") },
+                 "Deploy Ubuntu 18.04 #${i}" :  { ACCDeployVM("${BIONIC_LABEL}-${i}".toLowerCase(), "bionic", "westeurope", BIONIC_RG, "${VHD_URL_BIONIC}") }
     }
 
     registerJenkinsSlaves()

--- a/.jenkins/provision/deploy-agent.sh
+++ b/.jenkins/provision/deploy-agent.sh
@@ -13,6 +13,7 @@ if [[ -z $REGION ]]; then echo "ERROR: Env variable REGION is not set"; exit 1; 
 if [[ -z $RESOURCE_GROUP ]]; then echo "ERROR: Env variable RESOURCE_GROUP is not set"; exit 1; fi
 
 if [[ -z $AGENT_NAME ]]; then echo "ERROR: Env variable AGENT_NAME is not set"; exit 1; fi
+if [[ -z $VHD_URL ]]; then echo "ERROR: Env variable VHD_URL is not set"; exit 1; fi
 if [[ "$AGENT_TYPE" != "xenial" ]] && [[ "$AGENT_TYPE" != "bionic" ]]; then
     echo "ERROR: Env variable AGENT_TYPE has the wrong value. The allowed values for the script are: xenial, bionic"
     exit 1

--- a/.jenkins/provision/templates/oe-engine/ubuntu-bionic.json
+++ b/.jenkins/provision/templates/oe-engine/ubuntu-bionic.json
@@ -23,7 +23,7 @@
         }
       ],
       "osImage": {
-        "url": "https://oejenkinswesteurope.blob.core.windows.net/disks/jenkins-agent-1804-base-disk.vhd"
+        "url": "${VHD_URL}"
       }
     },
     "diagnosticsProfile": {

--- a/.jenkins/provision/templates/oe-engine/ubuntu-xenial.json
+++ b/.jenkins/provision/templates/oe-engine/ubuntu-xenial.json
@@ -23,7 +23,7 @@
         }
       ],
       "osImage": {
-        "url": "https://oejenkins.blob.core.windows.net/disks/jenkins-agent-1604-base-disk.vhd"
+        "url": "${VHD_URL}"
       }
     },
     "diagnosticsProfile": {


### PR DESCRIPTION
This PR adds a VHD_URL parameter for the libcxx and Nightly packaging jobs.

These are the sandbox runs for validating that impacted jobs still work:

* [OpenEnclave-sandbox#990](https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/OpenEnclave-sandbox/detail/OpenEnclave-sandbox/990/pipeline/) - validates that `OpenEnclave-libcxx_tests` job has no regressions
* [OpenEnclave-sandbox#1009](https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/OpenEnclave-sandbox/detail/OpenEnclave-sandbox/1009/pipeline) - validates that `OpenEnclave-packages-testing` job has no regression