### PR TITLE
Factor out scripts/deploy-docs from Packaging.Jenkinsfile

### DIFF
--- a/.jenkins/Packaging.Jenkinsfile
+++ b/.jenkins/Packaging.Jenkinsfile
@@ -13,11 +13,6 @@ def packageUpload(String version, String build_type) {
             oe.Run("clang-7", task)
             azureUpload(storageCredentialId: 'oe_jenkins_storage_account', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: "master/${BUILD_NUMBER}/ubuntu/${version}/${build_type}/SGX1FLC/", containerName: 'oejenkins')
             azureUpload(storageCredentialId: 'oe_jenkins_storage_account', filesPath: 'build/*.deb', storageType: 'blobstorage', virtualPath: "master/latest/ubuntu/${version}/${build_type}/SGX1FLC/", containerName: 'oejenkins')
-            if ( build_type == 'Release' ) {
-                withCredentials([usernamePassword(credentialsId: 'https_gh_pages_push', passwordVariable: 'GHUSER_PASSWORD', usernameVariable: 'GHUSER_ID')]) {
-                    sh 'bash ./scripts/deploy-docs build https $GHUSER_ID $GHUSER_PASSWORD'
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
This logic is moved as part of a separate individual Jenkins job: [OpenEnclave-Deploy-Docs](https://oe-jenkins.eastus.cloudapp.azure.com/job/OpenEnclave-Deploy-Docs).

Fixes https://github.com/Microsoft/openenclave/issues/1665