### PR TITLE
Refactor oe_cert_verify to remove error string return

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -99,6 +99,10 @@ const char* oe_result_str(oe_result_t result)
             return "OE_UNSUPPORTED_ENCLAVE_IMAGE";
         case OE_VERIFY_CRL_EXPIRED:
             return "OE_VERIFY_CRL_EXPIRED";
+        case OE_VERIFY_CRL_MISSING:
+            return "OE_VERIFY_CRL_MISSING";
+        case OE_VERIFY_REVOKED:
+            return "OE_VERIFY_REVOKED";
         case __OE_RESULT_MAX:
             break;
     }

--- a/common/sgx/revocation.c
+++ b/common/sgx/revocation.c
@@ -160,14 +160,12 @@ oe_result_t oe_enforce_revocation(
     oe_cert_chain_t* pck_cert_chain)
 {
     oe_result_t result = OE_FAILURE;
-    oe_result_t r = OE_FAILURE;
     ParsedExtensionInfo parsed_extension_info = {{0}};
     oe_get_revocation_info_args_t revocation_args = {0};
     oe_cert_chain_t tcb_issuer_chain = {0};
     oe_cert_chain_t crl_issuer_chain[3] = {{{0}}};
     oe_parsed_tcb_info_t parsed_tcb_info = {0};
     oe_tcb_level_t platform_tcb_level = {{0}};
-    oe_verify_cert_error_t cert_verify_error = {0};
     char* intermediate_crl_url = NULL;
     char* leaf_crl_url = NULL;
     oe_crl_t crls[2] = {{{0}}};
@@ -240,13 +238,7 @@ oe_result_t oe_enforce_revocation(
     // constraint. If the crl_issuer_chain was different from the certificate
     // chain, then verification would fail because the CRLs will not be found
     // for certificates in the chain.
-    r = oe_cert_verify(
-        leaf_cert, &crl_issuer_chain[0], crl_ptrs, 2, &cert_verify_error);
-    if (r != OE_OK)
-    {
-        OE_RAISE_MSG(
-            r, "oe_cer_verify failed with error = %s\n", cert_verify_error.buf);
-    }
+    OE_CHECK(oe_cert_verify(leaf_cert, &crl_issuer_chain[0], crl_ptrs, 2));
 
     for (uint32_t i = 0; i < OE_COUNTOF(platform_tcb_level.sgx_tcb_comp_svn);
          ++i)

--- a/common/sgx/revocation.c
+++ b/common/sgx/revocation.c
@@ -238,7 +238,8 @@ oe_result_t oe_enforce_revocation(
     // constraint. If the crl_issuer_chain was different from the certificate
     // chain, then verification would fail because the CRLs will not be found
     // for certificates in the chain.
-    OE_CHECK(oe_cert_verify(leaf_cert, &crl_issuer_chain[0], crl_ptrs, 2));
+    OE_CHECK(oe_cert_verify(
+        leaf_cert, crl_issuer_chain, crl_ptrs, OE_COUNTOF(crl_ptrs)));
 
     for (uint32_t i = 0; i < OE_COUNTOF(platform_tcb_level.sgx_tcb_comp_svn);
          ++i)
@@ -273,7 +274,7 @@ oe_result_t oe_enforce_revocation(
     for (uint32_t i = 0; i < OE_COUNTOF(crls); ++i)
     {
         OE_CHECK(oe_crl_get_update_dates(
-            &crls[0], &crl_this_update_date, &crl_next_update_date));
+            &crls[i], &crl_this_update_date, &crl_next_update_date));
 
         _trace_datetime("crl this update date ", &crl_this_update_date);
         _trace_datetime("crl next update date ", &crl_next_update_date);

--- a/host/crypto/openssl/cert.c
+++ b/host/crypto/openssl/cert.c
@@ -35,16 +35,6 @@
 /* Randomly generated magic number */
 #define OE_CERT_MAGIC 0xbc8e184285de4d2a
 
-static void _set_err(oe_verify_cert_error_t* error, const char* str)
-{
-    if (error)
-    {
-        error->buf[0] = '\0';
-        oe_strncat_s(
-            error->buf, sizeof(error->buf), str, sizeof(error->buf) - 1);
-    }
-}
-
 typedef struct _cert
 {
     uint64_t magic;
@@ -230,16 +220,6 @@ static int X509_up_ref(X509* x509)
     return 1;
 }
 
-/* Needed because some versions of OpenSSL do not support X509_CRL_up_ref() */
-static int X509_CRL_up_ref(X509_CRL* x509_crl)
-{
-    if (!x509_crl)
-        return 0;
-
-    CRYPTO_add(&x509_crl->references, 1, CRYPTO_LOCK_X509_CRL);
-    return 1;
-}
-
 static const STACK_OF(X509_EXTENSION) * X509_get0_extensions(const X509* x)
 {
     if (!x->cert_info)
@@ -294,48 +274,107 @@ static STACK_OF(X509) * _clone_chain(STACK_OF(X509) * chain)
     return sk;
 }
 
-static oe_result_t _verify_cert(X509* cert_, STACK_OF(X509) * chain_)
+static oe_result_t _verify_cert(
+    X509* cert,
+    STACK_OF(X509) * chain_,
+    const oe_crl_t* const* crls,
+    size_t num_crls)
 {
     oe_result_t result = OE_UNEXPECTED;
     X509_STORE_CTX* ctx = NULL;
-    X509* cert = NULL;
+    X509_STORE* store = NULL;
+    X509* x509 = NULL;
     STACK_OF(X509)* chain = NULL;
 
     /* Clone the certificate to clear any cached verification state */
-    if (!(cert = _clone_x509(cert_)))
-        OE_RAISE(OE_FAILURE);
+    if (!(x509 = _clone_x509(cert)))
+        OE_RAISE_MSG(OE_FAILURE, "Failed to clone X509 cert", NULL);
 
     /* Clone the chain to clear any cached verification state */
     if (!(chain = _clone_chain(chain_)))
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE_MSG(OE_FAILURE, "Failed to clone X509 cert chain", NULL);
+
+    /* Create a store for the verification */
+    if (!(store = X509_STORE_new()))
+        OE_RAISE_MSG(OE_FAILURE, "Failed to allocate X509 store", NULL);
 
     /* Create a context for verification */
     if (!(ctx = X509_STORE_CTX_new()))
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE_MSG(OE_FAILURE, "Failed to create new X509 context", NULL);
 
     /* Initialize the context that will be used to verify the certificate */
-    if (!X509_STORE_CTX_init(ctx, NULL, NULL, NULL))
-        OE_RAISE(OE_FAILURE);
+    if (!X509_STORE_CTX_init(ctx, store, NULL, NULL))
+    {
+        OE_RAISE_MSG(OE_FAILURE, "Failed to initialize X509 context", NULL);
+    }
+
+    /* Create a store with CRLs if needed */
+    if (crls && num_crls)
+    {
+        X509_VERIFY_PARAM* verify_param = NULL;
+
+        for (size_t i = 0; i < num_crls; i++)
+        {
+            crl_t* crl_impl = (crl_t*)crls[i];
+
+            /* X509_STORE_add_crl manages its own addition refcount */
+            if (!X509_STORE_add_crl(store, crl_impl->crl))
+                OE_RAISE_MSG(
+                    OE_FAILURE, "Failed to add CRL to X509 store", NULL);
+        }
+
+        /* Get the verify parameter (must not be null) */
+        if (!(verify_param = X509_STORE_CTX_get0_param(ctx)))
+            OE_RAISE_MSG(
+                OE_FAILURE, "Failed to get X509 verify parameter", NULL);
+
+        X509_VERIFY_PARAM_set_flags(verify_param, X509_V_FLAG_CRL_CHECK);
+        X509_VERIFY_PARAM_set_flags(verify_param, X509_V_FLAG_CRL_CHECK_ALL);
+    }
 
     /* Inject the certificate into the verification context */
-    X509_STORE_CTX_set_cert(ctx, cert);
+    X509_STORE_CTX_set_cert(ctx, x509);
 
     /* Set the CA chain into the verification context */
     X509_STORE_CTX_trusted_stack(ctx, chain);
 
     /* Finally verify the certificate */
     if (!X509_verify_cert(ctx))
-        OE_RAISE(OE_FAILURE);
+    {
+        oe_result_t verify_result = OE_VERIFY_FAILED;
+        int errorno = X509_STORE_CTX_get_error(ctx);
+        switch (errorno)
+        {
+            case X509_V_ERR_CRL_HAS_EXPIRED:
+                verify_result = OE_VERIFY_CRL_EXPIRED;
+                break;
+            case X509_V_ERR_UNABLE_TO_GET_CRL:
+                verify_result = OE_VERIFY_CRL_MISSING;
+                break;
+            case X509_V_ERR_CERT_REVOKED:
+                verify_result = OE_VERIFY_REVOKED;
+                break;
+        }
+        OE_RAISE_MSG(
+            verify_result,
+            "X509_verify_cert failed!\n"
+            " error: (%d) %s\n",
+            errorno,
+            X509_verify_cert_error_string(errorno));
+    }
 
     result = OE_OK;
 
 done:
 
-    if (cert)
-        X509_free(cert);
+    if (x509)
+        X509_free(x509);
 
     if (chain)
         sk_X509_pop_free(chain, X509_free);
+
+    if (store)
+        X509_STORE_free(store);
 
     if (ctx)
         X509_STORE_CTX_free(ctx);
@@ -380,7 +419,7 @@ static oe_result_t _verify_whole_chain(STACK_OF(X509) * chain)
 
     /* Get the root certificate */
     if (!(root = _find_root_cert(chain)))
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_VERIFY_FAILED);
 
     /* Get number of certificates in the chain */
     n = sk_X509_num(chain);
@@ -409,7 +448,8 @@ static oe_result_t _verify_whole_chain(STACK_OF(X509) * chain)
         if (!cert)
             OE_RAISE(OE_FAILURE);
 
-        OE_CHECK(_verify_cert(cert, subchain));
+        /* Verify cert chain without CRL checks */
+        OE_CHECK(_verify_cert(cert, subchain, NULL, 0));
 
         /* Add this certificate to the subchain */
         {
@@ -591,8 +631,8 @@ oe_result_t oe_cert_chain_free(oe_cert_chain_t* chain)
     CertChain* impl = (CertChain*)chain;
 
     /* Check the parameter */
-    if (_cert_chain_is_valid(impl))
-        OE_RAISE_NO_TRACE(OE_INVALID_PARAMETER);
+    if (!_cert_chain_is_valid(impl))
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Release the stack of certificates */
     sk_X509_pop_free(impl->sk, X509_free);
@@ -610,130 +650,33 @@ oe_result_t oe_cert_verify(
     oe_cert_t* cert,
     oe_cert_chain_t* chain,
     const oe_crl_t* const* crls,
-    size_t num_crls,
-    oe_verify_cert_error_t* error)
+    size_t num_crls)
 {
     oe_result_t result = OE_UNEXPECTED;
     Cert* cert_impl = (Cert*)cert;
     CertChain* chain_impl = (CertChain*)chain;
-    X509_STORE_CTX* ctx = NULL;
-    X509_STORE* store = NULL;
-    X509* x509 = NULL;
-
-    /* Initialize error to NULL for now */
-    if (error)
-        *error->buf = '\0';
 
     /* Check for invalid cert parameter */
     if (!_cert_is_valid(cert_impl))
     {
-        _set_err(error, "invalid cert parameter");
-        OE_RAISE(OE_INVALID_PARAMETER);
+        OE_RAISE_MSG(OE_INVALID_PARAMETER, "Invalid cert parameter", NULL);
     }
 
     /* Check for invalid chain parameter */
     if (!_cert_chain_is_valid(chain_impl))
     {
-        _set_err(error, "invalid chain parameter");
-        OE_RAISE(OE_INVALID_PARAMETER);
-    }
-
-    /* We must make a copy of the certificate, else previous successful
-     * verifications cause subsequent bad verifications to succeed. It is
-     * likely that some state is stored in the certificate upon successful
-     * verification. We can clear this by making a copy.
-     */
-    if (!(x509 = _clone_x509(cert_impl->x509)))
-    {
-        _set_err(error, "invalid X509 certificate");
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE_MSG(OE_INVALID_PARAMETER, "Invalid chain parameter", NULL);
     }
 
     /* Initialize OpenSSL (if not already initialized) */
     oe_initialize_openssl();
 
-    /* Create a context for verification */
-    if (!(ctx = X509_STORE_CTX_new()))
-    {
-        _set_err(error, "failed to allocate X509 context");
-        OE_RAISE(OE_FAILURE);
-    }
-
-    /* Create a store for the verification */
-    if (!(store = X509_STORE_new()))
-    {
-        _set_err(error, "failed to allocate X509 store");
-        OE_RAISE(OE_FAILURE);
-    }
-
-    /* Initialize the context that will be used to verify the certificate */
-    if (!X509_STORE_CTX_init(ctx, store, NULL, NULL))
-    {
-        _set_err(error, "failed to initialize X509 context");
-        OE_RAISE(OE_FAILURE);
-    }
-
-    /* Set the certificate into the verification context */
-    X509_STORE_CTX_set_cert(ctx, x509);
-
-    /* Set the CA chain into the verification context */
-    X509_STORE_CTX_trusted_stack(ctx, chain_impl->sk);
-
-    /* Set the CRLs if any */
-    if (crls && num_crls)
-    {
-        X509_VERIFY_PARAM* verify_param;
-
-        for (size_t i = 0; i < num_crls; i++)
-        {
-            crl_t* crl_impl = (crl_t*)crls[i];
-
-            X509_CRL_up_ref(crl_impl->crl);
-
-            if (!X509_STORE_add_crl(store, crl_impl->crl))
-                OE_RAISE(OE_FAILURE);
-        }
-
-        /* Get the verify parameter (must not be null) */
-        if (!(verify_param = X509_STORE_CTX_get0_param(ctx)))
-            OE_RAISE(OE_FAILURE);
-
-        X509_VERIFY_PARAM_set_flags(verify_param, X509_V_FLAG_CRL_CHECK);
-        X509_VERIFY_PARAM_set_flags(verify_param, X509_V_FLAG_CRL_CHECK_ALL);
-    }
-
-    /* Finally verify the certificate */
-    if (!X509_verify_cert(ctx))
-    {
-        int errorno;
-        if (error)
-            _set_err(
-                error,
-                X509_verify_cert_error_string(X509_STORE_CTX_get_error(ctx)));
-
-        errorno = X509_STORE_CTX_get_error(ctx);
-        OE_RAISE_MSG(
-            (X509_V_ERR_CRL_HAS_EXPIRED == errorno) ? OE_VERIFY_CRL_EXPIRED
-                                                    : OE_VERIFY_FAILED,
-            "X509_verify_cert failed!\n"
-            " error: (%d) %s\n",
-            errorno,
-            X509_verify_cert_error_string(errorno));
-    }
+    /* Verify the certificate */
+    OE_CHECK(_verify_cert(cert_impl->x509, chain_impl->sk, crls, num_crls));
 
     result = OE_OK;
 
 done:
-
-    if (ctx)
-        X509_STORE_CTX_free(ctx);
-
-    if (store)
-        X509_STORE_free(store);
-
-    if (x509)
-        X509_free(x509);
-
     return result;
 }
 

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -265,12 +265,12 @@ typedef enum _oe_result
     OE_UNSUPPORTED_ENCLAVE_IMAGE,
 
     /**
-     * The CRL for a PCK certificate has expired.
+     * The CRL for a certificate has expired.
      */
     OE_VERIFY_CRL_EXPIRED,
 
     /**
-     * The CRL for a PCK certificate could not be found.
+     * The CRL for a certificate could not be found.
      */
     OE_VERIFY_CRL_MISSING,
 

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -265,9 +265,19 @@ typedef enum _oe_result
     OE_UNSUPPORTED_ENCLAVE_IMAGE,
 
     /**
-     * The CRL for a PCK certification expired
+     * The CRL for a PCK certificate has expired.
      */
     OE_VERIFY_CRL_EXPIRED,
+
+    /**
+     * The CRL for a PCK certificate could not be found.
+     */
+    OE_VERIFY_CRL_MISSING,
+
+    /**
+     * The certificate or signature has been revoked.
+     */
+    OE_VERIFY_REVOKED,
 
     __OE_RESULT_MAX = OE_ENUM_MAX,
 } oe_result_t;

--- a/include/openenclave/internal/cert.h
+++ b/include/openenclave/internal/cert.h
@@ -25,13 +25,6 @@ typedef struct _oe_cert_chain
     uint64_t impl[4];
 } oe_cert_chain_t;
 
-/* Error message type for oe_verify_cert_error_t() function */
-typedef struct _oe_verify_cert_error
-{
-    /* Zero-terminated string error message */
-    char buf[1024];
-} oe_verify_cert_error_t;
-
 /**
  * Read a certificate from PEM format
  *
@@ -120,7 +113,6 @@ oe_result_t oe_cert_chain_free(oe_cert_chain_t* chain);
  * @param chain verify the certificate against this certificate chain
  * @param crls verify the certificate against these CRLs (may be null).
  * @param num_crls number of CRLs.
- * @param error Optional. Holds the error message if this function failed.
  *
  * @return OE_OK verify ok
  * @return OE_VERIFY_FAILED
@@ -131,8 +123,7 @@ oe_result_t oe_cert_verify(
     oe_cert_t* cert,
     oe_cert_chain_t* chain,
     const oe_crl_t* const* crls,
-    size_t num_crls,
-    oe_verify_cert_error_t* error);
+    size_t num_crls);
 
 /**
  * Get the RSA public key from a certificate.

--- a/tests/crypto/crl_tests.c
+++ b/tests/crypto/crl_tests.c
@@ -44,7 +44,6 @@ static void _test_verify(
 {
     oe_cert_t cert;
     oe_cert_chain_t chain;
-    oe_verify_cert_error_t error = {0};
     oe_result_t r;
 
     r = oe_cert_read_pem(&cert, cert_pem, strlen(cert_pem) + 1);
@@ -59,31 +58,11 @@ static void _test_verify(
     if (crl)
         OE_TEST(num_crl > 0);
 
-    r = oe_cert_verify(&cert, &chain, crl, num_crl, &error);
+    r = oe_cert_verify(&cert, &chain, crl, num_crl);
 
     if (revoked)
     {
-        OE_TEST(r == OE_VERIFY_FAILED);
-
-        /* Look for a revocation error message */
-        {
-            bool found = false;
-            const char* messages[] = {
-                "certificate revoked",
-                "The certificate has been revoked (is on a CRL)",
-            };
-
-            for (size_t i = 0; i < OE_COUNTOF(messages); i++)
-            {
-                if (strstr(error.buf, messages[i]) == 0)
-                {
-                    found = true;
-                    break;
-                }
-            }
-
-            OE_TEST(found);
-        }
+        OE_TEST(r == OE_VERIFY_REVOKED);
     }
     else
     {

--- a/tests/crypto/crl_tests.c
+++ b/tests/crypto/crl_tests.c
@@ -250,13 +250,17 @@ void TestCRL(void)
     OE_TEST(read_cert("../data/Leaf.crt.pem", _CERT2) == OE_OK);
 
     OE_TEST(
-        read_chain("../data/Leaf.crt.pem", "../data/RootCA.crt.pem", _CHAIN1) ==
-        OE_OK);
+        read_chain(
+            "../data/Leaf.crt.pem",
+            "../data/RootCA.crt.pem",
+            _CHAIN1,
+            OE_COUNTOF(_CHAIN1)) == OE_OK);
     OE_TEST(
         read_chain(
             "../data/Intermediate.crt.pem",
             "../data/RootCA.crt.pem",
-            _CHAIN2) == OE_OK);
+            _CHAIN2,
+            OE_COUNTOF(_CHAIN2)) == OE_OK);
 
     OE_TEST(
         read_crl("../data/intermediate_crl.der", _CRL1, &crl_size1) == OE_OK);

