### PR TITLE
[host/cmake] _FORTIFY_SOURCE should not be used on debug builds

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -176,7 +176,7 @@ if (UNIX)
      PUBLIC -fstack-protector-strong)
   target_compile_definitions(oehost
      PRIVATE _GNU_SOURCE
-     PUBLIC _FORTIFY_SOURCE=2)
+     PUBLIC $<$<NOT:$<CONFIG:debug>>:_FORTIFY_SOURCE=2>)
 endif ()
 
 if (CMAKE_C_COMPILER_ID MATCHES GNU)


### PR DESCRIPTION
As per: https://github.com/microsoft/openenclave/issues/1725 , `_FORTIFY_SOURCE`
should be used only on the targets: release, relwithdebinfo, minsizerel.

Fixes: https://github.com/microsoft/openenclave/issues/1725