### PR TITLE
[Ansible] Add missing APT packages to be installed

### DIFF
--- a/scripts/ansible/roles/linux/intel/tasks/sgx-packages.yml
+++ b/scripts/ansible/roles/linux/intel/tasks/sgx-packages.yml
@@ -5,17 +5,16 @@
 - name: Gather Ansible facts
   setup:
 
+- name: Include vars
+  include_vars: "{{ ansible_distribution_release | lower }}.yml"
+
 - import_role:
     name: linux/common
     tasks_from: apt-repo-intel.yml
 
 - name: Install the Intel libsgx packages
   apt:
-    name:
-      - "libsgx-enclave-common"
-      - "libsgx-enclave-common-dev"
-      - "libsgx-dcap-ql"
-      - "libsgx-dcap-ql-dev"
+    name: "{{ intel_sgx_packages }}"
     state: present
     update_cache: yes
     install_recommends: no

--- a/scripts/ansible/roles/linux/intel/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/intel/vars/bionic.yml
@@ -3,3 +3,9 @@
 
 ---
 intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_dcap_3c2bd37.bin"
+intel_sgx_packages:
+  - "libprotobuf10"
+  - "libsgx-enclave-common"
+  - "libsgx-enclave-common-dev"
+  - "libsgx-dcap-ql"
+  - "libsgx-dcap-ql-dev"

--- a/scripts/ansible/roles/linux/intel/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/intel/vars/xenial.yml
@@ -3,3 +3,9 @@
 
 ---
 intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_dcap_3c2bd37.bin"
+intel_sgx_packages:
+  - "libprotobuf9v5"
+  - "libsgx-enclave-common"
+  - "libsgx-enclave-common-dev"
+  - "libsgx-dcap-ql"
+  - "libsgx-dcap-ql-dev"


### PR DESCRIPTION
These packages used to be dependencies for the `libsgx-enclave-common` APT package. But the latest `2.5` Intel SGX deb package does not have any dependencies set, even though these are still needed.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>

Fixes https://github.com/Microsoft/openenclave/issues/1677