### PR TITLE
Add phony targest sample makefiles

### DIFF
--- a/samples/data-sealing/Makefile
+++ b/samples/data-sealing/Makefile
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+.PHONY: all build clean run
+
+all: build
+
 build:
 	$(MAKE) -C enclave_a_v1
 	$(MAKE) -C enclave_a_v2

--- a/samples/file-encryptor/Makefile
+++ b/samples/file-encryptor/Makefile
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+.PHONY: all build clean run simulate
+
+all: build
+
 build:
 	$(MAKE) -C enclave
 	$(MAKE) -C host

--- a/samples/helloworld/Makefile
+++ b/samples/helloworld/Makefile
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+.PHONY: all build clean run simulate
+
+all: build
+
 build:
 	$(MAKE) -C enclave
 	$(MAKE) -C host

--- a/samples/local_attestation/Makefile
+++ b/samples/local_attestation/Makefile
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+.PHONY: all build clean run
+
 all: build
 
 build:

--- a/samples/remote_attestation/Makefile
+++ b/samples/remote_attestation/Makefile
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+.PHONY: all build clean run
+
 all: build
 
 build:


### PR DESCRIPTION
[samples][Makefile]: Add phony targets for data-sealing/Makefile
[samples][Makefile]: Add phony targets for file-encryptor/Makefile
[samples][Makefile]: Add phony targets for helloworld/Makefile
[samples][Makefile]: Add phony targets for local_attestation/Makefile
[samples][Makefile]: Add phony targets for remote_attestation/Makefile

Fixes: https://github.com/Microsoft/openenclave/issues/1750