### PR TITLE
Limit testcase name to 120 chars.

### DIFF
--- a/cmake/get_testcase_name.cmake
+++ b/cmake/get_testcase_name.cmake
@@ -19,5 +19,16 @@ function(get_testcase_name FILENAME NAMEVAR PREFIX)
         endif()
         string(REGEX REPLACE "[/=]" "_" n ${n})
         string(REGEX REPLACE "[\!]" "-" n ${n})
+
+        # Encrypted filesystems on Linux have a smaller limit on the
+	# maximum file name length. Limit the testcase name to the
+	# last 120 characters.
+	set(max_length 120)
+	string(LENGTH ${n} n_length)
+	if (${n_length} GREATER ${max_length})
+	    math(EXPR start_pos "${n_length} - ${max_length}")
+	    string(SUBSTRING ${n} ${start_pos} ${max_length} n)
+	endif()
+
 	set(${NAMEVAR} ${n} PARENT_SCOPE)
 endfunction(get_testcase_name)

--- a/cmake/get_testcase_name.cmake
+++ b/cmake/get_testcase_name.cmake
@@ -13,22 +13,22 @@
 # namevar - variable to receive the testcase name
 #
 function(get_testcase_name FILENAME NAMEVAR PREFIX)
-        string(REGEX REPLACE "\.c(pp)?$" "" n ${FILENAME})
-        if (NOT ${PREFIX} STREQUAL "")
-            string(REGEX REPLACE ${PREFIX} "" n ${n})
-        endif()
-        string(REGEX REPLACE "[/=]" "_" n ${n})
-        string(REGEX REPLACE "[\!]" "-" n ${n})
+  string(REGEX REPLACE "\.c(pp)?$" "" n ${FILENAME})
+  if (NOT PREFIX STREQUAL "")
+    string(REGEX REPLACE ${PREFIX} "" n ${n})
+  endif ()
+  string(REGEX REPLACE "[/=]" "_" n ${n})
+  string(REGEX REPLACE "[\!]" "-" n ${n})
 
-        # Encrypted filesystems on Linux have a smaller limit on the
-	# maximum file name length. Limit the testcase name to the
-	# last 120 characters.
-	set(max_length 120)
-	string(LENGTH ${n} n_length)
-	if (${n_length} GREATER ${max_length})
-	    math(EXPR start_pos "${n_length} - ${max_length}")
-	    string(SUBSTRING ${n} ${start_pos} ${max_length} n)
-	endif()
+  # Encrypted filesystems on Linux have a smaller limit on the
+  # maximum file name length. Limit the testcase name to the
+  # last 120 characters.
+  set(max_length 120)
+  string(LENGTH ${n} n_length)
+  if (n_length GREATER max_length)
+    math(EXPR start_pos "${n_length} - ${max_length}")
+    string(SUBSTRING ${n} ${start_pos} ${max_length} n)
+  endif ()
 
-	set(${NAMEVAR} ${n} PARENT_SCOPE)
+  set(${NAMEVAR} ${n} PARENT_SCOPE)
 endfunction(get_testcase_name)


### PR DESCRIPTION
Reason:
Encrypted filesystems have a smaller limit on maximum file name
length (somewhere around 123 chars).

Fixes #1610 