--- a/tests/crypto/ec_tests.c
+++ b/tests/crypto/ec_tests.c
@@ -907,7 +907,8 @@ void TestEC()
             "../data/Leafec.crt.pem",
             "../data/Intermediateec.crt.pem",
             "../data/Rootec.crt.pem",
-            _CHAIN) == OE_OK);
+            _CHAIN,
+            OE_COUNTOF(_CHAIN)) == OE_OK);
     OE_TEST(read_key("../data/Rootec.key.pem", _PRIVATE_KEY) == OE_OK);
     OE_TEST(read_key("../data/Rootec.public.key", _PUBLIC_KEY) == OE_OK);
     OE_TEST(

--- a/tests/crypto/read_file.c
+++ b/tests/crypto/read_file.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <ctype.h>
+#include <openenclave/corelibc/string.h>
 #include "readfile.h"
 
 oe_result_t read_cert(char* filename, char* cert)
@@ -21,7 +22,11 @@ oe_result_t read_cert(char* filename, char* cert)
     return OE_OK;
 }
 
-oe_result_t read_chain(char* filename1, char* filename2, char* chain)
+oe_result_t read_chain(
+    char* filename1,
+    char* filename2,
+    char* chain,
+    size_t chain_size)
 {
     size_t len_cert1 = 0, len_cert2 = 0;
     char chain_temp[max_cert_size];
@@ -34,7 +39,7 @@ oe_result_t read_chain(char* filename1, char* filename2, char* chain)
         chain[len_cert1] = '\0';
         len_cert2 = fread(chain_temp, sizeof(char), max_cert_size, cfp2);
         chain_temp[len_cert2] = '\0';
-        strcat(chain, chain_temp);
+        oe_strlcat(chain, chain_temp, chain_size);
     }
     else
     {
@@ -50,7 +55,8 @@ oe_result_t read_chains(
     char* filename1,
     char* filename2,
     char* filename3,
-    char* chain)
+    char* chain,
+    size_t chain_size)
 {
     size_t len_cert1 = 0, len_cert2 = 0, len_cert3 = 0;
     char chain_temp1[max_cert_size];
@@ -67,8 +73,8 @@ oe_result_t read_chains(
         chain_temp1[len_cert2] = '\0';
         len_cert3 = fread(chain_temp2, sizeof(char), max_cert_size, cfp3);
         chain_temp2[len_cert3] = '\0';
-        strcat(chain, chain_temp1);
-        strcat(chain, chain_temp2);
+        oe_strlcat(chain, chain_temp1, chain_size);
+        oe_strlcat(chain, chain_temp2, chain_size);
     }
     else
     {
@@ -226,10 +232,14 @@ oe_result_t read_mod(char* filename, uint8_t* mod, size_t* mod_size)
     return OE_OK;
 }
 
-oe_result_t read_mixed_chain(char* chain, char* chain1, char* chain2)
+oe_result_t read_mixed_chain(
+    char* chain1,
+    char* chain2,
+    char* chain,
+    size_t chain_size)
 {
-    strcat(chain, chain1);
-    strcat(chain, chain2);
+    oe_strlcat(chain, chain1, chain_size);
+    oe_strlcat(chain, chain2, chain_size);
     return OE_OK;
 }
 

--- a/tests/crypto/read_file.c
+++ b/tests/crypto/read_file.c
@@ -228,12 +228,8 @@ oe_result_t read_mod(char* filename, uint8_t* mod, size_t* mod_size)
 
 oe_result_t read_mixed_chain(char* chain, char* chain1, char* chain2)
 {
-    char chain_temp[max_cert_chain_size * 2];
-    OE_UNUSED(chain);
-
-    strcat(chain_temp, chain1);
-    strcat(chain_temp, chain2);
-    chain = chain_temp;
+    strcat(chain, chain1);
+    strcat(chain, chain2);
     return OE_OK;
 }
 

--- a/tests/crypto/readfile.h
+++ b/tests/crypto/readfile.h
@@ -24,13 +24,18 @@
 
 oe_result_t read_cert(char* filename, char* cert);
 
-oe_result_t read_chain(char* filename1, char* filename2, char* chain);
+oe_result_t read_chain(
+    char* filename1,
+    char* filename2,
+    char* chain,
+    size_t chain_size);
 
 oe_result_t read_chains(
     char* filename1,
     char* filename2,
     char* filename3,
-    char* chain);
+    char* chain,
+    size_t chain_size);
 
 oe_result_t read_crl(char* filename, uint8_t* crl, size_t* crl_size);
 
