### PR TITLE
Refactor the edger8r

### DIFF
--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -616,15 +616,19 @@ let oe_gen_ecall_functions (tfs : trusted_func list) =
   if tfs <> [] then List.flatten (List.map oe_gen_ecall_function tfs)
   else ["/* There were no ecalls. */"]
 
-let oe_gen_ecall_table (os : out_channel) (ec : enclave_content) =
-  fprintf os "\n\n/****** ECALL function table  *************/\n" ;
-  fprintf os "oe_ecall_func_t __oe_ecalls_table[] = {\n" ;
-  List.iter
-    (fun f -> fprintf os "    (oe_ecall_func_t) ecall_%s,\n" f.tf_fdecl.fname)
-    ec.tfunc_decls ;
-  fprintf os "};\n\n" ;
-  fprintf os
-    "size_t __oe_ecalls_table_size = OE_COUNTOF(__oe_ecalls_table);\n\n"
+(** Generate ECALL function table. *)
+let oe_gen_ecall_table (tfs : trusted_func list) =
+  if tfs <> [] then
+    [ "oe_ecall_func_t __oe_ecalls_table[] = {"
+    ; "    "
+      ^ String.concat ",\n    "
+          (List.map
+             (fun f -> sprintf "(oe_ecall_func_t) ecall_%s" f.tf_fdecl.fname)
+             tfs)
+    ; "};"
+    ; ""
+    ; "size_t __oe_ecalls_table_size = OE_COUNTOF(__oe_ecalls_table);" ]
+  else ["/* There were no ecalls. */"]
 
 let gen_fill_marshal_struct (os : out_channel) (fd : func_decl) (args : string)
     =

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -491,20 +491,6 @@ let get_cast_from_mem_expr (ptype, decl) =
         sprintf "(const %s) " (get_tystr t)
       else ""
 
-let oe_copy_members_to_enclave (os : out_channel) (fd : func_decl) =
-  let is_primitive ptype =
-    match ptype with
-    | PTPtr (atype, ptr_attr) -> not ptr_attr.pa_chkptr
-    | _ -> true
-  in
-  let gen_copy_member (ptype, decl) =
-    if is_primitive ptype then
-      fprintf os "    enc_args.%s = args.%s;\n" decl.identifier decl.identifier
-  in
-  fprintf os "    /* Copy primitive properties to enc_args */\n" ;
-  List.iter gen_copy_member fd.plist ;
-  fprintf os "\n"
-
 let oe_gen_allocate_buffers (os : out_channel) (fd : func_decl) =
   let gen_allocate_buffer (ptype, decl) =
     match ptype with

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -341,7 +341,10 @@ let oe_gen_args_header (ec : enclave_content) (dir : string) =
     ; "#include <stdint.h>"
     ; "#include <stdlib.h> /* for wchar_t */"
     ; ""
-    ; (if with_errno then "#include <errno.h>" else "/* No errno support. */")
+    ; ( if with_errno then "#include <errno.h>"
+      else
+        "/* #include <errno.h> - Errno propagation not enabled so not \
+         included. */" )
     ; ""
     ; "#include <openenclave/bits/result.h>"
     ; ""
@@ -800,9 +803,9 @@ let oe_gen_enclave_ocall_wrapper (uf : untrusted_func) =
   ; ""
   ; String.concat "\n    " (oe_process_output_buffer fd)
   ; ""
-  ; "    /* Propagate errno. */"
+  ; "    /* Retrieve propagated errno from OCALL. */"
   ; ( if uf.uf_propagate_errno then "    errno = _pargs_out->_ocall_errno;\n"
-    else sprintf "    /* Errno not enabled. */" )
+    else sprintf "    /* Errno propagation not enabled. */" )
   ; ""
   ; "    _result = OE_OK;"
   ; ""
@@ -860,9 +863,9 @@ let oe_gen_ocall_function (uf : untrusted_func) =
   ; (* Call the host function *)
     "    " ^ String.concat "\n    " (oe_gen_call_user_function fd)
   ; ""
-  ; "    /* Propagate errno. */"
+  ; "    /* Propagate errno back to enclave. */"
   ; ( if uf.uf_propagate_errno then "    pargs_out->_ocall_errno = errno;"
-    else "    /* Errno not enabled. */" )
+    else "    /* Errno propagation not enabled. */" )
   ; ""
   ; (* Mark call as success *)
     "    /* Success. */"

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -491,27 +491,6 @@ let get_cast_from_mem_expr (ptype, decl) =
         sprintf "(const %s) " (get_tystr t)
       else ""
 
