### PR TITLE
[Ansible] [CI/CD] Removed clang-7 pinned package version & added platform specific validation

### DIFF
--- a/scripts/ansible/inventory/group_vars/linux-agents
+++ b/scripts/ansible/inventory/group_vars/linux-agents
@@ -3,12 +3,6 @@
 
 ansible_ssh_user: azureuser
 
-cmake_target_version: "3.13"
-docker_target_version: "18.09"
-dockerd_target_version: "18.09"
-clang_target_version: "7.0"
-ocaml_target_version: "4.0"
-
 validation_directories:
   - "/opt/intel/sgxdriver"
   - "/opt/intel/libsgx-enclave-common"

--- a/scripts/ansible/roles/linux/openenclave/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/bionic.yml
@@ -3,8 +3,8 @@
 
 ---
 apt_packages:
-  - "clang-7=1:7.0.1~svn348686-1~exp1~20190113235231.54"
-  - "clang-format-7=1:7.0.1~svn348686-1~exp1~20190113235231.54"
+  - "clang-7"
+  - "clang-format-7"
   - "make=4.1-9.1ubuntu1"
   - "ocaml-nox=4.05.0-10ubuntu1"
   - "ninja-build=1.8.2-1"

--- a/scripts/ansible/roles/linux/openenclave/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/xenial.yml
@@ -3,8 +3,8 @@
 
 ---
 apt_packages:
-  - "clang-7=1:7.0.1~svn348686-1~exp1~20181221231927.53"
-  - "clang-format-7=1:7.0.1~svn348686-1~exp1~20181221231927.53"
+  - "clang-7"
+  - "clang-format-7"
   - "make=4.1-6"
   - "ocaml-native-compilers=4.02.3-5ubuntu2"
   - "ninja-build=1.5.1-0.1ubuntu1"

--- a/scripts/ansible/roles/linux/validation/tasks/slave-validation.yml
+++ b/scripts/ansible/roles/linux/validation/tasks/slave-validation.yml
@@ -2,6 +2,10 @@
 # Licensed under the MIT License.
 
 ---
+- name: Include vars
+  include_vars:
+    file: "{{ ansible_distribution_release | lower }}.yml"
+
 - name: Check for existing required binaries
   stat:
     path: "{{ item }}"

--- a/scripts/ansible/roles/linux/validation/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/validation/vars/bionic.yml
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+cmake_target_version: "3.13.1"
+docker_target_version: "18.09"
+dockerd_target_version: "18.09"
+clang_target_version: "7.1.0"
+ocaml_target_version: "4.05.0"

--- a/scripts/ansible/roles/linux/validation/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/validation/vars/xenial.yml
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+---
+cmake_target_version: "3.13.1"
+docker_target_version: "18.09"
+dockerd_target_version: "18.09"
+clang_target_version: "7.0.1"
+ocaml_target_version: "4.02.3"


### PR DESCRIPTION
* Removed clang-7 pinned packages versions. The `clang-7` APT packages were recently updated, and the previous packages versions were removed from the upstream LLVM repository.

  This caused us [CI failures](https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/OpenEnclave-sandbox/detail/OpenEnclave-sandbox/1017/pipeline) because we use Ansible when building Docker images.

  Thus, due to the fact that only a single `clang-7` package version will be available in the upstream LLVM repository, it doesn't make any sense to pin to a specific version.

* Add platform specific validation. Instead of having global variables for the packages versions
used at the validation role, we use platform specific role variables. These will contain the expected versions to be found on each platform.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>