@@ -38,7 +43,11 @@ oe_result_t read_dates(char* filename, oe_datetime_t* time);
 
 oe_result_t read_mod(char* filename, uint8_t* mod, size_t* mod_size);
 
-oe_result_t read_mixed_chain(char* chain, char* chain1, char* chain2);
+oe_result_t read_mixed_chain(
+    char* chain1,
+    char* chain2,
+    char* chain,
+    size_t chain_size);
 
 oe_result_t read_sign(char* filename, uint8_t* sign, size_t* sign_size);
 

--- a/tests/crypto/rsa_tests.c
+++ b/tests/crypto/rsa_tests.c
@@ -113,7 +113,6 @@ static void _test_cert_verify_good()
     printf("=== begin %s()\n", __FUNCTION__);
 
     oe_result_t r;
-    oe_verify_cert_error_t error = {0};
     oe_cert_t cert = {0};
     oe_cert_chain_t chain = {0};
 
@@ -123,7 +122,7 @@ static void _test_cert_verify_good()
     r = oe_cert_chain_read_pem(&chain, CHAIN1, strlen(CHAIN1) + 1);
     OE_TEST(r == OE_OK);
 
-    r = oe_cert_verify(&cert, &chain, NULL, 0, &error);
+    r = oe_cert_verify(&cert, &chain, NULL, 0);
     OE_TEST(r == OE_OK);
 
     oe_cert_free(&cert);