-let oe_gen_allocate_buffers (os : out_channel) (fd : func_decl) =
-  let gen_allocate_buffer (ptype, decl) =
-    match ptype with
-    | PTPtr (atype, ptr_attr) ->
-        if ptr_attr.pa_chkptr then
-          let size = oe_get_param_size (ptype, decl, "args.") in
-          let macro =
-            match ptr_attr.pa_direction with
-            | PtrOut -> "OE_CHECKED_ALLOCATE_OUTPUT"
-            | _ -> "OE_CHECKED_COPY_INPUT"
-          in
-          fprintf os "    %s(enc_args.%s, args.%s, %s);\n" macro
-            decl.identifier decl.identifier size
-        else ()
-    | _ -> ()
-    (* Non pointer arguments *)
-  in
-  fprintf os "    /* Copy checked buffers properties to enclave memory */\n" ;
-  List.iter gen_allocate_buffer fd.plist ;
-  fprintf os "\n"
-
 let oe_gen_free_buffers (os : out_channel) (fd : func_decl) =
   let gen_free_buffer (ptype, decl) =
     match ptype with

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -705,12 +705,6 @@ let oe_get_host_ecall_function (os : out_channel) (fd : func_decl) =
   fprintf os "    return _result;\n" ;
   fprintf os "}\n\n"
 
-let iter_ptr_params f params =
-  List.iter
-    (fun (ptype, decl) ->
-      match ptype with PTPtr (_, attr) -> f (ptype, decl, attr) | _ -> () )
-    params
-
 (** Generate ocalls wrapper function. *)
 let oe_gen_ocall_enclave_wrapper (os : out_channel) (uf : untrusted_func) =
   let propagate_errno = uf.uf_propagate_errno in

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -541,26 +541,6 @@ let oe_gen_free_buffers (os : out_channel) (fd : func_decl) =
   List.iter gen_free_buffer fd.plist ;
   fprintf os "\n"
 
-let oe_gen_copy_outputs (os : out_channel) (fd : func_decl) =
-  let gen_free_buffer (ptype, decl) =
-    match ptype with
-    | PTPtr (atype, ptr_attr) ->
-        if ptr_attr.pa_chkptr then
-          match ptr_attr.pa_direction with
-          | PtrOut | PtrInOut ->
-              fprintf os "    if (args.%s)\n" decl.identifier ;
-              fprintf os "        memcpy(args.%s, enc_args.%s, %s);\n"
-                decl.identifier decl.identifier
-                (oe_get_param_size (ptype, decl, "args."))
-          | _ -> ()
-        else ()
-    | _ -> ()
-    (* Non pointer arguments *)
-  in
-  fprintf os "\n    /* Copy output buffers */\n" ;
-  List.iter gen_free_buffer fd.plist ;
-  fprintf os "\n"
-
 let oe_gen_call_function (os : out_channel) (fd : func_decl) =
   let params =
     List.map

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -140,9 +140,6 @@ let open_file (filename : string) (dir : string) =
   fprintf os " */\n" ;
   os
 
-(** [oe_mk_ms_struct_name] appends our [struct] naming suffix. *)
-let oe_mk_ms_struct_name (fname : string) = fname ^ "_args_t"
-
 (** [oe_mk_struct_decl] constructs the string of a [struct] definition. *)
 let oe_mk_struct_decl (fs : string) (name : string) =
   String.concat "\n"
@@ -162,7 +159,7 @@ let oe_gen_marshal_struct_impl (fd : func_decl) (errno : string)
       (fun acc (pt, declr) -> acc ^ mk_ms_member_decl pt declr isecall)
       "" new_param_list
   in
-  let struct_name = oe_mk_ms_struct_name fd.fname in
+  let struct_name = fd.fname ^ "_args_t" in
   match fd.rtype with
   | Void -> oe_mk_struct_decl member_list_str struct_name
   | _ ->

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -78,13 +78,14 @@ let conv_array_to_ptr (pd : pdecl) : pdecl =
     the pass-by-address scheme as in the C programming language. *)
 let mk_ms_member_decl (pt : parameter_type) (declr : declarator)
     (isecall : bool) =
+  (* TODO: Clean this up. *)
   let aty = get_param_atype pt in
   let tystr =
     if is_foreign_array pt then
       sprintf "/* foreign array of type %s */ void" (get_tystr aty)
     else get_tystr aty
   in
