### PR TITLE
[CI/CD] Fix CI shared lib race condition

### DIFF
--- a/src/jenkins/common/Openenclave.groovy
+++ b/src/jenkins/common/Openenclave.groovy
@@ -18,7 +18,7 @@ String dockerImage(String tag, String dockerfile = ".jenkins/Dockerfile", String
 
 def ContainerRun(String imageName, String compiler, String task, String runArgs="") {
     docker.withRegistry("https://oejenkinscidockerregistry.azurecr.io", "oejenkinscidockerregistry") {
-        image = docker.image("${imageName}:latest")
+        def image = docker.image("${imageName}:latest")
         image.pull()
         image.inside(runArgs) {
             dir("${WORKSPACE}/build") {
@@ -36,7 +36,7 @@ def azureEnvironment(String task) {
                          string(credentialsId: 'OSCTLabSubID', variable: 'SUBSCRIPTION_ID'),
                          string(credentialsId: 'TenantID', variable: 'TENANT_ID')]) {
             docker.withRegistry("https://oejenkinscidockerregistry.azurecr.io", "oejenkinscidockerregistry") {
-                image = docker.image("oetools-deploy:latest")
+                def image = docker.image("oetools-deploy:latest")
                 image.pull()
                 image.inside {
                     sh "${task}"


### PR DESCRIPTION
Variables declared in Jenkins groovy pipeline logic without any
type or the keyword `def` are considered global by default.
Every global variable is shared among parallel stages with all
the nodes.

The `image` variable from the CI shared library was meant to be
a local variable, but due to the fact that we lacked `def` or
any type when declaring the variable, this was considered global
and caused a lot of race conditions, and random transient failures.