### PR TITLE
Use correct offset for debug and simulate flags.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -46,7 +46,7 @@ def simulationTest(String version, String platform_mode, String build_type) {
                            ninja -v
                            ctest --output-on-failure
                            """
-                oe.ContainerRun("oetools-full-${version}", "clang-7", task)
+                oe.ContainerRun("oetools-full-${version}", "clang-7", task, "--cap-add=SYS_PTRACE")
             }
         }
     }
@@ -62,7 +62,7 @@ def ACCContainerTest(String label, String version) {
                        ninja -v
                        ctest --output-on-failure
                        """
-            oe.ContainerRun("oetools-full-${version}", "clang-7", task, "--device /dev/sgx:/dev/sgx")
+            oe.ContainerRun("oetools-full-${version}", "clang-7", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx")
         }
     }
 }
@@ -76,7 +76,7 @@ def checkDevFlows(String version) {
                        cmake ${WORKSPACE} -G Ninja -DUSE_LIBSGX=OFF -Wdev --warn-uninitialized -Werror=dev
                        ninja -v
                        """
-            oe.ContainerRun("oetools-minimal-${version}", "clang-7", task)
+            oe.ContainerRun("oetools-minimal-${version}", "clang-7", task, "--cap-add=SYS_PTRACE")
         }
     }
 }
@@ -88,7 +88,7 @@ def checkCI() {
             checkout scm
             // At the moment, the check-ci script assumes that it's executed from the
             // root source code directory.
-            oe.ContainerRun("oetools-minimal-18.04", "clang-7", "cd ${WORKSPACE} && ./scripts/check-ci")
+            oe.ContainerRun("oetools-minimal-18.04", "clang-7", "cd ${WORKSPACE} && ./scripts/check-ci", "--cap-add=SYS_PTRACE")
         }
     }
 }
@@ -102,7 +102,7 @@ def win2016LinuxElfBuild(String version, String compiler, String build_type) {
                        cmake ${WORKSPACE} -G Ninja -DCMAKE_BUILD_TYPE=${build_type} -DUSE_DEBUG_MALLOC=OFF -Wdev
                        ninja -v
                        """
-            oe.ContainerRun("oetools-full-${version}", compiler, task)
+            oe.ContainerRun("oetools-full-${version}", compiler, task, "--cap-add=SYS_PTRACE")
             stash includes: 'build/tests/**', name: "linux-${compiler}-${build_type}-${version}-${BUILD_NUMBER}"
         }
     }

--- a/debugger/pythonExtension/gdb_sgx_plugin.py
+++ b/debugger/pythonExtension/gdb_sgx_plugin.py
@@ -19,7 +19,7 @@ OE_ENCLAVE_MAGIC_VALUE = 0x20dc98463a5ad8b8
 
 # The following are the offset of the 'debug' and
 # 'simulate' flag fields which must lie one after the other.
-OE_ENCLAVE_FLAGS_OFFSET = 0x798
+OE_ENCLAVE_FLAGS_OFFSET = 0x788
 OE_ENCLAVE_FLAGS_LENGTH = 2
 OE_ENCLAVE_FLAGS_FORMAT = 'BB'
 OE_ENCLAVE_THREAD_BINDING_OFFSET = 0x28

--- a/debugger/pythonExtension/gdb_sgx_plugin.py
+++ b/debugger/pythonExtension/gdb_sgx_plugin.py
@@ -25,7 +25,7 @@ OE_ENCLAVE_FLAGS_FORMAT = 'BB'
 OE_ENCLAVE_THREAD_BINDING_OFFSET = 0x28
 
 # These constant definitions must align with ThreadBinding structure defined in host\enclave.h
-THREAD_BINDING_SIZE = 0x28
+THREAD_BINDING_SIZE = 0x38
 THREAD_BINDING_HEADER_LENGTH = 0X8
 THREAD_BINDING_HEADER_FORMAT = 'Q'
 

--- a/tests/debugger/oegdb/CMakeLists.txt
+++ b/tests/debugger/oegdb/CMakeLists.txt
@@ -9,6 +9,7 @@ add_test(
     COMMAND
         ${OE_BINDIR}/oegdb --batch
         --command=${CMAKE_CURRENT_SOURCE_DIR}/commands.gdb
+        --return-child-result # This fails the test in case of any error.
         -arg host/oe_gdb_test_host enc/oe_gdb_test_enc
 )
 