@@ -137,7 +136,6 @@ static void _test_cert_verify_bad()
     printf("=== begin %s()\n", __FUNCTION__);
 
     oe_result_t r;
-    oe_verify_cert_error_t error = {0};
     oe_cert_t cert = {0};
     oe_cert_chain_t chain = {0};
 
@@ -148,7 +146,7 @@ static void _test_cert_verify_bad()
     r = oe_cert_chain_read_pem(&chain, CHAIN2, strlen(CHAIN2) + 1);
     OE_TEST(r == OE_OK);
 
-    r = oe_cert_verify(&cert, &chain, NULL, 0, &error);
+    r = oe_cert_verify(&cert, &chain, NULL, 0);
     OE_TEST(r == OE_VERIFY_FAILED);
 
     oe_cert_free(&cert);
@@ -170,7 +168,7 @@ static void _test_mixed_chain()
 
     /* Chain does not contain a root for this certificate */
     r = oe_cert_chain_read_pem(&chain, MIXED_CHAIN, strlen(MIXED_CHAIN) + 1);
-    OE_TEST(r == OE_FAILURE);
+    OE_TEST(r == OE_VERIFY_FAILED);
 
     oe_cert_free(&cert);
     oe_cert_chain_free(&chain);

--- a/tests/crypto/rsa_tests.c
+++ b/tests/crypto/rsa_tests.c
@@ -448,13 +448,16 @@ void TestRSA(void)
     OE_TEST(read_cert("../data/Leaf.crt.pem", _CERT1) == OE_OK);
     OE_TEST(
         read_chain(
-            "../data/Intermediate.crt.pem", "../data/RootCA.crt.pem", CHAIN1) ==
-        OE_OK);
+            "../data/Intermediate.crt.pem",
+            "../data/RootCA.crt.pem",
+            CHAIN1,
+            OE_COUNTOF(CHAIN1)) == OE_OK);
     OE_TEST(
         read_chain(
             "../data/Intermediate2.crt.pem",
             "../data/RootCA2.crt.pem",
-            CHAIN2) == OE_OK);
+            CHAIN2,
+            OE_COUNTOF(CHAIN2)) == OE_OK);
     OE_TEST(
         read_mod(
             "../data/Leaf_modulus.hex",
@@ -465,7 +468,9 @@ void TestRSA(void)
     OE_TEST(
         read_sign("../data/test_rsa_signature", _SIGNATURE, &sign_size) ==
         OE_OK);
-    OE_TEST(read_mixed_chain(MIXED_CHAIN, CHAIN1, CHAIN2) == OE_OK);
+    OE_TEST(
+        read_mixed_chain(
+            CHAIN1, CHAIN2, MIXED_CHAIN, OE_COUNTOF(MIXED_CHAIN)) == OE_OK);
     _test_cert_methods();
     _test_cert_verify_good();
     _test_cert_verify_bad();

--- a/tests/crypto_crls_cert_chains/common/tests.cpp
+++ b/tests/crypto_crls_cert_chains/common/tests.cpp
@@ -107,31 +107,18 @@ void test_cert_chain_negative(
     // Missing cert in chain.
     OE_TEST(
         create_and_read_chain(std::vector<const char*>{leaf, root}, &chain) ==
-        OE_FAILURE);
+        OE_VERIFY_FAILED);
 
     // Missing cert in chain.
     // Specifically root is missing.
     OE_TEST(
         create_and_read_chain(
             std::vector<const char*>{leaf, intermediate}, &chain) ==
-        OE_FAILURE);
+        OE_VERIFY_FAILED);
 
     oe_cert_chain_free(&chain);
     printf("===test_cert_chain_negative passed\n");
 }
