### PR TITLE
Cleanup samples v2 and fix ctest failure on 2nd PASS with remote attestation

### DIFF
--- a/samples/local_attestation/README.md
+++ b/samples/local_attestation/README.md
@@ -34,23 +34,23 @@ For two enclaves on the same system to locally attest each other, the enclaves n
 
 Here are the basic steps of a typical local attestation between two enclaves.
 
-Let's say two enclaves involved are enclave1 and enclave2.
+Let's say two enclaves involved are enclave_a and enclave_b.
 
-1. Inside enclave1, call `oe_get_report` to get enclave1's report, then call `oe_get_target_info` on enclave1's report
-   to get enclave1's target info, enclave1's identity.
+1. Inside enclave_a, call `oe_get_report` to get enclave_a's report, then call `oe_get_target_info` on enclave_a's report
+   to get enclave_a's target info, enclave_a's identity.
 
-2. Send enclave1's identity to enclave2.
+2. Send enclave_a's identity to enclave_b.
 
-3. Inside enclave2, create an **enclave2 report targeted at enclave1**, that is, a report with enclave2's identity
-   signed so that enclave1 can verify it.
+3. Inside enclave_b, create an **enclave_b report targeted at enclave_a**, that is, a report with enclave_b's identity
+   signed so that enclave_a can verify it.
 
-4. Send the enclave2 report above to enclave1.
+4. Send the enclave_b report above to enclave_a.
 
-5. Inside enclave1, call `oe_verify_report` to verify enclave2 report, on success, it means enclave2 was successfully attested to enclave1.
+5. Inside enclave_a, call `oe_verify_report` to verify enclave_b report, on success, it means enclave_b was successfully attested to enclave_a.
 
-Step 1-5 completes the process of local attesting enclave2 to enclave1
+Step 1-5 completes the process of local attesting enclave_b to enclave_a
 
-Repeating step 1-4 with reverse roles of enclave1 and enclave2 can achieve attesting enclave1 to enclave2.
+Repeating step 1-4 with reverse roles of enclave_a and enclave_b can achieve attesting enclave_a to enclave_b.
 
 ### Authoring the Host
 
@@ -58,7 +58,7 @@ The host application coordinates the local attestation steps described above for
 
 The host does the following in this sample:
 
-1. Create two enclaves for attesting each other, let's say they are enclave1 and enclave2
+1. Create two enclaves for attesting each other, let's say they are enclave_a and enclave_b
 
     ```c
     oe_create_localattestation_enclave( enclaveImagePath, OE_ENCLAVE_TYPE_SGX, OE_ENCLAVE_FLAG_DEBUG, NULL, 0, &enclave);
@@ -67,13 +67,13 @@ The host does the following in this sample:
 2.  Attest enclave 1 to enclave 2
 
     ```c
-    attest_one_enclave_to_the_other("enclave1", enclave1, "enclave2", enclave2);
+    attest_one_enclave_to_the_other("enclave_a", enclave_a, "enclave_b", enclave_b);
     ```
 
 3. Attest enclave 2 to enclave 1
 
     ```c
-    attest_one_enclave_to_the_other("enclave2", enclave2, "enclave1", enclave1);
+    attest_one_enclave_to_the_other("enclave_b", enclave_b, "enclave_a", enclave_a);
     ```
 
     With successfully attestation on each other, we are ready to securely exchange data between enclaves via asymmetric encryption.
@@ -81,7 +81,7 @@ The host does the following in this sample:
 4. Get encrypted message from 1st enclave
 
     ```c
-    generate_encrypted_message(enclave1, &ret, &encrypted_msg, &encrypted_msg_size);
+    generate_encrypted_message(enclave_a, &ret, &encrypted_msg, &encrypted_msg_size);
     ```
 
 5. Sending the encrypted message to 2nd enclave to decrypt and validate if the decrypted 
@@ -90,22 +90,22 @@ The host does the following in this sample:
    Note: both enclaves hardcode their sample messages for this validation.
 
     ```c
-    process_encrypted_msg(enclave2, &ret, encrypted_msg, encrypted_msg_size);
+    process_encrypted_msg(enclave_b, &ret, encrypted_msg, encrypted_msg_size);
     ```
 
 #### attest_one_enclave_to_the_other() routine
 
-This routine handles the process of attesting enclave2 to enclave1 with the following three steps.
+This routine handles the process of attesting enclave_b to enclave_a with the following three steps.
 
 ```c