@@ -17,5 +18,6 @@ add_test(
     COMMAND
         ${OE_BINDIR}/oegdb --batch
         --command=${CMAKE_CURRENT_SOURCE_DIR}/commands.gdb
+        --return-child-result # Tnis fails the test in case of any error.
         -arg host/oe_gdb_test_host enc/oe_gdb_test_enc --simulation-mode
 )

--- a/tests/debugger/oegdb/CMakeLists.txt
+++ b/tests/debugger/oegdb/CMakeLists.txt
@@ -18,6 +18,6 @@ add_test(
     COMMAND
         ${OE_BINDIR}/oegdb --batch
         --command=${CMAKE_CURRENT_SOURCE_DIR}/commands.gdb
-        --return-child-result # Tnis fails the test in case of any error.
+        --return-child-result # This fails the test in case of any error.
         -arg host/oe_gdb_test_host enc/oe_gdb_test_enc --simulation-mode
 )

--- a/tests/debugger/oegdb/commands.gdb
+++ b/tests/debugger/oegdb/commands.gdb
@@ -78,17 +78,22 @@ commands 5
     python gdb.parse_and_eval("OE_ENCLAVE_MAGIC_FIELD = " + str(gdb_sgx_plugin.OE_ENCLAVE_MAGIC_FIELD))
     python gdb.parse_and_eval("OE_ENCLAVE_ADDR_FIELD = sizeof(void*) * " + str(gdb_sgx_plugin.OE_ENCLAVE_ADDR_FIELD))
     python gdb.parse_and_eval("OE_ENCLAVE_HEADER_LENGTH = " + str(gdb_sgx_plugin.OE_ENCLAVE_HEADER_LENGTH))
-    python gdb.parse_and_eval('sprintf(OE_ENCLAVE_HEADER_FORMAT, "%s", "' + gdb_sgx_plugin.OE_ENCLAVE_HEADER_FORMAT + '")')
+    python gdb.parse_and_eval("OE_ENCLAVE_HEADER_FORMAT[0] = '" + str(gdb_sgx_plugin.OE_ENCLAVE_HEADER_FORMAT[0]) + "'")
+    python gdb.parse_and_eval("OE_ENCLAVE_HEADER_FORMAT[1] = '" + str(gdb_sgx_plugin.OE_ENCLAVE_HEADER_FORMAT[1]) + "'")
+    python gdb.parse_and_eval("OE_ENCLAVE_HEADER_FORMAT[2] = '" + str(gdb_sgx_plugin.OE_ENCLAVE_HEADER_FORMAT[2]) + "'")
+    python gdb.parse_and_eval("OE_ENCLAVE_HEADER_FORMAT[3] = '" + str(gdb_sgx_plugin.OE_ENCLAVE_HEADER_FORMAT[3]) + "'")
+    python gdb.parse_and_eval("OE_ENCLAVE_HEADER_FORMAT[4] = '" + str(gdb_sgx_plugin.OE_ENCLAVE_HEADER_FORMAT[4]) + "'")
     python gdb.parse_and_eval("OE_ENCLAVE_MAGIC_VALUE = " + str(gdb_sgx_plugin.OE_ENCLAVE_MAGIC_VALUE))
 
     python gdb.parse_and_eval("OE_ENCLAVE_FLAGS_OFFSET = " + str(gdb_sgx_plugin.OE_ENCLAVE_FLAGS_OFFSET))
     python gdb.parse_and_eval("OE_ENCLAVE_FLAGS_LENGTH = " + str(gdb_sgx_plugin.OE_ENCLAVE_FLAGS_LENGTH))
-    python gdb.parse_and_eval('sprintf(OE_ENCLAVE_FLAGS_FORMAT, "%s", "' + gdb_sgx_plugin.OE_ENCLAVE_FLAGS_FORMAT + '")')
+    python gdb.parse_and_eval("OE_ENCLAVE_FLAGS_FORMAT[0] = '" + str(gdb_sgx_plugin.OE_ENCLAVE_FLAGS_FORMAT[0]) + "'")
+    python gdb.parse_and_eval("OE_ENCLAVE_FLAGS_FORMAT[1] = '" + str(gdb_sgx_plugin.OE_ENCLAVE_FLAGS_FORMAT[1]) + "'")
     python gdb.parse_and_eval("OE_ENCLAVE_THREAD_BINDING_OFFSET = " + str(gdb_sgx_plugin.OE_ENCLAVE_THREAD_BINDING_OFFSET))
 
     python gdb.parse_and_eval("THREAD_BINDING_SIZE = " + str(gdb_sgx_plugin.THREAD_BINDING_SIZE))
     python gdb.parse_and_eval("THREAD_BINDING_HEADER_LENGTH = " + str(gdb_sgx_plugin.THREAD_BINDING_HEADER_LENGTH))