-
-#ifndef OE_BUILD_ENCLAVE
-
-#define ERROR_MSG_CERT_REVOKED "certificate revoked"
-#define ERROR_MSG_MISSING_CRL "unable to get certificate CRL"
-
-#else
-
-#define ERROR_MSG_CERT_REVOKED \
-    "The certificate has been revoked (is on a CRL)\n"
-#define ERROR_MSG_MISSING_CRL "unable to get certificate CRL"
-
-#endif
 
 void test_crls(
     const char* root,
@@ -165,7 +152,6 @@ void test_crls(
     oe_crl_t root_crl2_obj = {0};
     oe_crl_t intermediate_crl1_obj = {0};
     oe_crl_t intermediate_crl2_obj = {0};
-    oe_verify_cert_error_t error = {0};
 
     OE_TEST(
         create_and_read_chain(
@@ -195,50 +181,42 @@ void test_crls(
             intermediate_crl2_size) == OE_OK);
 
     // The following should succeed since no crls are pased in.
-    OE_TEST(oe_cert_verify(&leaf_cert1, &cert_chain, NULL, 0, &error) == OE_OK);
+    OE_TEST(oe_cert_verify(&leaf_cert1, &cert_chain, NULL, 0) == OE_OK);
 
-    OE_TEST(oe_cert_verify(&leaf_cert2, &cert_chain, NULL, 0, &error) == OE_OK);
+    OE_TEST(oe_cert_verify(&leaf_cert2, &cert_chain, NULL, 0) == OE_OK);
 
     // The following should succeed since both crl1s don't revoke any
     // certificates.
     {
         oe_crl_t* crls[] = {&root_crl1_obj, &intermediate_crl1_obj};
-        OE_TEST(
-            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2, &error) == OE_OK);
+        OE_TEST(oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2) == OE_OK);
 
-        OE_TEST(
-            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2, &error) == OE_OK);
+        OE_TEST(oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2) == OE_OK);
 
         // Crls can be given in any order.
         std::swap(crls[0], crls[1]);
