### PR TITLE
 Prefix function IDs with enclave name

### DIFF
--- a/tests/oeedger8r/CMakeLists.txt
+++ b/tests/oeedger8r/CMakeLists.txt
@@ -8,5 +8,6 @@ if (BUILD_ENCLAVES)
 endif()
 
 add_enclave_test(tests/oeedger8r edl_host edl_enc)
+add_enclave_test(tests/oeedger8r_other edl_host edl_other_enc)
 
 add_subdirectory(behavior)

--- a/tests/oeedger8r/edl/basic.edl
+++ b/tests/oeedger8r/edl/basic.edl
@@ -11,24 +11,24 @@ enclave  {
         TYPE_LONG_DOUBLE
     };
 
-    trusted {        
+    trusted {
 
         /* Test all basic type parameters */
         public void ecall_basic_types(
-            char arg1, 
-            short arg2, 
-            int arg3, 
-            float arg4, 
-            double arg5, 
-            size_t arg6, 
+            char arg1,
+            short arg2,
+            int arg3,
+            float arg4,
+            double arg5,
+            size_t arg6,
             unsigned arg7,
-            int8_t arg8, 
-            int16_t arg9, 
-            int32_t arg10, 
+            int8_t arg8,
+            int16_t arg9,
+            int32_t arg10,
             int64_t arg11,
-            uint8_t arg12, 
-            uint16_t arg13, 
-            uint32_t arg14, 
+            uint8_t arg12,
+            uint16_t arg13,
+            uint32_t arg14,
             uint64_t arg15,
             long long arg16,
             unsigned char arg17,
@@ -64,7 +64,7 @@ enclave  {
         public uint8_t ecall_ret_uint8_t();
         public uint16_t ecall_ret_uint16_t();
         public uint32_t ecall_ret_uint32_t();
-        public uint64_t ecall_ret_uint64_t();   
+        public uint64_t ecall_ret_uint64_t();
         public long long ecall_ret_long_long();
         public unsigned char ecall_ret_unsigned_char();
         public unsigned short ecall_ret_unsigned_short();
@@ -74,27 +74,26 @@ enclave  {
         public unsigned long long ecall_ret_unsigned_long_long();
         public void ecall_ret_void();
 
-
-        public void test_basic_edl_ocalls();             
+        public void test_basic_edl_ocalls();
     };
 
     untrusted {
         /* Test all basic type parameters */
         void ocall_basic_types(
-            char arg1, 
-            short arg2, 
-            int arg3, 
-            float arg4, 
-            double arg5, 
-            size_t arg6, 
+            char arg1,
+            short arg2,
+            int arg3,
+            float arg4,
+            double arg5,
+            size_t arg6,
             unsigned arg7,
-            int8_t arg8, 
-            int16_t arg9, 
-            int32_t arg10, 
+            int8_t arg8,
+            int16_t arg9,
+            int32_t arg10,
             int64_t arg11,
-            uint8_t arg12, 
-            uint16_t arg13, 
-            uint32_t arg14, 
+            uint8_t arg12,
+            uint16_t arg13,
+            uint32_t arg14,
             uint64_t arg15,
             long long arg16,
             unsigned char arg17,
@@ -108,10 +107,10 @@ enclave  {
             long arg2,
             unsigned long arg3,
             long double arg4
-        );        
+        );
 
         // Get the size of the given type.
-        uint64_t get_host_sizeof(type_enum_t t);        
+        uint64_t get_host_sizeof(type_enum_t t);
 
         /* Test all basic types are return type */
         char ocall_ret_char();
@@ -130,15 +129,15 @@ enclave  {
         uint8_t ocall_ret_uint8_t();
         uint16_t ocall_ret_uint16_t();
         uint32_t ocall_ret_uint32_t();
-        uint64_t ocall_ret_uint64_t();     
+        uint64_t ocall_ret_uint64_t();
         long long ocall_ret_long_long();
         unsigned char ocall_ret_unsigned_char();
         unsigned short ocall_ret_unsigned_short();
         unsigned int ocall_ret_unsigned_int();
         unsigned long ocall_ret_unsigned_long();
-        long double ocall_ret_long_double();     
-        unsigned long long ocall_ret_unsigned_long_long();     
-        
-        void ocall_ret_void();        
-    }; 
+        long double ocall_ret_long_double();
+        unsigned long long ocall_ret_unsigned_long_long();
+
+        void ocall_ret_void();
+    };
 };

--- a/tests/oeedger8r/edl/other.edl
+++ b/tests/oeedger8r/edl/other.edl
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+  // This enclave is explicitly separate from the `all` enclave, but
+  // shares the same host. This tests the ability of a single host to
+  // include multiple enclave headers (and so host multiple enclaves).
+
+  struct MyOther {
+    int x;
+  };
+
+  trusted {
+    public MyOther ecall_other(MyOther o);
+  };
+
+  untrusted {
+    MyOther ocall_other(MyOther o);
+  };
+};

--- a/tests/oeedger8r/edl/other.edl
+++ b/tests/oeedger8r/edl/other.edl
@@ -12,6 +12,8 @@ enclave {
 
   trusted {
     public MyOther ecall_other(MyOther o);
+
+    public void test_other_edl_ocalls();
   };
 
   untrusted {

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -35,7 +35,6 @@ add_enclave(TARGET edl_enc CXX
     ${bar_t}
     )
 
-
 # The tests intentionally use floats etc in size context.
 # Disable warnings.
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang OR USE_CLANGW)
@@ -55,3 +54,13 @@ if (NOT WIN32)
   # Re-enable strict aliasing. TODO: Remove this when #1717 is resolved.
   target_compile_options(edl_enc PUBLIC -fstrict-aliasing -Werror=strict-aliasing)
 endif ()
+
+# This is a separate enclave specifically shared with the same host.
+oeedl_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/../edl/other.edl
+    enclave
+    other_t
+)
+
+add_enclave(TARGET edl_other_enc CXX SOURCES testother.cpp ${other_t})
+target_include_directories(edl_other_enc PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-
 oeedl_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/../edl/all.edl 
     enclave

--- a/tests/oeedger8r/enc/bar.cpp
+++ b/tests/oeedger8r/enc/bar.cpp
@@ -1,5 +1,3 @@
-
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "bar_t.h"

--- a/tests/oeedger8r/enc/testother.cpp
+++ b/tests/oeedger8r/enc/testother.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../edltestutils.h"
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/tests.h>
+#include "other_t.h"
+
+MyOther ecall_other(MyOther o)
+{
+    return MyOther{o.x + 1};
+}

--- a/tests/oeedger8r/enc/testother.cpp
+++ b/tests/oeedger8r/enc/testother.cpp
@@ -11,3 +11,18 @@ MyOther ecall_other(MyOther o)
 {
     return MyOther{o.x + 1};
 }
+
+void test_other_edl_ocalls()
+{
+    MyOther ret;
+    OE_TEST(ocall_other(&ret, {1}) == OE_OK);
+    OE_TEST(ret.x == 2);
+}
+
+OE_SET_ENCLAVE_SGX(
+    1,    /* ProductID */
+    1,    /* SecurityVersion */
+    true, /* AllowDebug */
+    1024, /* HeapPageCount */
+    256,  /* StackPageCount */
+    4);   /* TCSCount */

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -15,6 +15,12 @@ oeedl_file(
     bar_u
 )
 
+oeedl_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/../edl/other.edl
+    host
+    other_u
+)
+
 add_executable(edl_host 
     main.cpp
     bar.cpp
@@ -23,11 +29,13 @@ add_executable(edl_host
     testbasic.cpp
     testenum.cpp
     testforeign.cpp
+    testother.cpp
     testpointer.cpp
     teststring.cpp
     teststruct.cpp
     ${all_u}
     ${bar_u}
+    ${other_u}
 )
 
 # The tests intentionally use floats etc in size context.

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-
 oeedl_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/../edl/all.edl 
     host

--- a/tests/oeedger8r/host/bar.cpp
+++ b/tests/oeedger8r/host/bar.cpp
@@ -1,5 +1,3 @@
-
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "bar_u.h"

--- a/tests/oeedger8r/host/main.cpp
+++ b/tests/oeedger8r/host/main.cpp
@@ -4,6 +4,8 @@
 #include <openenclave/host.h>
 #include <openenclave/internal/tests.h>
 #include <wchar.h>
+#include <algorithm>
+#include <string>
 #include "all_u.h"
 #include "other_u.h" // Test that multiple enclaves can be shared with one host.
 
@@ -20,6 +22,7 @@ void test_pointer_edl_ecalls(oe_enclave_t* enclave);
 void test_struct_edl_ecalls(oe_enclave_t* enclave);
 void test_enum_edl_ecalls(oe_enclave_t* enclave);
 void test_foreign_edl_ecalls(oe_enclave_t* enclave);
+void test_other_edl_ecalls(oe_enclave_t* enclave);
 
 int main(int argc, const char* argv[])
 {
@@ -33,6 +36,23 @@ int main(int argc, const char* argv[])
     }
 
     const uint32_t flags = oe_get_create_flags();
+
+    std::string other("edl_other_enc");
+    // If we loaded `edl_other_enc` instead of `edl_enc`...
+    if (std::equal(other.rbegin(), other.rend(), std::string(argv[1]).rbegin()))
+    {
+        result = oe_create_other_enclave(
+            argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
+        if (result != OE_OK)
+        {
+            fprintf(stderr, "%s: cannot create enclave: %u\n", argv[0], result);
+            return 1;
+        }
+
+        test_other_edl_ecalls(enclave);
+        OE_TEST(test_other_edl_ocalls(enclave) == OE_OK);
+        goto done;
+    }
 
     result = oe_create_all_enclave(
         argv[1], OE_ENCLAVE_TYPE_SGX, flags, NULL, 0, &enclave);
@@ -68,6 +88,7 @@ int main(int argc, const char* argv[])
     test_foreign_edl_ecalls(enclave);
     OE_TEST(test_foreign_edl_ocalls(enclave) == OE_OK);
 
+done:
     oe_terminate_enclave(enclave);
 
     printf("=== passed all tests (file)\n");

--- a/tests/oeedger8r/host/main.cpp
+++ b/tests/oeedger8r/host/main.cpp
@@ -5,6 +5,7 @@
 #include <openenclave/internal/tests.h>
 #include <wchar.h>
 #include "all_u.h"
+#include "other_u.h" // Test that multiple enclaves can be shared with one host.
 
 // The types wchar_t, long, unsigned long and long double have different sizes
 // in Linux and Windows. Therefore enclaves built in Linux cannot be safely

--- a/tests/oeedger8r/host/testother.cpp
+++ b/tests/oeedger8r/host/testother.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../edltestutils.h"
+
+#include <openenclave/host.h>
+#include <openenclave/internal/tests.h>
+#include "other_u.h"
+
+MyOther ocall_other(MyOther o)
+{
+    return MyOther{o.x + 1};
+}

--- a/tests/oeedger8r/host/testother.cpp
+++ b/tests/oeedger8r/host/testother.cpp
@@ -11,3 +11,10 @@ MyOther ocall_other(MyOther o)
 {
     return MyOther{o.x + 1};
 }
+
+void test_other_edl_ecalls(oe_enclave_t* enclave)
+{
+    MyOther ret;
+    OE_TEST(ecall_other(enclave, &ret, MyOther{1}) == OE_OK);
+    OE_TEST(ret.x == 2);
+}

--- a/tests/oeedger8r/host/teststring.cpp
+++ b/tests/oeedger8r/host/teststring.cpp
@@ -80,7 +80,7 @@ oe_result_t ecall_string_no_null_terminator_modified(
     /* Call enclave function */
     if ((_result = oe_call_enclave_function(
              enclave,
-             fcn_id_ecall_string_no_null_terminator,
+             all_fcn_id_ecall_string_no_null_terminator,
              _input_buffer,
              _input_buffer_size,
              _output_buffer,
@@ -186,7 +186,7 @@ oe_result_t ecall_wstring_no_null_terminator_modified(
     /* Call enclave function */
     if ((_result = oe_call_enclave_function(
              enclave,
-             fcn_id_ecall_wstring_no_null_terminator,
+             all_fcn_id_ecall_wstring_no_null_terminator,
              _input_buffer,
              _input_buffer_size,
              _output_buffer,

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -285,28 +285,29 @@ let emit_composite_type =
   | UnionDef u -> emit_struct_or_union u true
   | EnumDef e -> emit_enum e
 
-let get_function_id (f : func_decl) = sprintf "fcn_id_%s" f.fname
+let get_function_id (f : func_decl) (e : string) =
+  sprintf "%s_fcn_id_%s" e f.fname
 
 (** Emit IDs in enum for trusted functions. *)
-let emit_trusted_function_ids (tfs : trusted_func list) =
+let emit_trusted_function_ids (tfs : trusted_func list) (name : string) =
   [ "enum"
   ; "{"
   ; String.concat "\n"
       (List.mapi
-         (fun i f -> sprintf "    %s = %d," (get_function_id f.tf_fdecl) i)
+         (fun i f -> sprintf "    %s = %d," (get_function_id f.tf_fdecl name) i)
          tfs)
-  ; "    fcn_id_trusted_call_id_max = OE_ENUM_MAX"
+  ; sprintf "    %s_fcn_id_trusted_call_id_max = OE_ENUM_MAX" name
   ; "};" ]
 
 (** Emit IDs in enum for untrusted functions. *)
-let emit_untrusted_function_ids (ufs : untrusted_func list) =
+let emit_untrusted_function_ids (ufs : untrusted_func list) (name : string) =
   [ "enum"
   ; "{"
   ; String.concat "\n"
       (List.mapi
-         (fun i f -> sprintf "    %s = %d," (get_function_id f.uf_fdecl) i)
+         (fun i f -> sprintf "    %s = %d," (get_function_id f.uf_fdecl name) i)
          ufs)
-  ; "    fcn_id_untrusted_call_max = OE_ENUM_MAX"
+  ; sprintf "    %s_fcn_id_untrusted_call_max = OE_ENUM_MAX" name
   ; "};" ]
 
 (** Generate [args.h] which contains [struct]s for ecalls and ocalls *)
@@ -361,10 +362,12 @@ let oe_gen_args_header (ec : enclave_content) (dir : string) =
     ; String.concat "\n" (oe_gen_ocall_marshal_structs ec.ufunc_decls)
     ; (* TODO: Fix newline generation. *)
       "/**** Trusted function IDs ****/"
-    ; String.concat "\n" (emit_trusted_function_ids ec.tfunc_decls)
+    ; String.concat "\n"
+        (emit_trusted_function_ids ec.tfunc_decls ec.enclave_name)
     ; ""
     ; "/**** Untrusted function IDs. ****/"
-    ; String.concat "\n" (emit_untrusted_function_ids ec.ufunc_decls)
+    ; String.concat "\n"
+        (emit_untrusted_function_ids ec.ufunc_decls ec.enclave_name)
     ; ""
     ; sprintf "#endif // %s" guard_macro
     ; "" ]
@@ -697,7 +700,7 @@ let gen_fill_marshal_struct (fd : func_decl) (args : string) =
     fd.plist
 
 (** Generate host ECALL wrapper function. *)
-let oe_gen_host_ecall_wrapper (tf : trusted_func) =
+let oe_gen_host_ecall_wrapper (name : string) (tf : trusted_func) =
   let fd = tf.tf_fdecl in
   [ sprintf "%s" (oe_gen_wrapper_prototype fd true)
   ; "{"
@@ -730,7 +733,7 @@ let oe_gen_host_ecall_wrapper (tf : trusted_func) =
   ; "             "
     ^ String.concat ",\n             "
         [ "enclave"
-        ; sprintf "%s" (get_function_id fd)
+        ; sprintf "%s" (get_function_id fd name)
         ; "_input_buffer"
         ; "_input_buffer_size"
         ; "_output_buffer"
@@ -749,13 +752,8 @@ let oe_gen_host_ecall_wrapper (tf : trusted_func) =
   ; "}"
   ; "" ]
 
-(** Generate all host ECALL wrappers, if any. *)
-let oe_gen_host_ecall_wrappers (tfs : trusted_func list) =
-  if tfs <> [] then List.flatten (List.map oe_gen_host_ecall_wrapper tfs)
-  else ["/* There were no ecalls. */"]
-
 (** Generate enclave OCALL wrapper function. *)
-let oe_gen_enclave_ocall_wrapper (uf : untrusted_func) =
+let oe_gen_enclave_ocall_wrapper (name : string) (uf : untrusted_func) =
   let fd = uf.uf_fdecl in
   [ oe_gen_wrapper_prototype fd false
   ; "{"
@@ -793,7 +791,7 @@ let oe_gen_enclave_ocall_wrapper (uf : untrusted_func) =
   ; "    if ((_result = oe_call_host_function("
   ; "             "
     ^ String.concat ",\n             "
-        [ sprintf "%s" (get_function_id fd)
+        [ sprintf "%s" (get_function_id fd name)
         ; "_input_buffer"
         ; "_input_buffer_size"
         ; "_output_buffer"
@@ -815,11 +813,6 @@ let oe_gen_enclave_ocall_wrapper (uf : untrusted_func) =
   ; "    return _result;"
   ; "}"
   ; "" ]
-
-(** Generate all enclave OCALL wrapper functions, if any. *)
-let oe_gen_enclave_ocall_wrappers (ufs : untrusted_func list) =
-  if ufs <> [] then List.flatten (List.map oe_gen_enclave_ocall_wrapper ufs)
-  else ["/* There were no ocalls. */"]
 
 (** Generate ocall function. *)
 let oe_gen_ocall_function (uf : untrusted_func) =
@@ -1089,6 +1082,12 @@ let gen_t_h (ec : enclave_content) (ep : edger8r_params) =
   close_out os
 
 let gen_t_c (ec : enclave_content) (ep : edger8r_params) =
+  let oe_gen_enclave_ocall_wrappers =
+    if ec.ufunc_decls <> [] then
+      List.flatten
+        (List.map (oe_gen_enclave_ocall_wrapper ec.enclave_name) ec.ufunc_decls)
+    else ["/* There were no ocalls. */"]
+  in
   let content =
     [ sprintf "#include \"%s_t.h\"" ec.file_shortnm
     ; ""
@@ -1107,7 +1106,7 @@ let gen_t_c (ec : enclave_content) (ep : edger8r_params) =
     ; String.concat "\n" (oe_gen_ecall_table ec.tfunc_decls)
     ; ""
     ; "/**** OCALL function wrappers. ****/"
-    ; String.concat "\n" (oe_gen_enclave_ocall_wrappers ec.ufunc_decls)
+    ; String.concat "\n" oe_gen_enclave_ocall_wrappers
     ; ""
     ; "OE_EXTERNC_END"
     ; "" ]
@@ -1166,6 +1165,12 @@ let gen_u_h (ec : enclave_content) (ep : edger8r_params) =
   close_out os
 
 let gen_u_c (ec : enclave_content) (ep : edger8r_params) =
+  let oe_gen_host_ecall_wrappers =
+    if ec.tfunc_decls <> [] then
+      List.flatten
+        (List.map (oe_gen_host_ecall_wrapper ec.enclave_name) ec.tfunc_decls)
+    else ["/* There were no ecalls. */"]
+  in
   let content =
     [ sprintf "#include \"%s_u.h\"" ec.file_shortnm
     ; ""
@@ -1178,7 +1183,7 @@ let gen_u_c (ec : enclave_content) (ep : edger8r_params) =
     ; "OE_EXTERNC_BEGIN"
     ; ""
     ; "/**** ECALL function wrappers. ****/"
-    ; String.concat "\n" (oe_gen_host_ecall_wrappers ec.tfunc_decls)
+    ; String.concat "\n" oe_gen_host_ecall_wrappers
     ; ""
     ; "/**** OCALL functions. ****/"
     ; String.concat "\n" (oe_gen_ocall_functions ec.ufunc_decls)


### PR DESCRIPTION
This makes the enums globally unique which allows the host to include multiple generated untrusted headers more easily. Note the addition of the enclave `edl_other_enc` which can be loaded via the edger8r tests host, meaning it includes both `all_u.h` _and_ `other_u.h`.