### PR TITLE
[CI/CD] Fix libcxx Jenkins job regression

### DIFF
--- a/.jenkins/Nightly_packages_testing.Jenkinsfile
+++ b/.jenkins/Nightly_packages_testing.Jenkinsfile
@@ -10,7 +10,9 @@ def ACCDeployVM(String agent_name, String agent_type, String region, String reso
             cleanWs()
             checkout scm
             withEnv(["REGION=${region}", "RESOURCE_GROUP=${resource_group}", "AGENT_NAME=${agent_name}", "AGENT_TYPE=${agent_type}", "VHD_URL=${vhd_url}"]) {
-                oe.azureEnvironment("./deploy-agent.sh")
+                dir("${WORKSPACE}/.jenkins/provision") {
+                    oe.azureEnvironment("./deploy-agent.sh")
+                }
             }
         }
     }

--- a/.jenkins/build_vhd.Jenkinsfile
+++ b/.jenkins/build_vhd.Jenkinsfile
@@ -13,12 +13,14 @@ def buildVHD(String version) {
                                       storageAccountKeyVariable: 'WESTEUROPE_STORAGE_ACCOUNT_KEY',
                                       storageAccountNameVariable: 'WESTEUROPE_STORAGE_ACCOUNT_NAME')]) {
             withEnv(["REGION=eastus", "DEST_VHD_NAME=${VHD_NAME_PREFIX}-${version}.vhd", "CONTAINER_NAME=disks"]) {
-                oe.azureEnvironment("""
-                                    packer build -var-file=templates/packer/ubuntu-${version}-variables.json templates/packer/packer.json 2>&1 | tee packer.log
-                                    export SOURCE_URI=\$(cat packer.log | grep OSDiskUri: | awk '{print \$2}')
-                                    az storage blob copy start --source-uri \$SOURCE_URI --destination-blob \$DEST_VHD_NAME --destination-container \$CONTAINER_NAME --account-key \$EASTUS_STORAGE_ACCOUNT_KEY --account-name \$EASTUS_STORAGE_ACCOUNT_NAME
-                                    az storage blob copy start --source-uri \$SOURCE_URI --destination-blob \$DEST_VHD_NAME --destination-container \$CONTAINER_NAME --account-key \$WESTEUROPE_STORAGE_ACCOUNT_KEY --account-name \$WESTEUROPE_STORAGE_ACCOUNT_NAME
-                                    """)
+                dir("${WORKSPACE}/.jenkins/provision") {
+                    oe.azureEnvironment("""
+                                        packer build -var-file=templates/packer/ubuntu-${version}-variables.json templates/packer/packer.json 2>&1 | tee packer.log
+                                        export SOURCE_URI=\$(cat packer.log | grep OSDiskUri: | awk '{print \$2}')
+                                        az storage blob copy start --source-uri \$SOURCE_URI --destination-blob \$DEST_VHD_NAME --destination-container \$CONTAINER_NAME --account-key \$EASTUS_STORAGE_ACCOUNT_KEY --account-name \$EASTUS_STORAGE_ACCOUNT_NAME
+                                        az storage blob copy start --source-uri \$SOURCE_URI --destination-blob \$DEST_VHD_NAME --destination-container \$CONTAINER_NAME --account-key \$WESTEUROPE_STORAGE_ACCOUNT_KEY --account-name \$WESTEUROPE_STORAGE_ACCOUNT_NAME
+                                        """)
+                }
             }
         }
     }

--- a/.jenkins/libcxx_tests.Jenkinsfile
+++ b/.jenkins/libcxx_tests.Jenkinsfile
@@ -27,7 +27,9 @@ def ACCDeployVM(String agent_name, String agent_type, String region, String reso
             cleanWs()
             checkout scm
             withEnv(["REGION=${region}", "RESOURCE_GROUP=${resource_group}", "AGENT_NAME=${agent_name}", "AGENT_TYPE=${agent_type}", "VHD_URL=${vhd_url}"]) {
-                oe.azureEnvironment("./deploy-agent.sh")
+                dir("${WORKSPACE}/.jenkins/provision") {
+                    oe.azureEnvironment("./deploy-agent.sh")
+                }
             }
         }
     }
@@ -48,7 +50,9 @@ def registerJenkinsSlaves() {
                          "BIONIC_LABEL=${BIONIC_LABEL}",
                          "XENIAL_HOSTS=${hostsList(XENIAL_LABEL, 'eastus').join(',')}",
                          "BIONIC_HOSTS=${hostsList(BIONIC_LABEL, 'westeurope').join(',')}"]) {
-                    oe.azureEnvironment("./register-agents.sh")
+                    dir(WORKSPACE) {
+                        oe.azureEnvironment("${WORKSPACE}/.jenkins/provision/register-agents.sh")
+                    }
                 }
             }
         }

--- a/src/jenkins/common/Openenclave.groovy
+++ b/src/jenkins/common/Openenclave.groovy
@@ -35,13 +35,11 @@ def azureEnvironment(String task) {
                                           usernameVariable: 'SERVICE_PRINCIPAL_ID'),
                          string(credentialsId: 'OSCTLabSubID', variable: 'SUBSCRIPTION_ID'),
                          string(credentialsId: 'TenantID', variable: 'TENANT_ID')]) {
-            dir("${WORKSPACE}/.jenkins/provision") {
-                docker.withRegistry("https://oejenkinscidockerregistry.azurecr.io", "oejenkinscidockerregistry") {
-                    image = docker.image("oetools-deploy:latest")
-                    image.pull()
-                    image.inside {
-                        sh "${task}"
-                    }
+            docker.withRegistry("https://oejenkinscidockerregistry.azurecr.io", "oejenkinscidockerregistry") {
+                image = docker.image("oetools-deploy:latest")
+                image.pull()
+                image.inside {
+                    sh "${task}"
                 }
             }
         }
@@ -69,7 +67,9 @@ def deleteRG(List resourceGroups) {
     stage("Delete ${resourceGroups.toString()} resource groups") {
         resourceGroups.each { rg ->
             withEnv(["RESOURCE_GROUP=${rg}"]) {
-                azureEnvironment("./cleanup.sh")
+                dir("${WORKSPACE}/.jenkins/provision") {
+                    azureEnvironment("./cleanup.sh")
+                }
             }
         }
     }


### PR DESCRIPTION
Since https://github.com/Microsoft/openenclave/commit/6ecc1463f5d7b1a1b6919fb75c6194b74c72c955, the Jenkins system user exists inside the testing
containers. Thus, when mounting the `provision` directory, the parent
directory is not mounted as well.

This caused a regression to the libcxx Jenkins job because the script
`register-agents.sh` needs access to the `scripts/ansible` directory.
Without mounting the entire parent directory (the OE repository root
directory), we get the following error:

```
./register-agents.sh
realpath: ./../../scripts/ansible: No such file or directory
script returned exit code 1
```

To solve the above problem, we moved the `dir` mounts from the
`azureEnvironment` shared library function. The mounts are used
in every place where `azureEnvironment` is called.