-        OE_TEST(
-            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2, &error) == OE_OK);
+        OE_TEST(oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2) == OE_OK);
 
-        OE_TEST(
-            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2, &error) == OE_OK);
+        OE_TEST(oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2) == OE_OK);
     }
 
     // With root_crl1 and intermediate_crl2, leaf1 should pass, but leaf2 should
     // be revoked.
     {
         oe_crl_t* crls[] = {&root_crl1_obj, &intermediate_crl2_obj};
-        OE_TEST(
-            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2, &error) == OE_OK);
+        OE_TEST(oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2) == OE_OK);
 
         OE_TEST(
-            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_CERT_REVOKED) == 0);
+            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2) ==
+            OE_VERIFY_REVOKED);
 
         // Crls can be given in any order.
         std::swap(crls[0], crls[1]);
-        OE_TEST(
-            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2, &error) == OE_OK);
+        OE_TEST(oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2) == OE_OK);
 
         OE_TEST(
-            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_CERT_REVOKED) == 0);
+            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2) ==
+            OE_VERIFY_REVOKED);
     }
 
     // With root_crl2 and intermediate_crl1, both leaf1 and leaf2 should fail.
@@ -246,26 +224,22 @@ void test_crls(
     {
         oe_crl_t* crls[] = {&root_crl2_obj, &intermediate_crl1_obj};
         OE_TEST(
-            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_CERT_REVOKED) == 0);
+            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2) ==
+            OE_VERIFY_REVOKED);
 
         OE_TEST(
-            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_CERT_REVOKED) == 0);
+            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2) ==
+            OE_VERIFY_REVOKED);
 
         // Crls can be given in any order.
         std::swap(crls[0], crls[1]);
         OE_TEST(
-            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_CERT_REVOKED) == 0);
+            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 2) ==
+            OE_VERIFY_REVOKED);
 
         OE_TEST(
-            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_CERT_REVOKED) == 0);
+            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 2) ==
+            OE_VERIFY_REVOKED);
     }
 
     // If you pass CRL for only one of the CAs (i.e. root or intermediate), then