-  let ptr = if is_foreign_array pt then "* " else "" in
+  let ptr = if is_foreign_array pt then "*" else "" in
   let field = declr.identifier in
   (* String attribute is available for in/in-out both ecall and ocall.
      For ocall ,strlen is called in trusted proxy code, so no need to
@@ -100,7 +101,7 @@ let mk_ms_member_decl (pt : parameter_type) (declr : declarator)
         else false
   in
   let str_len =
-    if need_str_len_var pt then sprintf "\tsize_t %s_len;\n" field else ""
+    if need_str_len_var pt then sprintf "    size_t %s_len;\n" field else ""
   in
   let dmstr = get_array_dims declr.array_dims in
   sprintf "    %s%s %s%s;\n%s" tystr ptr field dmstr str_len
@@ -143,7 +144,8 @@ let open_file (filename : string) (dir : string) =
 (** [oe_mk_struct_decl] constructs the string of a [struct] definition. *)
 let oe_mk_struct_decl (fs : string) (name : string) =
   String.concat "\n"
-    [ sprintf "typedef struct _%s {" name
+    [ sprintf "typedef struct _%s" name
+    ; "{"
     ; "    oe_result_t _result;"
     ; sprintf "%s} %s;" fs name ]
 
@@ -151,6 +153,7 @@ let oe_mk_struct_decl (fs : string) (name : string) =
     definition. *)
 let oe_gen_marshal_struct_impl (fd : func_decl) (errno : string)
     (isecall : bool) =
+  (* TODO: Clean this up. *)
   let member_list_str =
     errno
     ^
@@ -167,13 +170,14 @@ let oe_gen_marshal_struct_impl (fd : func_decl) (errno : string)
       oe_mk_struct_decl (rv_str ^ member_list_str) struct_name
 
 let oe_gen_ecall_marshal_struct (tf : trusted_func) =
-  oe_gen_marshal_struct_impl tf.tf_fdecl "" true
+  oe_gen_marshal_struct_impl tf.tf_fdecl "" true ^ "\n"
 
 let oe_gen_ocall_marshal_struct (uf : untrusted_func) =
   let errno_decl =
     if uf.uf_propagate_errno then "    int _ocall_errno;\n" else ""
   in
-  oe_gen_marshal_struct_impl uf.uf_fdecl errno_decl true
+  (* TODO: Shouldn't this be false?! *)
+  oe_gen_marshal_struct_impl uf.uf_fdecl errno_decl true ^ "\n"
 
 (** [oe_get_param_size] is the most complex function. For a parameter,
     get its size expression. *)

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -1027,22 +1027,30 @@ let gen_t_h (ec : enclave_content) (ep : edger8r_params) =
   close_out os
 
 let gen_t_c (ec : enclave_content) (ep : edger8r_params) =
+  let content =
+    [ sprintf "#include \"%s_t.h\"" ec.file_shortnm
+    ; "#include <openenclave/edger8r/enclave.h>"
+    ; "#include <stdlib.h>"
+    ; "#include <string.h>"
+    ; "#include <wchar.h>"
+    ; ""
+    ; "OE_EXTERNC_BEGIN"
+    ; ""
+    ; "/**** ECALL functions. ****/"
+    ; String.concat "\n" (oe_gen_ecall_functions ec.tfunc_decls)
+    ; ""
+    ; "/**** ECALL function table. ****/"
+    ; String.concat "\n" (oe_gen_ecall_table ec.tfunc_decls)
+    ; ""
+    ; "/**** OCALL function wrappers. ****/"
+    ; String.concat "\n" (oe_gen_enclave_ocall_wrappers ec.ufunc_decls)
+    ; ""
+    ; "OE_EXTERNC_END"
+    ; "" ]
+  in
   let ecalls_fname = ec.file_shortnm ^ "_t.c" in
   let os = open_file ecalls_fname ep.trusted_dir in
-  fprintf os "#include \"%s_t.h\"\n" ec.file_shortnm ;
-  fprintf os "#include <openenclave/edger8r/enclave.h>\n" ;
-  fprintf os "#include <stdlib.h>\n" ;
-  fprintf os "#include <string.h>\n" ;
-  fprintf os "#include <wchar.h>\n" ;
-  fprintf os "\n" ;
-  fprintf os "OE_EXTERNC_BEGIN\n\n" ;
-  if ec.tfunc_decls <> [] then (
-    oe_gen_ecall_functions os ec ;
-    oe_gen_ecall_table os ec ) ;
-  if ec.ufunc_decls <> [] then (
-    fprintf os "\n/* ocall wrappers */\n\n" ;
-    List.iter (fun d -> oe_gen_ocall_enclave_wrapper os d) ec.ufunc_decls ) ;
-  fprintf os "OE_EXTERNC_END\n" ;
+  fprintf os "%s" (String.concat "\n" content) ;
   close_out os
 
 let oe_emit_create_enclave_decl (os : out_channel) (ec : enclave_content) =

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -487,9 +487,8 @@ let get_cast_from_mem_expr (ptype, decl) =
         sprintf "(const %s)" (get_tystr t)
       else ""
 
-let oe_gen_call_function (fd : func_decl) =
-  [ ""
-  ; "/* Call user function. */"
+let oe_gen_call_user_function (fd : func_decl) =
+  [ "/* Call user function. */"
   ; (match fd.rtype with Void -> "" | _ -> "pargs_out->_retval = ")
     ^ fd.fname ^ "("
   ; String.concat ",\n    "
@@ -589,7 +588,7 @@ let oe_gen_ecall_function (tf : trusted_func) =
   ; "    oe_lfence();"
   ; ""
   ; (* Call the enclave function *)
-    "    " ^ String.concat "\n    " (oe_gen_call_function fd)
+    "    " ^ String.concat "\n    " (oe_gen_call_user_function fd)
   ; ""
   ; (* Mark call as success *)
     "    /* Success. */"
@@ -826,7 +825,7 @@ let oe_gen_ocall_host_wrapper (os : out_channel) (uf : untrusted_func) =
       | _ -> () )
     fd.plist ;
   (* Call the host function *)
-  fprintf os "%s\n" (String.concat "\n    " (oe_gen_call_function fd)) ;
+  fprintf os "%s\n" (String.concat "\n    " (oe_gen_call_user_function fd)) ;
   (* Propagate errno *)
   if propagate_errno then (
     fprintf os "\n    /* Propagate errno */\n" ;

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -491,21 +491,6 @@ let get_cast_from_mem_expr (ptype, decl) =
         sprintf "(const %s) " (get_tystr t)
       else ""
 
-let oe_gen_free_buffers (os : out_channel) (fd : func_decl) =
-  let gen_free_buffer (ptype, decl) =
-    match ptype with
-    | PTPtr (atype, ptr_attr) ->
-        if ptr_attr.pa_chkptr then (
-          fprintf os "    if (enc_args.%s)\n" decl.identifier ;
-          fprintf os "        free (enc_args.%s);\n" decl.identifier )
-        else ()
-    | _ -> ()
-    (* Non pointer arguments *)
-  in
-  fprintf os "    /* Free enclave buffers */\n" ;
-  List.iter gen_free_buffer fd.plist ;
-  fprintf os "\n"
-
 let oe_gen_call_function (os : out_channel) (fd : func_decl) =
   let params =
     List.map
@@ -626,7 +611,6 @@ let oe_gen_ecall_function (os : out_channel) (fd : func_decl) =
   fprintf os "    _result = OE_OK;\n" ;
   fprintf os "    *output_bytes_written = output_buffer_offset;\n\n" ;
   fprintf os "done:\n" ;
-  (* oe_gen_free_buffers os fd; *)
   fprintf os "    if (pargs_out && output_buffer_size >= sizeof(*pargs_out))\n" ;
   fprintf os "        pargs_out->_result = _result;\n" ;
   fprintf os "}\n\n"
@@ -847,7 +831,6 @@ let oe_gen_ocall_host_wrapper (os : out_channel) (uf : untrusted_func) =
   fprintf os "    _result = OE_OK;\n" ;
   fprintf os "    *output_bytes_written = output_buffer_offset;\n\n" ;
   fprintf os "done:\n" ;
-  (* oe_gen_free_buffers os fd; *)
   fprintf os "    if (pargs_out && output_buffer_size >= sizeof(*pargs_out))\n" ;
   fprintf os "        pargs_out->_result = _result;\n" ;
   fprintf os "}\n\n"


### PR DESCRIPTION
This refactoring pays back the technical debt of the edger8r having previously been a prototype. The main goal of the work were to make the edger8r easier to understand. To that end, most functions now read "forwards" instead of "backwards," that is, you can look at the list of strings and see skeleton of the code it is supposed to generate. Most formatting has been removed from the string content and instead applied to the lists of strings, again making it easier to parse the embedded C code.

All code was tested for current usage, with a fair amount of dead code identified and removed. As the refactoring progressed, better patterns were identified and implemented. Notably, embedded pattern matching to identify different pointer types was mostly replaced with maps onto lists instead filtered by predicates. Some code generation was identified as duplicate and so refactored into reusable functions; conversely some code which had no business being independent functions was "unfactored" to read more plainly.

The generated files now (mostly) pass `format-code`, with the exception of whitespace on empty lines and extra-long lines, both problems not being worth fixing for generated code. Also of note, when there is nothing to emit, a comment to that effect is now produced instead of an extra blank line, making it obvious to the reader that indeed no code should exist there. All generated comments and headers are now consistent and easy to identify, with more section headers introduced for easier reading of the edge routines.

Due to the nature of the work, this code is best reviewed by commit instead of by the whole diff. Most commits in the series should build without further commits, except where noted.

Still TODO: I identified a bad pattern I'd introduced in the predicates where I'm matching `(ptype, decl)` and throwing away the `decl`, as these functions became increasingly reused it was made obvious their signature should change to just `ptype`, but it was too late to do this retroactively. Expect another commit or two on Monday, with that change, the addition of a unit test for errno propagation, a cleanup of the member decl generation logic (note internal TODOs), and maybe a commit to group functions logically (now that it is possible to do so).