### PR TITLE
[Ansible] Remove version pinning for Docker package

### DIFF
--- a/scripts/ansible/roles/linux/docker/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/docker/vars/bionic.yml
@@ -3,7 +3,7 @@
 
 ---
 apt_packages:
-  - "docker-ce=5:18.09.3~3-0~ubuntu-bionic"
+  - "docker-ce"
 
 ci_apt_packages:
   - "automake"

--- a/scripts/ansible/roles/linux/docker/vars/xenial.yml
+++ b/scripts/ansible/roles/linux/docker/vars/xenial.yml
@@ -3,7 +3,7 @@
 
 ---
 apt_packages:
-  - "docker-ce=5:18.09.3~3-0~ubuntu-xenial"
+  - "docker-ce"
 
 ci_apt_packages:
   - "automake"


### PR DESCRIPTION
The PR https://github.com/Microsoft/openenclave/pull/1746 proposed the removal of version pinning
in Ansible, but the Docker package version pin was omitted.