@@ -273,26 +247,22 @@ void test_crls(
     {
         oe_crl_t* crls[] = {&root_crl1_obj};
         OE_TEST(
-            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 1, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_MISSING_CRL) == 0);
+            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 1) ==
+            OE_VERIFY_CRL_MISSING);
 
         OE_TEST(
-            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 1, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_MISSING_CRL) == 0);
+            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 1) ==
+            OE_VERIFY_CRL_MISSING);
 
         // Try out the other crl.
         crls[0] = &intermediate_crl1_obj;
         OE_TEST(
-            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 1, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_MISSING_CRL) == 0);
+            oe_cert_verify(&leaf_cert1, &cert_chain, crls, 1) ==
+            OE_VERIFY_CRL_MISSING);
 
         OE_TEST(
-            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 1, &error) ==
-            OE_VERIFY_FAILED);
-        OE_TEST(strcmp(error.buf, ERROR_MSG_MISSING_CRL) == 0);
+            oe_cert_verify(&leaf_cert2, &cert_chain, crls, 1) ==
+            OE_VERIFY_CRL_MISSING);
     }
 
     /* Clean up */


### PR DESCRIPTION
- Remove optional arg for return error string in oe_cert_verify

   - This was not being percolated to user anyway as part of public
     API (e.g. revocation check) and only checked as part of tests.

   - Tests that use this mechanism were not robust and cannot be
     extended easily to accomodate BCrypt equivalents on Windows,
     which does not return error strings.

- Introduce OE_VERIFY_CRL_MISSING and OE_VERIFY_REVOKED error codes
  as specific error codes that can be checked by tests instead.

- Trace underlying verification errors string with logging methods.

- Update cert.c for host and enclave to consistently return
  OE_VERIFY_FAILED for non-specific failures as part of the
  oe_cert_verify call.

- Consolidate calls to openssl/mbedTLS library for cert verification
  for consistent error handling.

- Fix read_mixed_chain in crypto tests to return a valid buffer.

- Fix openssl version of oe_cert_chain_free to return OE_INVALID_PARAMETER
      when passed an invalid cert chain instead of a valid one.