-    python gdb.parse_and_eval('sprintf(THREAD_BINDING_HEADER_FORMAT, "%s", "' + gdb_sgx_plugin.THREAD_BINDING_HEADER_FORMAT + '")')
+    python gdb.parse_and_eval("THREAD_BINDING_HEADER_FORMAT[0] = '" + str(gdb_sgx_plugin.THREAD_BINDING_HEADER_FORMAT[0]) + "'")
 
     python print("Debugger contract serialized on host side.")
     continue

--- a/tests/debugger/oegdb/commands.gdb
+++ b/tests/debugger/oegdb/commands.gdb
@@ -69,6 +69,51 @@ commands 4
     continue
 end
 
+# Assert debugger contract on host side.
+b assert_debugger_binary_contract_host_side
+commands 5
+    python print("Serializing debugger contract on host side....")
+    python import gdb_sgx_plugin
+
+    python gdb.parse_and_eval("OE_ENCLAVE_MAGIC_FIELD = " + str(gdb_sgx_plugin.OE_ENCLAVE_MAGIC_FIELD))
+    python gdb.parse_and_eval("OE_ENCLAVE_ADDR_FIELD = sizeof(void*) * " + str(gdb_sgx_plugin.OE_ENCLAVE_ADDR_FIELD))
+    python gdb.parse_and_eval("OE_ENCLAVE_HEADER_LENGTH = " + str(gdb_sgx_plugin.OE_ENCLAVE_HEADER_LENGTH))
+    python gdb.parse_and_eval('sprintf(OE_ENCLAVE_HEADER_FORMAT, "%s", "' + gdb_sgx_plugin.OE_ENCLAVE_HEADER_FORMAT + '")')
+    python gdb.parse_and_eval("OE_ENCLAVE_MAGIC_VALUE = " + str(gdb_sgx_plugin.OE_ENCLAVE_MAGIC_VALUE))
+
+    python gdb.parse_and_eval("OE_ENCLAVE_FLAGS_OFFSET = " + str(gdb_sgx_plugin.OE_ENCLAVE_FLAGS_OFFSET))
+    python gdb.parse_and_eval("OE_ENCLAVE_FLAGS_LENGTH = " + str(gdb_sgx_plugin.OE_ENCLAVE_FLAGS_LENGTH))
+    python gdb.parse_and_eval('sprintf(OE_ENCLAVE_FLAGS_FORMAT, "%s", "' + gdb_sgx_plugin.OE_ENCLAVE_FLAGS_FORMAT + '")')
+    python gdb.parse_and_eval("OE_ENCLAVE_THREAD_BINDING_OFFSET = " + str(gdb_sgx_plugin.OE_ENCLAVE_THREAD_BINDING_OFFSET))
+
+    python gdb.parse_and_eval("THREAD_BINDING_SIZE = " + str(gdb_sgx_plugin.THREAD_BINDING_SIZE))
+    python gdb.parse_and_eval("THREAD_BINDING_HEADER_LENGTH = " + str(gdb_sgx_plugin.THREAD_BINDING_HEADER_LENGTH))
+    python gdb.parse_and_eval('sprintf(THREAD_BINDING_HEADER_FORMAT, "%s", "' + gdb_sgx_plugin.THREAD_BINDING_HEADER_FORMAT + '")')
+
+    python print("Debugger contract serialized on host side.")
+    continue
+end
+
+# Assert debugger contract on enclave side.
+b assert_debugger_binary_contract_enclave_side
+commands 6
+    python print("Serializing debugger contract on enclave side....")
+    python import gdb_sgx_plugin
+
+    python gdb.parse_and_eval("TD_OFFSET_FROM_TCS = " + str(gdb_sgx_plugin.TD_OFFSET_FROM_TCS))
+    python gdb.parse_and_eval("TD_CALLSITE_OFFSET = " + str(gdb_sgx_plugin.TD_CALLSITE_OFFSET))
+    python gdb.parse_and_eval("CALLSITE_OCALLCONTEXT_OFFSET = " + str(gdb_sgx_plugin.CALLSITE_OCALLCONTEXT_OFFSET))
+
+    python gdb.parse_and_eval("OCALLCONTEXT_LENGTH  = " + str(gdb_sgx_plugin.OCALLCONTEXT_LENGTH))
+    python gdb.parse_and_eval("OCALLCONTEXT_FORMAT[0] = '" + gdb_sgx_plugin.OCALLCONTEXT_FORMAT[0] + "'")
+    python gdb.parse_and_eval("OCALLCONTEXT_FORMAT[1] = '" + gdb_sgx_plugin.OCALLCONTEXT_FORMAT[1] + "'")
+    python gdb.parse_and_eval("OCALLCONTEXT_RBP = " + str(gdb_sgx_plugin.OCALLCONTEXT_RBP))
+    python gdb.parse_and_eval("OCALLCONTEXT_RET = " + str(gdb_sgx_plugin.OCALLCONTEXT_RET))
+
+    python print("Debugger contract serialized on enclave side.")
+    continue
+end
+
 # Run the program
 run
 