-get_target_info(enclave1, &ret, &target_info_buf, &target_info_size);
+get_target_info(enclave_a, &ret, &target_info_buf, &target_info_size);
 
-get_targeted_report_with_pubkey(enclave2, &ret,
+get_targeted_report_with_pubkey(enclave_b, &ret,
                                 target_info_buf, target_info_size,
                                 &pem_key, &pem_key_size,
                                 &report, &report_size);
 
-verify_report_and_set_pubkey(enclave1, &ret, 
+verify_report_and_set_pubkey(enclave_a, &ret,
                              pem_key,pem_key_size,
                              report, report_size);
 ```
@@ -135,7 +135,7 @@ On a successful return, target_info_buffer will be deposited with platform speci
 
 ##### 2) Generate a targeted report with the other enclave's target info (identity)
 
-Inside enclave 2, call oe_get_report with the target info as opt_params. This creates a enclave2 report that' targeted at enclave 1, 
+Inside enclave 2, call oe_get_report with the target info as opt_params. This creates a enclave_b report that' targeted at enclave 1,
 that is, for enclave 1 to validate.
 
 ```c

--- a/samples/local_attestation/host/host.cpp
+++ b/samples/local_attestation/host/host.cpp
@@ -113,8 +113,8 @@ exit:
 }
 int main(int argc, const char* argv[])
 {
-    oe_enclave_t* enclave1 = NULL;
-    oe_enclave_t* enclave2 = NULL;
+    oe_enclave_t* enclave_a = NULL;
+    oe_enclave_t* enclave_b = NULL;
     uint8_t* encrypted_msg = NULL;
     size_t encrypted_msg_size = 0;
     oe_result_t result = OE_OK;
@@ -128,20 +128,20 @@ int main(int argc, const char* argv[])
     }
 
     printf("Host: Creating two enclaves\n");
-    enclave1 = create_enclave(argv[1]);
-    if (enclave1 == NULL)
+    enclave_a = create_enclave(argv[1]);
+    if (enclave_a == NULL)
     {
         goto exit;
     }
-    enclave2 = create_enclave(argv[2]);
-    if (enclave2 == NULL)
+    enclave_b = create_enclave(argv[2]);
+    if (enclave_b == NULL)
     {
         goto exit;
     }
 
     // attest enclave 2 to enclave 1
     ret = attest_one_enclave_to_the_other(
-        "enclave1", enclave1, "enclave2", enclave2);
+        "enclave_a", enclave_a, "enclave_b", enclave_b);
     if (ret)
     {
         printf("Host: attestation failed with %d\n", ret);
@@ -150,7 +150,7 @@ int main(int argc, const char* argv[])
 
     // attest enclave 1 to enclave 2
     ret = attest_one_enclave_to_the_other(
-        "enclave2", enclave2, "enclave1", enclave1);
+        "enclave_b", enclave_b, "enclave_a", enclave_a);
     if (ret)
     {
         printf("Host: attestation failed with %d\n", ret);
@@ -161,7 +161,7 @@ int main(int argc, const char* argv[])
     // data between enclaves, securely via asymmetric encryption
     printf("Host: Requesting encrypted message from 1st enclave\n");
     result = generate_encrypted_message(
-        enclave1, &ret, &encrypted_msg, &encrypted_msg_size);
+        enclave_a, &ret, &encrypted_msg, &encrypted_msg_size);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -174,7 +174,7 @@ int main(int argc, const char* argv[])
 
     printf("Host: Sending the encrypted message to 2nd enclave\n");
     result = process_encrypted_msg(
-        enclave2, &ret, encrypted_msg, encrypted_msg_size);
+        enclave_b, &ret, encrypted_msg, encrypted_msg_size);
     if ((result != OE_OK) || (ret != 0))
     {
         printf("Host: process_encrypted_msg failed. %s", oe_result_str(result));
@@ -194,7 +194,7 @@ int main(int argc, const char* argv[])
 
     printf("Host: Requesting encrypted message from 2nd enclave\n");
     result = generate_encrypted_message(
-        enclave2, &ret, &encrypted_msg, &encrypted_msg_size);
+        enclave_b, &ret, &encrypted_msg, &encrypted_msg_size);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -207,7 +207,7 @@ int main(int argc, const char* argv[])
 
     printf("Sending encrypted message to 1st  enclave=====\n");
     result = process_encrypted_msg(
-        enclave1, &ret, encrypted_msg, encrypted_msg_size);
+        enclave_a, &ret, encrypted_msg, encrypted_msg_size);
     if ((result != OE_OK) || (ret != 0))
     {
         printf("host process_encrypted_msg failed. %s", oe_result_str(result));
@@ -228,11 +228,11 @@ exit:
         free(encrypted_msg);
 
     printf("Host: Terminating enclaves\n");
-    if (enclave1)
-        terminate_enclave(enclave1);
+    if (enclave_a)
+        terminate_enclave(enclave_a);
 
-    if (enclave2)
-        terminate_enclave(enclave2);
+    if (enclave_b)
+        terminate_enclave(enclave_b);
 
     printf("Host:  %s \n", (ret == 0) ? "succeeded" : "failed");
     return ret;

--- a/samples/remote_attestation/Makefile
+++ b/samples/remote_attestation/Makefile
@@ -18,4 +18,4 @@ clean:
 	$(MAKE) -C host clean
 
 run:
-	host/attestation_host ./enclave_a/enclave1.signed ./enclave_b/enclave2.signed
+	host/attestation_host ./enclave_a/enclave_a.signed ./enclave_b/enclave_b.signed

--- a/samples/remote_attestation/README.md
+++ b/samples/remote_attestation/README.md
@@ -70,15 +70,15 @@ The host process is what drives the enclave app. It is responsible for managing 
 
 The host does the following in this sample:
 
-   1. Create two enclaves for attesting each other, let's say they are enclave1 and enclave2
+   1. Create two enclaves for attesting each other, let's say they are enclave_a and enclave_b
 
       ```c
       oe_create_remoteattestation_enclave( enclaveImagePath, OE_ENCLAVE_TYPE_SGX, OE_ENCLAVE_FLAG_DEBUG, NULL, 0, &enclave);
       ```
 
-   2. Ask enclave1 for a remote report and a public key, which is returned in a `RemoteReportWithPKey` structure.
+   2. Ask enclave_a for a remote report and a public key, which is returned in a `RemoteReportWithPKey` structure.
 
-      This is done through a call into the enclave1 `GetRemoteReportWithPKey` `OE_ECALL`
+      This is done through a call into the enclave_a `GetRemoteReportWithPKey` `OE_ECALL`
 
       ```c
       oe_call_enclave(enclave, "GetRemoteReportWithPKey", &args);
@@ -93,20 +93,20 @@ The host does the following in this sample:
 
       Where:
 
-        - `pem_key` holds the public key that identifying enclave1 and will be used for establishing a secure communication channel between the enclave1 and the enclave2 once the attestation was done.
+        - `pem_key` holds the public key that identifying enclave_a and will be used for establishing a secure communication channel between the enclave_a and the enclave_b once the attestation was done.
 
         - `remote_report` contains a remote report signed by the enclave platform for use in remote attestation
 
-   3. Ask enclave2 to attest (validate) enclave1's remote report (remote_report from above)
+   3. Ask enclave_b to attest (validate) enclave_a's remote report (remote_report from above)
 
       This is done through the following call:
       ```c
       oe_call_enclave(enclave, "VerifyReportAndSetPKey", &args);
       ```
 
-      In the enclave2's implmentation of `VerifyReportAndSetPKey`, it calls `oe_verify_report`, which will be described in the enclave section to handle all the platform specfic report validation operations (including PCK certificate chain checking). If successful the public key in `RemoteReportWithPKey.pem_key` will be stored inside the enclave for future use
+      In the enclave_b's implmentation of `VerifyReportAndSetPKey`, it calls `oe_verify_report`, which will be described in the enclave section to handle all the platform specfic report validation operations (including PCK certificate chain checking). If successful the public key in `RemoteReportWithPKey.pem_key` will be stored inside the enclave for future use
 
-   4. Repeat step 2 and 3 for asking enclave1 to validate enclave2
+   4. Repeat step 2 and 3 for asking enclave_a to validate enclave_b
   
    5. After both enclaves successfully attest each other, use Asymmetric/Public-Key Encryption to establish secure communications between the two attesting enclaves.
   
@@ -115,13 +115,13 @@ The host does the following in this sample:
    6. Send encrypted messages securely between enclaves
 
       ```c
-      // Ask enclave1 to encrypt an internal data with its private key and output encrypted message in encrypted_msg
-      generate_encrypted_message(enclave1, &encrypted_msg, &encrypted_msg_size);
+      // Ask enclave_a to encrypt an internal data with its private key and output encrypted message in encrypted_msg
+      generate_encrypted_message(enclave_a, &encrypted_msg, &encrypted_msg_size);
 
-      // Send encrypted_msg to the enclave2, which will decrypt it and comparing with its internal data,
+      // Send encrypted_msg to the enclave_b, which will decrypt it and comparing with its internal data,
       // In this sample, it starts both enclaves with the exact same data contents for the purpose of
       // demonstrating that the encryption works as expected
-      process_encrypted_msg(enclave2, encrypted_msg, encrypted_msg_size);
+      process_encrypted_msg(enclave_b, encrypted_msg, encrypted_msg_size);
       ```
 
    7. Free the resource used, including the host memory allocated by the enclaves and the enclaves themselves
@@ -129,8 +129,8 @@ The host does the following in this sample:
       For example:
 
       ```c
-      oe_terminate_enclave(enclave1);
-      oe_terminate_enclave(enclave2);
+      oe_terminate_enclave(enclave_a);
+      oe_terminate_enclave(enclave_b);
       ```
 
 ### Authoring the Enclave

--- a/samples/remote_attestation/enclave_a/Makefile
+++ b/samples/remote_attestation/enclave_a/Makefile
@@ -48,10 +48,10 @@ build:
 	oeedger8r ../remoteattestation.edl --trusted --trusted-dir ../common
 	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
 	$(CC) -g -c $(CFLAGS) $(CINCLUDES) -I.. -DOE_API_VERSION=2 ../common/remoteattestation_t.c
-	$(CXX) -o enclave1 attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS)
+	$(CXX) -o enclave_a attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS)
 
 sign:
-	oesign sign -e enclave1 -c enc.conf -k private.pem
+	oesign sign -e enclave_a -c enc.conf -k private.pem
 
 clean:
-	rm -f *.o enclave1 enclave1.signed ../common/remoteattestation_t.* ../common/remoteattestation_args.h *.pem enclave_b_pubkey.h
+	rm -f *.o enclave_a enclave_a.signed ../common/remoteattestation_t.* ../common/remoteattestation_args.h *.pem enclave_b_pubkey.h

--- a/samples/remote_attestation/enclave_b/Makefile
+++ b/samples/remote_attestation/enclave_b/Makefile
@@ -47,13 +47,13 @@ build:
 	@ echo "Compilers used: $(CC), $(CXX)"
 	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -I.. -std=c++11 -DOE_API_VERSION=2 ecalls.cpp ../common/attestation.cpp ../common/crypto.cpp ../common/dispatcher.cpp
 	$(CC) -g -c $(CFLAGS) $(CINCLUDES) -I.. -DOE_API_VERSION=2 ../common/remoteattestation_t.c
-	$(CXX) -o enclave2 attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS)
+	$(CXX) -o enclave_b attestation.o crypto.o ecalls.o dispatcher.o remoteattestation_t.o $(LDFLAGS)
 
 sign:
-	oesign sign -e enclave2 -c enc.conf -k private.pem
+	oesign sign -e enclave_b -c enc.conf -k private.pem
 
 clean:
-	rm -f *.o enclave2 enclave2.signed ../common/remoteattestation_t.* ../common/remoteattestation_args.h *.pem enclave_a_pubkey.h
+	rm -f *.o enclave_b enclave_b.signed ../common/remoteattestation_t.* ../common/remoteattestation_args.h *.pem enclave_a_pubkey.h
 
 
 

--- a/samples/remote_attestation/host/host.cpp
+++ b/samples/remote_attestation/host/host.cpp
@@ -39,8 +39,8 @@ void terminate_enclave(oe_enclave_t* enclave)
 
 int main(int argc, const char* argv[])
 {
-    oe_enclave_t* enclave1 = NULL;
-    oe_enclave_t* enclave2 = NULL;
+    oe_enclave_t* enclave_a = NULL;
+    oe_enclave_t* enclave_b = NULL;
     uint8_t* encrypted_msg = NULL;
     size_t encrypted_msg_size = 0;
     oe_result_t result = OE_OK;
@@ -58,13 +58,13 @@ int main(int argc, const char* argv[])
     }
 
     printf("Host: Creating two enclaves\n");
-    enclave1 = create_enclave(argv[1]);
-    if (enclave1 == NULL)
+    enclave_a = create_enclave(argv[1]);
+    if (enclave_a == NULL)
     {
         goto exit;
     }
-    enclave2 = create_enclave(argv[2]);
-    if (enclave2 == NULL)
+    enclave_b = create_enclave(argv[2]);
+    if (enclave_b == NULL)
     {
         goto exit;
     }
@@ -72,7 +72,7 @@ int main(int argc, const char* argv[])
     printf("Host: requesting a remote report and the encryption key from 1st "
            "enclave\n");
     result = get_remote_report_with_pubkey(
-        enclave1,
+        enclave_a,
         &ret,
         &pem_key,
         &pem_key_size,
@@ -92,7 +92,7 @@ int main(int argc, const char* argv[])
     printf("Host: requesting 2nd enclave to attest 1st enclave's the remote "
            "report and the public key\n");
     result = verify_report_and_set_pubkey(
-        enclave2,
+        enclave_b,
         &ret,
         pem_key,
         pem_key_size,
@@ -115,7 +115,7 @@ int main(int argc, const char* argv[])
     printf("Host: Requesting a remote report and the encryption key from "
            "2nd enclave=====\n");
     result = get_remote_report_with_pubkey(
-        enclave2,
+        enclave_b,
         &ret,
         &pem_key,
         &pem_key_size,
@@ -136,7 +136,7 @@ int main(int argc, const char* argv[])
     printf("Host: Requesting first enclave to attest 2nd enclave's "
            "remote report and the public key=====\n");
     result = verify_report_and_set_pubkey(
-        enclave1,
+        enclave_a,
         &ret,
         pem_key,
         pem_key_size,
@@ -159,7 +159,7 @@ int main(int argc, const char* argv[])
     // exchange data between enclaves, securely
     printf("Host: Requesting encrypted message from 1st enclave\n");
     result = generate_encrypted_message(
-        enclave1, &ret, &encrypted_msg, &encrypted_msg_size);
+        enclave_a, &ret, &encrypted_msg, &encrypted_msg_size);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -172,7 +172,7 @@ int main(int argc, const char* argv[])
 
     printf("Host: Sending the encrypted message to 2nd enclave\n");
     result = process_encrypted_msg(
-        enclave2, &ret, encrypted_msg, encrypted_msg_size);
+        enclave_b, &ret, encrypted_msg, encrypted_msg_size);
     if ((result != OE_OK) || (ret != 0))
     {
         printf("Host: process_encrypted_msg failed. %s", oe_result_str(result));
@@ -188,7 +188,7 @@ int main(int argc, const char* argv[])
 
     printf("Host: Requesting encrypted message from 2nd enclave\n");
     result = generate_encrypted_message(
-        enclave2, &ret, &encrypted_msg, &encrypted_msg_size);
+        enclave_b, &ret, &encrypted_msg, &encrypted_msg_size);
     if ((result != OE_OK) || (ret != 0))
     {
         printf(
@@ -201,7 +201,7 @@ int main(int argc, const char* argv[])
 
     printf("Sending encrypted message to 1st  enclave=====\n");
     result = process_encrypted_msg(
-        enclave1, &ret, encrypted_msg, encrypted_msg_size);
+        enclave_a, &ret, encrypted_msg, encrypted_msg_size);
     if ((result != OE_OK) || (ret != 0))
     {
         printf("host process_encrypted_msg failed. %s", oe_result_str(result));
@@ -227,11 +227,11 @@ exit:
         free(encrypted_msg);
 
     printf("Host: Terminating enclaves\n");
-    if (enclave1)
-        terminate_enclave(enclave1);
+    if (enclave_a)
+        terminate_enclave(enclave_a);
 
-    if (enclave2)
-        terminate_enclave(enclave2);
+    if (enclave_b)
+        terminate_enclave(enclave_b);
 
     printf("Host:  %s \n", (ret == 0) ? "succeeded" : "failed");
     return ret;

--- a/samples/test-samples.cmake
+++ b/samples/test-samples.cmake
@@ -29,6 +29,8 @@ else ()
 endif ()
 
 # Install the SDK from current build to a known location in the build tree.
+# Make sure the directory in which we try to install does not exist.
+execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory ${BUILD_DIR}/install${PREFIX_DIR})
 execute_process(COMMAND ${CMAKE_COMMAND} -E env DESTDIR=${BUILD_DIR}/install ${CMAKE_COMMAND} --build ${BUILD_DIR} --target install)
 
 # The prefix is appended to the value given to DESTDIR, e.g. build/install/opt/openenclave/...


### PR DESCRIPTION
[samples] Makefile: rename enclave1 to enclave_a and enclave2 to enclave_b
[samples] CMAKE: Make the test install directory does not exist - Fixes #1715 
[samples] local_attestation: Change code and readme to reflect new enclave naming convention
[samples] remote_attestation: Change code and readme to reflect new enclave naming convention