### PR TITLE
Update ansible version in requirements.txt to 2.7.10

### DIFF
--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -5,7 +5,7 @@ This directory contains the Ansible work used to automate all the required tasks
 
 To quickly install / uninstall Ansible, the script `install-ansible.sh` / `remove-ansible.sh` can be used.
 
-Supported Ansible version >= 2.7.2
+Supported Ansible version >= 2.7.10
 
 # Open Enclave Deployment Options via Ansible
 

--- a/scripts/ansible/requirements.txt
+++ b/scripts/ansible/requirements.txt
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-ansible==2.7.2
+ansible==2.7.10
 pywinrm==0.2.1

--- a/scripts/ansible/roles/linux/intel/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/intel/vars/bionic.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_dcap_3c2bd37.bin"
+intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_dcap_1.1.100.2786ad8.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf10"
 intel_sgx_packages:

--- a/scripts/ansible/roles/linux/intel/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/intel/vars/xenial.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_dcap_3c2bd37.bin"
+intel_sgx_driver_url: "https://download.01.org/intel-sgx/dcap-1.1/linux/dcap_installers/ubuntuServer16.04/sgx_linux_x64_driver_dcap_1.1.100.2786ad8.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf9v5"
 intel_sgx_packages:


### PR DESCRIPTION
There are security issues with ansible < version 2.7.8, so we're increasing the required version to the latest release (2.7.10 as of today)