### PR TITLE
Lock down propagate_errno behavior.

### DIFF
--- a/tests/oeedger8r/README.md
+++ b/tests/oeedger8r/README.md
@@ -25,6 +25,11 @@ Test constructs supported by `oeedger8r`.
   2. *enc/testbasic.cpp* : Defines ecall implementations. Also `test_enum_edl_ocalls` function to test ocalls.
   3. *host/testbasic.cpp*: Defines ocall implementations. Also `test_enum_edl_ecalls` function to test ecalls.
 
+- **errno.edl**
+  1. *Purpose*: Test propagate_errno annotation. Lock down initial value of errno, propagation/non-propagation of errno value from host to enclave depending on annotation, generation/non-generation of _ocall_errno field.
+  2. *enc/testerrno.cpp* : Defines ecall implementations.
+  3. *host/testerrno.cpp* : Defines ocall implementations.
+
 - **foreign.edl**
   1. *Purpose* : Test ecalls and ocalls for foreign types. Foreign type is a type that is defined outside of EDL and is not a primitive type. Test pass by value and `isary` attributes. Also when an explicit `*` is used, test all pointer semantics.
      Also if `*` is not used but `isptr` attribute is specified (say for `typedef int * my_type`), then pointer semantics are allowed.

--- a/tests/oeedger8r/edl/errno.edl
+++ b/tests/oeedger8r/edl/errno.edl
@@ -8,5 +8,12 @@ enclave {
 
   untrusted {
     void ocall_errno() propagate_errno;
+
+    // Set host errno to given value.
+    // But do not propagate the value back to the enclave.
+    void ocall_set_host_errno(int e);
+
+    // Noop. But propagate current host errno value to enclave.
+    void ocall_noop() propagate_errno;
   };
 };

--- a/tests/oeedger8r/edltestutils.h
+++ b/tests/oeedger8r/edltestutils.h
@@ -49,6 +49,7 @@ struct unused
     }
 
 DEFINE_ASSERT_NO_FIELD(s_len)
+DEFINE_ASSERT_NO_FIELD(_ocall_errno)
 
 template <typename T, std::size_t N, typename U>
 inline int array_compare(const T (&a1)[N], U u)

--- a/tests/oeedger8r/enc/testerrno.cpp
+++ b/tests/oeedger8r/enc/testerrno.cpp
@@ -11,11 +11,41 @@
 
 void test_errno_edl_ocalls()
 {
+    // Currently each ecall creates an new enclave thread and therefore all
+    // thread-local variables are initialized to their default values. Thus
+    // errno has default value 0. Also, ecalls currently do no transfer the host
+    // errno value to the enclave.
+    OE_TEST(errno == 0);
+
     errno = 0;
     OE_TEST(errno == 0);
 
     OE_TEST(ocall_errno() == OE_OK);
     OE_TEST(errno == 0x12345678);
+
+    // Set host errno value using a function that does not propagate the value
+    // back. Assert that the enclave errno value has not changed.
+    OE_TEST(ocall_set_host_errno(0x1111) == OE_OK);
+    OE_TEST(errno == 0x12345678);
+
+    // Call a noop function to transfer current value of errno from host.
+    OE_TEST(ocall_noop() == OE_OK);
+    OE_TEST(errno == 0x1111);
+
+    // Mashalling structs for ocalls marked with propagate_errno should have an
+    // int _ocall_errno field. If not the case, the following code will not
+    // compile.
+    {
+        ocall_errno_args_t args1;
+        check_type<int>(args1._ocall_errno);
+
+        ocall_noop_args_t args2;
+        check_type<int>(args2._ocall_errno);
+    }
+
+    // Marshalling structs without the propagate_errno annotation will not have
+    // the _ocall_errno field.
+    assert_no_field__ocall_errno<ocall_set_host_errno_args_t>();
 
     printf("=== test_errno_edl_ocalls passed\n");
 }

--- a/tests/oeedger8r/host/main.cpp
+++ b/tests/oeedger8r/host/main.cpp
@@ -85,6 +85,9 @@ int main(int argc, const char* argv[])
     test_enum_edl_ecalls(enclave);
     OE_TEST(test_enum_edl_ocalls(enclave) == OE_OK);
 
+    // Change the value of errno on the host side before making the ecall.
+    // Ecalls do not transfer errno values from host to enclave.
+    errno = 0xbadf00d;
     OE_TEST(test_errno_edl_ocalls(enclave) == OE_OK);
 
     test_foreign_edl_ecalls(enclave);

--- a/tests/oeedger8r/host/testerrno.cpp
+++ b/tests/oeedger8r/host/testerrno.cpp
@@ -13,3 +13,12 @@ void ocall_errno()
     // Super unique number.
     errno = 0x12345678;
 }
+
+void ocall_set_host_errno(int e)
+{
+    errno = e;
+}
+
+void ocall_noop()
+{
+}


### PR DESCRIPTION
1. Test that initial value of errno is always zero.
   This is because:
   a) Each ecall creates a new enclave thread and
      thread-local variables (including errno) are initialized
      to their default values.
   b) Ecalls do not transfer the current host errno value
      over to the enclave.
2. Test that only ocalls annotated with propagate_errno actually
   propagate the errno.
3. Test that int _ocall_errno field is only added for ocalls with
   propagate_errno annotation.