### PR TITLE
[Ansible] General cleanup and add missing APT package

### DIFF
--- a/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
+++ b/scripts/ansible/roles/linux/docker/tasks/ci-setup.yml
@@ -5,29 +5,13 @@
 - name: Gather Ansible facts
   setup:
 
-- name: Set the names list of the APT packages to be installed
-  block:
-    - set_fact:
-        pkg_names:
-          - "automake"
-          - "dh-exec"
-          - "dpkg-dev"
-          - "gawk"
-          - "git"
-          - "libmbedtls10"
-          - "sudo"
-
-    - set_fact:
-        pkg_names: "{{ pkg_names }} + {{ ['libcurl3', 'libprotobuf9v5'] }}"
-      when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial'
-
-    - set_fact:
-        pkg_names: "{{ pkg_names }} + {{ ['libcurl4', 'libprotobuf10'] }}"
-      when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'bionic'
+- name: Include vars
+  include_vars:
+    file: "{{ ansible_distribution_release | lower }}.yml"
 
 - name: Install Docker prerequisite packages
   apt:
-    name: "{{ pkg_names }}"
+    name: "{{ ci_apt_packages }}"
     state: present
     update_cache: yes
     install_recommends: no

--- a/scripts/ansible/roles/linux/docker/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/docker/vars/bionic.yml
@@ -4,3 +4,14 @@
 ---
 apt_packages:
   - "docker-ce=5:18.09.3~3-0~ubuntu-bionic"
+
+ci_apt_packages:
+  - "automake"
+  - "dh-exec"
+  - "dpkg-dev"
+  - "gawk"
+  - "git"
+  - "libmbedtls10"
+  - "sudo"
+  - "libcurl4"
+  - "libprotobuf10"

--- a/scripts/ansible/roles/linux/docker/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/docker/vars/xenial.yml
@@ -4,3 +4,14 @@
 ---
 apt_packages:
   - "docker-ce=5:18.09.3~3-0~ubuntu-xenial"
+
+ci_apt_packages:
+  - "automake"
+  - "dh-exec"
+  - "dpkg-dev"
+  - "gawk"
+  - "git"
+  - "libmbedtls10"
+  - "sudo"
+  - "libcurl3"
+  - "libprotobuf9v5"

--- a/scripts/ansible/roles/linux/openenclave/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/bionic.yml
@@ -22,3 +22,4 @@ apt_packages:
   - "libexpat1-dev"
   - "libtool"
   - "subversion"
+  - "libcurl4-openssl-dev"

--- a/scripts/ansible/roles/linux/openenclave/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/xenial.yml
@@ -22,3 +22,4 @@ apt_packages:
   - "libexpat1-dev"
   - "libtool"
   - "subversion"
+  - "libcurl4-openssl-dev"


### PR DESCRIPTION
* Cleanup platform specific packages names. Add the list of APT packages names to be installed to the
variables files, and cleanup the dirty `if` from the Ansible tasks.
* Add `libcurl4-openssl-dev` to the APT packages list. This is needed when running the testing jobs for Azure-DCAP-Client with Open Enclave.