--- a/tests/debugger/oegdb/enc/CMakeLists.txt
+++ b/tests/debugger/oegdb/enc/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 oeedl_file(../oe_gdb_test.edl enclave oe_gdb_test_t)
 
-add_enclave(TARGET oe_gdb_test_enc SOURCES enc.c ${oe_gdb_test_t})
+add_enclave(TARGET oe_gdb_test_enc SOURCES enc.c contract.c ${oe_gdb_test_t})
 
 target_include_directories(oe_gdb_test_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(oe_gdb_test_enc oelibc)

--- a/tests/debugger/oegdb/enc/contract.c
+++ b/tests/debugger/oegdb/enc/contract.c
@@ -8,21 +8,21 @@
 #include <string.h>
 #include "../../../../enclave/core/sgx/td.h"
 
+// These values are filled by the debugger.
+// The variables are marked volatile so that the compiler does not hard-code
+// the initialization value of the variables in comparision.
+// Since 0 could be a legal value for some of these items, they are
+// initialized to -1.
+volatile uint64_t TD_OFFSET_FROM_TCS = (uint64_t)-1;
+volatile uint64_t TD_CALLSITE_OFFSET = (uint64_t)-1;
+volatile uint64_t CALLSITE_OCALLCONTEXT_OFFSET = (uint64_t)-1;
+volatile uint64_t OCALLCONTEXT_LENGTH = (uint64_t)-1;
+volatile char OCALLCONTEXT_FORMAT[10];
+volatile uint64_t OCALLCONTEXT_RBP = (uint64_t)-1;
+volatile uint64_t OCALLCONTEXT_RET = (uint64_t)-1;
+
 void assert_debugger_binary_contract_enclave_side()
 {
-    // These values are filled by the debugger.
-    // The variables are marked volatile so that the compiler does not hard-code
-    // the initialization value of the variables in comparision.
-    // Since 0 could be a legal value for some of these items, they are
-    // initialized to -1.
-    static volatile uint64_t TD_OFFSET_FROM_TCS = (uint64_t)-1;
-    static volatile uint64_t TD_CALLSITE_OFFSET = (uint64_t)-1;
-    static volatile uint64_t CALLSITE_OCALLCONTEXT_OFFSET = (uint64_t)-1;
-    static volatile uint64_t OCALLCONTEXT_LENGTH = (uint64_t)-1;
-    static volatile char OCALLCONTEXT_FORMAT[10];
-    static volatile uint64_t OCALLCONTEXT_RBP = (uint64_t)-1;
-    static volatile uint64_t OCALLCONTEXT_RET = (uint64_t)-1;
-
     OE_TEST(TD_OFFSET_FROM_TCS == 4 * OE_PAGE_SIZE);
     OE_TEST(TD_CALLSITE_OFFSET == OE_OFFSETOF(td_t, callsites));
     OE_TEST(

--- a/tests/debugger/oegdb/enc/contract.c
+++ b/tests/debugger/oegdb/enc/contract.c
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/sgxtypes.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include <string.h>
+#include "../../../../enclave/core/sgx/td.h"
+
+void assert_debugger_binary_contract_enclave_side()
+{
+    // These values are filled by the debugger.
+    // The variables are marked volatile so that the compiler does not hard-code
+    // the initialization value of the variables in comparision.
+    // Since 0 could be a legal value for some of these items, they are
+    // initialized to -1.
+    static volatile uint64_t TD_OFFSET_FROM_TCS = (uint64_t)-1;
+    static volatile uint64_t TD_CALLSITE_OFFSET = (uint64_t)-1;
+    static volatile uint64_t CALLSITE_OCALLCONTEXT_OFFSET = (uint64_t)-1;
+    static volatile uint64_t OCALLCONTEXT_LENGTH = (uint64_t)-1;
+    static volatile char OCALLCONTEXT_FORMAT[10];
+    static volatile uint64_t OCALLCONTEXT_RBP = (uint64_t)-1;
+    static volatile uint64_t OCALLCONTEXT_RET = (uint64_t)-1;
+
+    OE_TEST(TD_OFFSET_FROM_TCS == 4 * OE_PAGE_SIZE);
+    OE_TEST(TD_CALLSITE_OFFSET == OE_OFFSETOF(td_t, callsites));
+    OE_TEST(
+        CALLSITE_OCALLCONTEXT_OFFSET == OE_OFFSETOF(Callsite, ocall_context));
+
+    OE_TEST(OCALLCONTEXT_LENGTH == sizeof(oe_ocall_context_t));
+    OE_TEST(strcmp((const char*)OCALLCONTEXT_FORMAT, "QQ") == 0);
+    OE_TEST(
+        OCALLCONTEXT_RBP ==
+        (OE_OFFSETOF(oe_ocall_context_t, rbp) / sizeof(uint64_t)));
+    OE_TEST(
+        OCALLCONTEXT_RET ==
+        (OE_OFFSETOF(oe_ocall_context_t, ret) / sizeof(uint64_t)));
+
+    printf("Debugger contract validated on enclave side.\n");
+}
+
+void enc_assert_debugger_binary_contract()
+{
+    assert_debugger_binary_contract_enclave_side();
+}

--- a/tests/debugger/oegdb/enc/contract.c
+++ b/tests/debugger/oegdb/enc/contract.c
@@ -8,11 +8,12 @@
 #include <string.h>
 #include "../../../../enclave/core/sgx/td.h"
 
-// These values are filled by the debugger.
-// The variables are marked volatile so that the compiler does not hard-code
-// the initialization value of the variables in comparision.
-// Since 0 could be a legal value for some of these items, they are
-// initialized to -1.
+// The following variables are initialized so that the assertions below will
+// fail by default. The test expects the debugger to update the values
+// of these variables by introspecting the gdb python plugin.
+// If the gdb plugin's assumptions match the layout of the data structures,
+// then the assertions won't be triggered.
+// volatile is used to prevent compiler-optimizations.
 volatile uint64_t TD_OFFSET_FROM_TCS = (uint64_t)-1;
 volatile uint64_t TD_CALLSITE_OFFSET = (uint64_t)-1;
 volatile uint64_t CALLSITE_OCALLCONTEXT_OFFSET = (uint64_t)-1;

--- a/tests/debugger/oegdb/host/CMakeLists.txt
+++ b/tests/debugger/oegdb/host/CMakeLists.txt
@@ -6,6 +6,7 @@ oeedl_file(../oe_gdb_test.edl host oe_gdb_test_u)
 
 add_executable(oe_gdb_test_host
     host.c
+    contract.c
     ${oe_gdb_test_u}
 )
 

--- a/tests/debugger/oegdb/host/contract.c
+++ b/tests/debugger/oegdb/host/contract.c
@@ -7,11 +7,12 @@
 #include <string.h>
 #include "../../../../host/sgx/enclave.h"
 
-// These values are filled by the debugger.
-// The variables are marked volatile so that the compiler does not hard-code
-// the initialization value of the variables in comparision.
-// Since 0 could be a legal value for some of these items, they are
-// initialized to -1.
+// The following variables are initialized so that the assertions below will
+// fail by default. The test expects the debugger to update the values
+// of these variables by introspecting the gdb python plugin.
+// If the gdb plugin's assumptions match the layout of the data structures,
+// then the assertions won't be triggered.
+// volatile is used to prevent compiler-optimizations.
 volatile uint64_t OE_ENCLAVE_MAGIC_FIELD = (uint64_t)-1;
 volatile uint64_t OE_ENCLAVE_ADDR_FIELD = (uint64_t)-1;
 volatile uint64_t OE_ENCLAVE_HEADER_LENGTH = (uint64_t)-1;

--- a/tests/debugger/oegdb/host/contract.c
+++ b/tests/debugger/oegdb/host/contract.c
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/error.h>
+#include <openenclave/internal/sgxtypes.h>
+#include <openenclave/internal/tests.h>
+#include <string.h>
+#include "../../../../host/sgx/enclave.h"
+
+void assert_debugger_binary_contract_host_side()
+{
+    // These values are filled by the debugger.
+    // The variables are marked volatile so that the compiler does not hard-code
+    // the initialization value of the variables in comparision.
+    // Since 0 could be a legal value for some of these items, they are
+    // initialized to -1.
+    static volatile uint64_t OE_ENCLAVE_MAGIC_FIELD = (uint64_t)-1;
+    static volatile uint64_t OE_ENCLAVE_ADDR_FIELD = (uint64_t)-1;
+    static volatile uint64_t OE_ENCLAVE_HEADER_LENGTH = (uint64_t)-1;
+    static volatile char OE_ENCLAVE_HEADER_FORMAT[10];
+    static volatile uint64_t OE_ENCLAVE_MAGIC_VALUE = (uint64_t)-1;
+    static volatile uint64_t OE_ENCLAVE_FLAGS_OFFSET = (uint64_t)-1;
+    static volatile uint64_t OE_ENCLAVE_FLAGS_LENGTH = (uint64_t)-1;
+    static volatile char OE_ENCLAVE_FLAGS_FORMAT[10];
+    static volatile uint64_t OE_ENCLAVE_THREAD_BINDING_OFFSET = (uint64_t)-1;
+    static volatile uint64_t THREAD_BINDING_SIZE = (uint64_t)-1;
+    static volatile uint64_t THREAD_BINDING_HEADER_LENGTH = (uint64_t)-1;
+    static volatile char THREAD_BINDING_HEADER_FORMAT[10];
+
+    OE_TEST(OE_ENCLAVE_MAGIC_FIELD == OE_OFFSETOF(oe_enclave_t, magic));
+    OE_TEST(OE_ENCLAVE_ADDR_FIELD == OE_OFFSETOF(oe_enclave_t, addr));
+    OE_TEST(OE_ENCLAVE_HEADER_LENGTH == OE_OFFSETOF(oe_enclave_t, bindings));
+    OE_TEST(strcmp((const char*)OE_ENCLAVE_HEADER_FORMAT, "QQQQQ") == 0);
+    OE_TEST(OE_ENCLAVE_MAGIC_VALUE == ENCLAVE_MAGIC);
+    OE_TEST(OE_ENCLAVE_FLAGS_LENGTH == 2);
+
+    OE_TEST(OE_ENCLAVE_FLAGS_OFFSET == OE_OFFSETOF(oe_enclave_t, debug));
+    OE_TEST(strcmp((const char*)OE_ENCLAVE_FLAGS_FORMAT, "BB") == 0);
+    OE_TEST(
+        OE_ENCLAVE_THREAD_BINDING_OFFSET ==
+        OE_OFFSETOF(oe_enclave_t, bindings));
+
+    OE_TEST(THREAD_BINDING_SIZE == sizeof(ThreadBinding));
+    OE_TEST(THREAD_BINDING_HEADER_LENGTH == OE_OFFSETOF(ThreadBinding, thread));
+    OE_TEST(strcmp((const char*)THREAD_BINDING_HEADER_FORMAT, "Q") == 0);
+
+    printf("Debugger contract validated on host side.\n");
+}

--- a/tests/debugger/oegdb/host/contract.c
+++ b/tests/debugger/oegdb/host/contract.c
@@ -7,26 +7,26 @@
 #include <string.h>
 #include "../../../../host/sgx/enclave.h"
 
+// These values are filled by the debugger.
+// The variables are marked volatile so that the compiler does not hard-code
+// the initialization value of the variables in comparision.
+// Since 0 could be a legal value for some of these items, they are
+// initialized to -1.
+volatile uint64_t OE_ENCLAVE_MAGIC_FIELD = (uint64_t)-1;
+volatile uint64_t OE_ENCLAVE_ADDR_FIELD = (uint64_t)-1;
+volatile uint64_t OE_ENCLAVE_HEADER_LENGTH = (uint64_t)-1;
+volatile char OE_ENCLAVE_HEADER_FORMAT[10];
+volatile uint64_t OE_ENCLAVE_MAGIC_VALUE = (uint64_t)-1;
+volatile uint64_t OE_ENCLAVE_FLAGS_OFFSET = (uint64_t)-1;
+volatile uint64_t OE_ENCLAVE_FLAGS_LENGTH = (uint64_t)-1;
+volatile char OE_ENCLAVE_FLAGS_FORMAT[10];
+volatile uint64_t OE_ENCLAVE_THREAD_BINDING_OFFSET = (uint64_t)-1;
+volatile uint64_t THREAD_BINDING_SIZE = (uint64_t)-1;
+volatile uint64_t THREAD_BINDING_HEADER_LENGTH = (uint64_t)-1;
+volatile char THREAD_BINDING_HEADER_FORMAT[10];
+
 void assert_debugger_binary_contract_host_side()
 {
-    // These values are filled by the debugger.
-    // The variables are marked volatile so that the compiler does not hard-code
-    // the initialization value of the variables in comparision.
-    // Since 0 could be a legal value for some of these items, they are
-    // initialized to -1.
-    static volatile uint64_t OE_ENCLAVE_MAGIC_FIELD = (uint64_t)-1;
-    static volatile uint64_t OE_ENCLAVE_ADDR_FIELD = (uint64_t)-1;
-    static volatile uint64_t OE_ENCLAVE_HEADER_LENGTH = (uint64_t)-1;
-    static volatile char OE_ENCLAVE_HEADER_FORMAT[10];
-    static volatile uint64_t OE_ENCLAVE_MAGIC_VALUE = (uint64_t)-1;
-    static volatile uint64_t OE_ENCLAVE_FLAGS_OFFSET = (uint64_t)-1;
-    static volatile uint64_t OE_ENCLAVE_FLAGS_LENGTH = (uint64_t)-1;
-    static volatile char OE_ENCLAVE_FLAGS_FORMAT[10];
-    static volatile uint64_t OE_ENCLAVE_THREAD_BINDING_OFFSET = (uint64_t)-1;
-    static volatile uint64_t THREAD_BINDING_SIZE = (uint64_t)-1;
-    static volatile uint64_t THREAD_BINDING_HEADER_LENGTH = (uint64_t)-1;
-    static volatile char THREAD_BINDING_HEADER_FORMAT[10];
-
     OE_TEST(OE_ENCLAVE_MAGIC_FIELD == OE_OFFSETOF(oe_enclave_t, magic));
     OE_TEST(OE_ENCLAVE_ADDR_FIELD == OE_OFFSETOF(oe_enclave_t, addr));
     OE_TEST(OE_ENCLAVE_HEADER_LENGTH == OE_OFFSETOF(oe_enclave_t, bindings));

--- a/tests/debugger/oegdb/host/host.c
+++ b/tests/debugger/oegdb/host/host.c
@@ -4,11 +4,14 @@
 #include <limits.h>
 #include <openenclave/host.h>
 #include <openenclave/internal/error.h>
+#include <openenclave/internal/sgxtypes.h>
 #include <openenclave/internal/tests.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "oe_gdb_test_u.h"
+
+extern void assert_debugger_binary_contract_host_side();
 
 int main(int argc, const char* argv[])
 {
@@ -46,6 +49,9 @@ int main(int argc, const char* argv[])
         // enclave.
         OE_TEST(c == 10000);
     }
+
+    assert_debugger_binary_contract_host_side();
+    OE_TEST(enc_assert_debugger_binary_contract(enclave1) == OE_OK);
 
     result = oe_terminate_enclave(enclave1);
     OE_TEST(result == OE_OK);

--- a/tests/debugger/oegdb/oe_gdb_test.edl
+++ b/tests/debugger/oegdb/oe_gdb_test.edl
@@ -4,7 +4,7 @@
 enclave {
     trusted {
         public int enc_add(int a, int b);
-	public void enc_assert_debugger_binary_contract();
+        public void enc_assert_debugger_binary_contract();
     };
 
     untrusted {

--- a/tests/debugger/oegdb/oe_gdb_test.edl
+++ b/tests/debugger/oegdb/oe_gdb_test.edl
@@ -4,6 +4,7 @@
 enclave {
     trusted {
         public int enc_add(int a, int b);
+	public void enc_assert_debugger_binary_contract();
     };
 
     untrusted {


### PR DESCRIPTION
Fixes #1708 

oe_enclave_t offsets here:
https://github.com/Microsoft/openenclave/blob/113a8bf22768b3152d57b31085e1cb981556ed99/host/sgx/enclave.h#L136-L139