### PR TITLE
Add `propagate_errno` oedger8r test

### DIFF
--- a/tests/oeedger8r/edl/all.edl
+++ b/tests/oeedger8r/edl/all.edl
@@ -7,6 +7,7 @@ enclave  {
     from "array.edl"    import *;
     from "basic.edl"    import *;
     from "enum.edl"     import *;
+    from "errno.edl"    import *;
     from "foreign.edl"  import *;
     from "pointer.edl"  import *;
     from "string.edl"   import *;

--- a/tests/oeedger8r/edl/errno.edl
+++ b/tests/oeedger8r/edl/errno.edl
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+  trusted {
+    public void test_errno_edl_ocalls();
+  };
+
+  untrusted {
+    void ocall_errno() propagate_errno;
+  };
+};

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -26,6 +26,7 @@ add_enclave(TARGET edl_enc CXX
     testarray.cpp
     testbasic.cpp
     testenum.cpp
+    testerrno.cpp
     testforeign.cpp
     testpointer.cpp
     teststring.cpp

--- a/tests/oeedger8r/enc/testerrno.cpp
+++ b/tests/oeedger8r/enc/testerrno.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../edltestutils.h"
+
+#include <errno.h>
+#include <openenclave/enclave.h>
+#include <openenclave/internal/tests.h>
+#include <stdio.h>
+#include "all_t.h"
+
+void test_errno_edl_ocalls()
+{
+    errno = 0;
+    OE_TEST(errno == 0);
+
+    OE_TEST(ocall_errno() == OE_OK);
+    OE_TEST(errno == 0x12345678);
+
+    printf("=== test_errno_edl_ocalls passed\n");
+}

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(edl_host
     testarray.cpp
     testbasic.cpp
     testenum.cpp
+    testerrno.cpp
     testforeign.cpp
     testother.cpp
     testpointer.cpp

--- a/tests/oeedger8r/host/main.cpp
+++ b/tests/oeedger8r/host/main.cpp
@@ -85,6 +85,8 @@ int main(int argc, const char* argv[])
     test_enum_edl_ecalls(enclave);
     OE_TEST(test_enum_edl_ocalls(enclave) == OE_OK);
 
+    OE_TEST(test_errno_edl_ocalls(enclave) == OE_OK);
+
     test_foreign_edl_ecalls(enclave);
     OE_TEST(test_foreign_edl_ocalls(enclave) == OE_OK);
 

--- a/tests/oeedger8r/host/testerrno.cpp
+++ b/tests/oeedger8r/host/testerrno.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../edltestutils.h"
+
+#include <errno.h>
+#include <openenclave/host.h>
+#include <openenclave/internal/tests.h>
+#include "all_u.h"
+
+void ocall_errno()
+{
+    // Super unique number.
+    errno = 0x12345678;
+}


### PR DESCRIPTION
This adds a very basic test asserting that `propagate_errno` works correctly to propagate the value of errno from an ocall to the enclave. It does not test any sort of complicated threading scenario, which we may want to add support for later.