### PR TITLE
[CI/CD] Use bash with profile loaded for shell steps

### DIFF
--- a/src/jenkins/common/Openenclave.groovy
+++ b/src/jenkins/common/Openenclave.groovy
@@ -39,7 +39,12 @@ def azureEnvironment(String task) {
                 def image = docker.image("oetools-deploy:latest")
                 image.pull()
                 image.inside {
-                    sh "${task}"
+                    sh """#!/usr/bin/env bash
+                          set -o errexit
+                          set -o pipefail
+                          source /etc/profile
+                          ${task}
+                       """
                 }
             }
         }
@@ -57,7 +62,12 @@ def Run(String compiler, String task, Integer timeoutMinutes = 30) {
     withEnv(["CC=${c_compiler}","CXX=${cpp_compiler}"]) {
         timeout(timeoutMinutes) {
             dir("${WORKSPACE}/build") {
-                sh "${task}"
+                sh """#!/usr/bin/env bash
+                      set -o errexit
+                      set -o pipefail
+                      source /etc/profile
+                      ${task}
+                   """
             }
         }
     }


### PR DESCRIPTION
The default shell pipeline steps use `/bin/sh` without any
environment variables set for the system / user profile.

This change paves the road for https://github.com/microsoft/openenclave/issues/1738 where we will be
setting up an environment file in `/etc/profile.d` with all the
OPAM environment variables.