### PR TITLE
Pull upstream edger8r code from Intel

### DIFF
--- a/tools/oeedger8r/intel/CodeGen.ml
+++ b/tools/oeedger8r/intel/CodeGen.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2011-2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,8 +43,8 @@ type enclave_content = Ast.enclave_content = {
   file_shortnm : string; (* the short name of original EDL file *)
   enclave_name : string; (* the normalized C identifier *)
 
-  include_list : string list;
-  import_exprs : Ast.import_decl list;
+  include_list : string list; (* include another .h *)
+  import_exprs : Ast.import_decl list;  (* always empty list after finished reduce_import. *)
   comp_defs    : Ast.composite_type list;
   tfunc_decls  : Ast.trusted_func   list;
   ufunc_decls  : Ast.untrusted_func list;
@@ -214,8 +214,11 @@ let ms_retval_name = mk_ms_member_name retval_name
 let mk_tbridge_name (fname: string) = "sgx_" ^ fname
 let mk_parm_accessor name = sprintf "%s->%s" ms_struct_val (mk_ms_member_name name)
 let mk_tmp_var name = "_tmp_" ^ name
+let mk_tmp_var2 name1 name2 = "_tmp_" ^ name1 ^ "_" ^ name2
 let mk_len_var name = "_len_" ^ name
+let mk_len_var2 name1 name2 = "_len_" ^ name1 ^ "_" ^ name2
 let mk_in_var name = "_in_" ^ name
+let mk_in_var2 name1 name2 = "_in_" ^ name1 ^ "_" ^ name2
 let mk_ocall_table_name enclave_name = "ocall_table_" ^ enclave_name
 
 (* Un-trusted bridge name is prefixed with enclave file short name. *)
@@ -296,12 +299,24 @@ let get_typed_declr_str (ty: Ast.atype) (declr: Ast.declarator) =
 let mk_member_decl (ty: Ast.atype) (declr: Ast.declarator) =
   sprintf "\t%s;\n" (get_typed_declr_str ty declr)
 
+(* Check whether given parameter is `const' specified. *)
+let is_const_ptr (pt: Ast.parameter_type) =
+    match pt with
+      Ast.PTVal _      -> false
+    | Ast.PTPtr(aty, pa) ->
+      if not pa.Ast.pa_rdonly then false
+      else
+        match aty with
+          Ast.Foreign _ -> false
+        | _             -> true
+
 (* Note that, for a foreign array type `foo_array_t' we will generate
  *   foo_array_t* ms_field;
  * in the marshaling data structure to keep the pass-by-address scheme
  * as in the C programming language.
 *)
 let mk_ms_member_decl (pt: Ast.parameter_type) (declr: Ast.declarator) (isecall: bool) =
+  let qual = if is_const_ptr pt then "const " else "" in
   let aty = Ast.get_param_atype pt in
   let tystr = Ast.get_tystr aty in
   let ptr = if is_foreign_array pt then "* " else "" in
@@ -322,17 +337,101 @@ let mk_ms_member_decl (pt: Ast.parameter_type) (declr: Ast.declarator) (isecall:
   let str_len = if need_str_len_var pt then sprintf "\tsize_t %s_len;\n" field else ""
   in
   let dmstr = get_array_dims declr.Ast.array_dims in
-    sprintf "\t%s%s %s%s;\n%s" tystr ptr field dmstr str_len
+    sprintf "\t%s%s%s %s%s;\n%s" qual tystr ptr field dmstr str_len
+
+(* It is used to save the structures defined in EDLs. *)
+let defined_structure = ref []
+let is_structure_defined s = List.exists (fun (( i, _ ): (Ast.struct_def * bool)) -> i.Ast.sname = s) !defined_structure
+let get_struct_def s = List.find (fun (( i, _ ): (Ast.struct_def * bool)) -> i.Ast.sname = s) !defined_structure
+
+let is_structure_deep_copy (s:Ast.struct_def) = 
+    let is_deep_copy (pd: Ast.pdecl) = 
+      let (pt, _)    = pd in
+      match pt with
+        | Ast.PTVal _      -> false
+        | Ast.PTPtr (_, attr) -> if attr.Ast.pa_size = Ast.empty_ptr_size then false else true
+    in
+    List.exists is_deep_copy s.Ast.smlist
+
+(* Check duplicated structure definition and illegal usage.
+ *)
+let check_structure (ec: enclave_content) =
+  let trusted_fds = tf_list_to_fd_list ec.tfunc_decls in
+  let untrusted_fds = uf_list_to_fd_list ec.ufunc_decls in
+  List.iter(fun (st: Ast.composite_type) ->
+      match st with
+        Ast.StructDef s -> 
+            if is_structure_defined s.Ast.sname then 
+                failwithf "duplicated structure definition `%s'" s.Ast.sname
+            else 
+                defined_structure := (s, is_structure_deep_copy s) :: !defined_structure;
+        | _ -> ()
+      )  ec.comp_defs;
+  List.iter  (fun (fd: Ast.func_decl) ->
+        List.iter (fun (pd: Ast.pdecl) ->
+            let (pt, _)= pd in
+            match pt with
+              | Ast.PTVal (Ast.Struct(s))     ->
+                if is_structure_defined s then
+                      let (struct_def, deep_copy) = get_struct_def s
+                      in
+                      if deep_copy then 
+                        failwithf "the structure declaration \"%s\" specifies a deep copy is expected. Referenced by value in function \"%s\" detected."s fd.Ast.fname
+                      else ()
+                 else ()
+            | Ast.PTPtr (Ast.Ptr(Ast.Struct(s)), attr) ->
+                if is_structure_defined s then
+                      let (_, deep_copy) = get_struct_def s
+                      in
+                      if deep_copy && attr.Ast.pa_direction = Ast.PtrOut then 
+                        failwithf "the structure declaration \"%s\" specifies a deep copy, should not be used with an `out' attribute in function \"%s\"."s fd.Ast.fname
+                      else ()
+                 else ()
+              | _ -> ()
+            ) fd.Ast.plist
+        ) (trusted_fds @ untrusted_fds)
+
+(* Generate code using given function if a parameter is structure pointer. *)
+let invoke_if_struct (ty: Ast.atype) (param_direction: Ast.ptr_direction) (var_name: string)
+    (pre:string -> string -> string)
+    (generator: Ast.ptr_direction -> string -> string -> Ast.atype -> Ast.ptr_attr -> Ast.declarator -> string )
+    (post:string)=
+    match ty with
+        Ast.Ptr(Ast.Struct(struct_type)) ->
+            if is_structure_defined struct_type then
+              let (struct_def, deep_copy)= get_struct_def struct_type
+              in
+              if deep_copy then
+                let body = 
+                  List.fold_left (
+                    fun acc (pty, declr) ->
+                     match pty with
+                        Ast.PTVal _          -> acc
+                      | Ast.PTPtr (member_ty, member_attr) ->
+                        if member_attr.Ast.pa_size <> Ast.empty_ptr_size then
+                          acc ^ generator param_direction struct_type var_name member_ty member_attr declr
+                        else acc 
+                    ) "" struct_def.Ast.smlist
+                in
+                if body = "" then ""
+                else (pre struct_type var_name) ^ body ^ post
+              else ""
+            else ""
+       | _ -> ""
 
 (* Generate data structure definition *)
 let gen_comp_def (st: Ast.composite_type) =
-  let gen_member_list mlist =
-    List.fold_left (fun acc (ty, declr) ->
-                      acc ^ mk_member_decl ty declr) "" mlist
+  let gen_union_member_list mlist =
+    List.fold_left (fun acc (ty, pdeclr) ->
+                 acc ^ mk_member_decl ty pdeclr) "" mlist
+  in
+  let gen_struct_member_list mlist =
+    List.fold_left (fun acc (pt, declr) ->
+                acc ^ mk_member_decl (Ast.get_param_atype pt) declr) "" mlist
   in
     match st with
-        Ast.StructDef s -> mk_struct_decl (gen_member_list s.Ast.mlist) s.Ast.sname
-      | Ast.UnionDef  u -> mk_union_decl  (gen_member_list u.Ast.mlist) u.Ast.sname
+        Ast.StructDef s -> mk_struct_decl (gen_struct_member_list s.Ast.smlist) s.Ast.sname
+      | Ast.UnionDef  u -> mk_union_decl  (gen_union_member_list u.Ast.umlist) u.Ast.uname
       | Ast.EnumDef   e -> mk_enum_def    e
 
 (* Generate a list of '#include' *)
@@ -364,18 +463,6 @@ let gen_ecall_marshal_struct (tf: Ast.trusted_func) =
 let gen_ocall_marshal_struct (uf: Ast.untrusted_func) =
     let errno_decl = if uf.Ast.uf_propagate_errno then "\tint ocall_errno;\n" else "" in
     gen_marshal_struct uf.Ast.uf_fdecl errno_decl false
-
-(* Check whether given parameter is `const' specified. *)
-let is_const_ptr (pt: Ast.parameter_type) =
-  let aty = Ast.get_param_atype pt in
-    match pt with
-      Ast.PTVal _      -> false
-    | Ast.PTPtr(_, pa) ->
-      if not pa.Ast.pa_rdonly then false
-      else
-        match aty with
-          Ast.Foreign _ -> false
-        | _             -> true
 
 (* Generate parameter representation. *)
 let gen_parm_str (p: Ast.pdecl) =
@@ -493,7 +580,9 @@ let gen_tproxy_proto (fd: Ast.func_decl) =
                             acc ^ ", " ^ gen_parm_str pd) (gen_parm_str x) xs
   in
   let retval_parm_str = gen_parm_retval fd.Ast.rtype in
-    if fd.Ast.plist = [] then
+    if fd.Ast.plist = [] && fd.Ast.rtype = Ast.Void then
+      sprintf "sgx_status_t SGX_CDECL %s(void)" fd.Ast.fname
+    else if fd.Ast.plist = [] then
       sprintf "sgx_status_t SGX_CDECL %s(%s)" fd.Ast.fname retval_parm_str
     else if fd.Ast.rtype = Ast.Void then
            sprintf "sgx_status_t SGX_CDECL %s(%s)" fd.Ast.fname parm_list
@@ -529,7 +618,7 @@ let gen_uproxy_com_proto (fd: Ast.func_decl) (prefix: string) =
 
 let get_ret_tystr (fd: Ast.func_decl) = Ast.get_tystr fd.Ast.rtype
 let get_plist_str (fd: Ast.func_decl) =
-  if fd.Ast.plist = [] then ""
+  if fd.Ast.plist = [] then "void"
   else List.fold_left (fun acc pd -> acc ^ ", " ^ gen_parm_str pd)
                       (gen_parm_str (List.hd fd.Ast.plist))
                       (List.tl fd.Ast.plist)
@@ -547,8 +636,9 @@ let gen_ufunc_proto (uf: Ast.untrusted_func) =
   let cconv_str = "SGX_" ^ Ast.get_call_conv_str uf.Ast.uf_fattr.Ast.fa_convention in
   let func_name = uf.Ast.uf_fdecl.Ast.fname in
   let plist_str = get_plist_str uf.Ast.uf_fdecl in
-    sprintf "%s%s SGX_UBRIDGE(%s, %s, (%s))"
-            dllimport ret_tystr cconv_str func_name plist_str
+  let func_guard = sprintf "%s_DEFINED__" (String.uppercase func_name) in 
+    sprintf "#ifndef %s\n#define %s\n%s%s SGX_UBRIDGE(%s, %s, (%s));\n#endif"
+            func_guard func_guard dllimport ret_tystr cconv_str func_name plist_str
 
 (* The preemble contains common include expressions. *)
 let gen_uheader_preemble (guard: string) (inclist: string)=
@@ -590,7 +680,7 @@ let gen_untrusted_header (ec: enclave_content) =
   let out_chan = open_out header_fname in
     output_string out_chan (preemble_code ^ "\n");
     List.iter (fun s -> output_string out_chan (s ^ "\n")) comp_def_list;
-    List.iter (fun s -> output_string out_chan (s ^ ";\n")) func_proto_ufunc;
+    List.iter (fun s -> output_string out_chan (s ^ "\n")) func_proto_ufunc;
     output_string out_chan "\n";
     List.iter (fun s -> output_string out_chan (s ^ ";\n")) uproxy_com_proto;
     output_string out_chan header_footer;
@@ -633,8 +723,6 @@ let mk_parm_name_raw (pt: Ast.parameter_type) (declr: Ast.declarator) =
     then
       let dims = get_array_dims (List.tl declr.Ast.array_dims) in
         sprintf "(%s (*)%s)"  tystr dims
-    else if is_const_ptr pt then
-        sprintf "(const %s)" tystr
     else ""
   in
     cast_expr ^ mk_parm_accessor declr.Ast.identifier
@@ -706,10 +794,8 @@ let fill_ms_field (isptr: bool) (pd: Ast.pdecl) =
   let (pt, declr)    = pd in
   let param_name     = declr.Ast.identifier in
   let ms_member_name = mk_ms_member_name param_name in
-  let assignment_str (use_cast: bool) (aty: Ast.atype) =
-    let cast_str = if use_cast then sprintf "(%s)" (Ast.get_tystr aty) else ""
-    in
-      sprintf "%s%s%s = %s%s;" ms_struct_val accessor ms_member_name cast_str param_name
+  let assignment_str (aty: Ast.atype) =
+    sprintf "%s%s%s = %s;" ms_struct_val accessor ms_member_name param_name
   in
   let gen_setup_foreign_array aty =
     sprintf "%s%s%s = (%s *)&%s[0];"
@@ -725,17 +811,15 @@ let fill_ms_field (isptr: bool) (pd: Ast.pdecl) =
   in
     if declr.Ast.array_dims = [] then
       match pt with
-          Ast.PTVal(aty)        -> assignment_str false aty
+          Ast.PTVal(aty)        -> assignment_str aty
         | Ast.PTPtr(aty, pattr) ->
             if pattr.Ast.pa_isary
             then gen_setup_foreign_array aty
             else if pattr.Ast.pa_isstr
-            then assignment_str true aty ^ "\n\t" ^ gen_setup_foreign_str aty
+            then assignment_str aty ^ "\n\t" ^ gen_setup_foreign_str aty
             else if pattr.Ast.pa_iswstr
-            then assignment_str true aty ^ "\n\t" ^ gen_setup_foreign_wstr aty
-            else
-              if pattr.Ast.pa_rdonly then assignment_str true aty
-              else assignment_str false aty
+            then assignment_str aty ^ "\n\t" ^ gen_setup_foreign_wstr aty
+            else assignment_str aty
     else
       (* Arrays are passed by address. *)
       let tystr = Ast.get_tystr (Ast.Ptr (Ast.get_param_atype pt)) in
@@ -917,11 +1001,184 @@ let gen_check_tbridge_ptr_parms (plist: Ast.pdecl list) =
   if pointer_checkings = "" then ""
   else pointer_checkings ^ "\n\t//\n\t// fence after pointer checks\n\t//\n\tsgx_lfence();\n"
 
-
 (* If a foreign type is a readonly pointer, we cast it to 'void*' for memcpy() and free() *)
-let mk_in_ptr_dst_name (rdonly: bool) (ptr_name: string) =
+let mk_in_ptr_dst_name (ty: Ast.atype) (attr: Ast.ptr_attr) (ptr_name: string) =
+  let rdonly = 
+    match ty with
+      Ast.Foreign _ -> attr.Ast.pa_rdonly
+    | _             -> false
+  in
   if rdonly then "(void*)" ^ ptr_name
   else ptr_name
+
+let gen_struct_ptr_size (ty: Ast.atype) (pattr: Ast.ptr_attr) (name: string) (get_parm: string -> string) =
+  let mk_len_size v =
+    match v with
+        Ast.AString s -> get_parm s
+      | Ast.ANumber n -> sprintf "%d" n in
+  let mk_len_count v size_str =
+    match v with
+        Ast.AString s -> sprintf "%s * %s" (get_parm s) size_str
+      | Ast.ANumber n -> sprintf "%d * %s" n size_str in
+  let do_ps_attribute (sattr: Ast.ptr_size) =
+    let size_str =
+      match sattr.Ast.ps_size with
+        Some a -> mk_len_size a
+      | None   -> 
+        match ty with
+          Ast.Ptr ty  -> 
+            sprintf "sizeof(%s)" (Ast.get_tystr ty)
+        | _ -> 
+          if pattr.Ast.pa_isptr then
+            sprintf "sizeof(*%s)" (get_parm name)
+          else
+            sprintf "sizeof(%s)"  (Ast.get_tystr ty)
+    in
+      match sattr.Ast.ps_count with
+        None   -> size_str
+      | Some a -> mk_len_count a size_str
+  in
+  sprintf "%s" (do_ps_attribute pattr.Ast.pa_size)
+  
+(* Generate code to check the length of buffers in structure. *)
+let gen_check_member_length (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) (get_parm: string -> string) (indent: string) (break_out: string list) =
+    let name        = declr.Ast.identifier in
+    let mk_len_size v =
+      match v with
+        Ast.AString s -> get_parm s
+      | Ast.ANumber n -> sprintf "%d" n in
+
+    let gen_check_overflow cnt size_str =
+      let if_statement =
+        match cnt with
+            Ast.AString s -> sprintf "if (%s != 0 &&\n%s\t\t(size_t)%s > (SIZE_MAX / %s)) {\n" size_str indent (get_parm s) size_str
+          | Ast.ANumber n -> sprintf "if (%s != 0 &&\n%s\t\t%d > (SIZE_MAX / %s)) {\n" size_str indent n size_str
+      in
+        (List.fold_left (fun acc s -> acc ^ indent ^ s ^ "\n") if_statement break_out) ^ indent ^ "}"
+    in
+    let size_str =
+      match attr.Ast.pa_size.Ast.ps_size with
+        Some a -> mk_len_size a
+      | None   -> 
+        match ty with
+          Ast.Ptr ty  -> 
+            sprintf "sizeof(%s)" (Ast.get_tystr ty)
+        | _ -> 
+          if attr.Ast.pa_isptr then
+            sprintf "sizeof(*%s)" (get_parm name)
+          else
+            sprintf "sizeof(%s)"  (Ast.get_tystr ty)
+      in
+        match attr.Ast.pa_size.Ast.ps_count with
+          None   -> ""
+        | Some a -> (gen_check_overflow a size_str) 
+
+(* Generate the code to handle structure pointer deep copy,
+ * which is to be inserted before actually calling the trusted function.
+ *)
+let gen_struct_ptr_direction_pre_calculate (param_direction: Ast.ptr_direction) (struct_type: string) (struct_name: string)  (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) =
+    let name        = declr.Ast.identifier in
+    let in_struct_name = mk_in_var struct_name in
+    let in_ptr_name = mk_in_var2 struct_name name in
+    let len_var     = mk_len_var2 struct_name name in
+    let in_struct = sprintf "(%s + i)->%s" in_struct_name in
+    let in_struct_member = sprintf "%s" (in_struct name)  in
+    let gen_tmp_var_for_out = 
+        match param_direction with
+            Ast.PtrInOut ->
+			[
+                    sprintf "if (ADD_ASSIGN_OVERFLOW(_%s_malloc_size, sizeof(void*) + sizeof(size_t))) {" struct_name;
+                    "\tstatus = SGX_ERROR_INVALID_PARAMETER;";
+                    "\tgoto err;";
+                    "}";
+                  ]
+            | _ -> []
+    in
+    let check_size =
+        match ty with
+        Ast.Ptr(Ast.Void) | Ast.Ptr(Ast.Foreign(_)) | Ast.Foreign(_)  | Ast.Ptr(Ast.Struct(_)) -> []
+        | _ ->
+            [
+            sprintf "\tif (%s %% sizeof(*%s) != 0) {" len_var in_ptr_name; (* "size x count" is a multiple of sizeof type *)
+            "\t\tstatus = SGX_ERROR_INVALID_PARAMETER;";
+            "\t\tgoto err;";
+            "\t}";
+            ]
+    in
+    let code_template =
+            [
+            gen_check_member_length ty attr declr in_struct "\t\t\t" ["\tstatus = SGX_ERROR_INVALID_PARAMETER;";"\tgoto err;"];
+            sprintf "if (%s != NULL && (%s = %s) != 0) {" in_struct_member len_var (gen_struct_ptr_size ty attr name in_struct);
+            sprintf "\tif (!sgx_is_outside_enclave(%s, %s)) {" in_struct_member len_var;
+            "\t\tstatus = SGX_ERROR_INVALID_PARAMETER;";
+            "\t\tgoto err;";
+            "\t}\n";
+            ]
+            @ check_size @
+            [
+            sprintf "\tif (ADD_ASSIGN_OVERFLOW(_%s_malloc_size, %s)) {" struct_name len_var;
+            "\t\tstatus = SGX_ERROR_INVALID_PARAMETER;";
+            "\t\tgoto err;";
+            "\t}";
+            "}";
+            ]
+    in
+    List.fold_left (fun acc s -> acc ^ "\t\t\t" ^ s ^ "\n") "" (gen_tmp_var_for_out @ code_template)
+
+(* Generate the code to handle structure pointer deep copy,
+ * which is to be inserted before actually calling the trusted function.
+ *)
+let gen_struct_ptr_direction_pre_copy (param_direction: Ast.ptr_direction) (struct_type: string) (struct_name: string)  (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) =
+    let name        = declr.Ast.identifier in
+    let in_struct_name = mk_in_var struct_name in
+    let in_ptr_name = mk_in_var2 struct_name name in
+    let len_var     = mk_len_var2 struct_name name in
+    let in_ptr_dst_name = mk_in_ptr_dst_name ty attr in_ptr_name in
+    let in_struct = sprintf "(%s + i)->%s" in_struct_name in
+    let in_struct_member = sprintf "%s" (in_struct name)  in
+    let code_template =
+        let gen_tmp_var_for_out = 
+            match param_direction with
+                Ast.PtrInOut -> 
+                    [
+                    sprintf "*(%s*)__tmp_%s = %s;" (Ast.get_tystr ty) in_struct_name in_ptr_name ;
+                    sprintf "__tmp_%s = (void *)((size_t)__tmp_%s + sizeof(void*));" in_struct_name in_struct_name;
+                    sprintf "*(size_t*)__tmp_%s = %s;" in_struct_name len_var;
+                    sprintf "__tmp_%s= (void *)((size_t)__tmp_%s + sizeof(size_t));" in_struct_name in_struct_name;
+                    ]
+                | _ -> []
+        in
+        let check_size =
+                match ty with
+                Ast.Ptr(Ast.Void) | Ast.Ptr(Ast.Foreign(_)) | Ast.Foreign(_)  | Ast.Ptr(Ast.Struct(_)) -> []
+                | _ ->
+                    [
+                    sprintf "\tif (%s %% sizeof(*%s) != 0) {" len_var in_struct_member; (* "size x count" is a multiple of sizeof type *)
+                    "\t\t\tstatus = SGX_ERROR_UNEXPECTED;";
+                    "\t\t\tgoto err;";
+                    "\t}";
+                    ]
+        in
+        [
+        sprintf "%s = %s;" in_ptr_name in_struct_member;
+        sprintf "%s = %s;" len_var (gen_struct_ptr_size ty attr name in_struct);
+        ] @ gen_tmp_var_for_out @
+        [
+        sprintf "if (%s != NULL && %s != 0) {" in_ptr_dst_name len_var;
+        ] @ check_size @
+        [
+        sprintf "\tif (memcpy_s(__tmp_%s, %s, %s, %s)) {" in_struct_name len_var in_struct_member len_var;
+        "\t\tstatus = SGX_ERROR_UNEXPECTED;";
+        "\t\tgoto err;";
+        sprintf "\t}";
+        sprintf "\t%s = __tmp_%s;" in_struct_member in_struct_name;
+        sprintf "\t__tmp_%s = (void *)((size_t)__tmp_%s + %s);" in_struct_name in_struct_name len_var ;
+        "}";
+        "else";
+        sprintf "\t%s = NULL;" in_struct_member;
+        ]
+    in
+    List.fold_left (fun acc s -> acc ^ "\t\t\t" ^ s ^ "\n") "" code_template
 
 (* Generate the code to handle function pointer parameter direction,
  * which is to be inserted before actually calling the trusted function.
@@ -933,33 +1190,90 @@ let gen_parm_ptr_direction_pre (plist: Ast.pdecl list) =
     let in_ptr_name = mk_in_var name in
     let in_ptr_type = sprintf "%s%s" (Ast.get_tystr ty) (if is_ary then "*"  else "") in
     let len_var     = mk_len_var name in
-    let in_ptr_dst_name = mk_in_ptr_dst_name attr.Ast.pa_rdonly in_ptr_name in
+    let in_ptr_dst_name = mk_in_ptr_dst_name ty attr in_ptr_name in
     let tmp_ptr_name= mk_tmp_var name in
     let malloc_and_copy pre_indent =
+      let check_size =
+          if attr.Ast.pa_isstr then [] else
+          if attr.Ast.pa_iswstr then
+                  [
+                  sprintf "\tif (%s %% sizeof(wchar_t) != 0)" len_var;
+                  "\t{";
+                  "\t\tstatus = SGX_ERROR_UNEXPECTED;";
+                  "\t\tgoto err;";
+                  "\t}";
+                  ]
+          else
+              match ty with
+                Ast.Ptr(Ast.Void) | Ast.Ptr(Ast.Foreign(_)) | Ast.Foreign(_) -> []
+              | Ast.Ptr(Ast.Struct(struct_type)) ->
+                    if is_structure_defined struct_type then
+                      let (struct_def, deep_copy)= get_struct_def struct_type
+                      in
+                      if deep_copy then
+                          [
+                          sprintf "\tif ( %s %% sizeof(*%s) != 0)" len_var tmp_ptr_name;
+                          "\t{";
+                          "\t\tstatus = SGX_ERROR_INVALID_PARAMETER;";
+                          "\t\tgoto err;";
+                          "\t}";
+                          ]
+                      else []
+                    else []
+              | _ -> 
+				  [
+				  sprintf "\tif ( %s %% sizeof(*%s) != 0)" len_var tmp_ptr_name;
+				  "\t{";
+				  "\t\tstatus = SGX_ERROR_INVALID_PARAMETER;";
+				  "\t\tgoto err;";
+				  "\t}";
+				  ]
+      in
       match attr.Ast.pa_direction with
           Ast.PtrIn | Ast.PtrInOut ->
-            let wstr_len_check =
-              if attr.Ast.pa_iswstr then
-                let wstr_len_check_template  = [
-                  sprintf "\n\t\tif (%s %% sizeof(wchar_t) != 0)" len_var;
-                  "\t\t{";
-                  "\t\t\tstatus = SGX_ERROR_UNEXPECTED;";
-                  "\t\t\tgoto err;";
-                  "\t\t}";
-                  ]
+            let struct_deep_copy_pre = 
+                let struct_calculate = 
+                    (invoke_if_struct ty attr.Ast.pa_direction name 
+                        (fun struct_type name ->
+                            sprintf "\t\tfor (i = 0; i < %s / sizeof(struct %s); i++){\n"  (mk_len_var name) struct_type
+                        )
+                    gen_struct_ptr_direction_pre_calculate "\t\t}\n")
+                in
+                let struct_malloc =
+                  let code_template = [
+                      sprintf "\t__tmp_%s = malloc(_%s_malloc_size);"(mk_in_var name) name;
+                      sprintf "\tif (__tmp_%s == NULL) {" (mk_in_var name);
+                      "\t\tstatus = SGX_ERROR_OUT_OF_MEMORY;";
+                      "\t\tgoto err;";
+                      "\t}";
+                      ]
                   in
-                  List.fold_left (fun acc s -> acc ^ s ^ "\n") "" wstr_len_check_template
-                else ""
+                  List.fold_left (fun acc s -> acc ^ "\t" ^ s ^ "\n") "" code_template
+                in
+                let struct_copy =
+                    (invoke_if_struct ty attr.Ast.pa_direction name 
+                    (fun struct_type name ->
+                        sprintf "\t\t_in_member_%s = __tmp_%s;\n\t\tfor (i = 0; i < %s / sizeof(struct %s); i++){\n"  name (mk_in_var name) (mk_len_var name) struct_type 
+                    ) gen_struct_ptr_direction_pre_copy "\t\t}\n")
+                in
+                struct_calculate ^ (if struct_calculate = "" then "" else struct_malloc) ^ struct_copy
             in
-            let code_template = [
-              sprintf "if (%s != NULL && %s != 0) {%s" tmp_ptr_name len_var wstr_len_check;
+            let code_template = 
+              [
+              sprintf "if (%s != NULL && %s != 0) {" tmp_ptr_name len_var;
+              ]
+              @ check_size @
+              [
               sprintf "\t%s = (%s)malloc(%s);" in_ptr_name in_ptr_type len_var;
               sprintf "\tif (%s == NULL) {" in_ptr_name;
               "\t\tstatus = SGX_ERROR_OUT_OF_MEMORY;";
               "\t\tgoto err;";
               "\t}\n";
-              sprintf "\tmemcpy(%s, %s, %s);" in_ptr_dst_name tmp_ptr_name len_var;
-            ]
+              sprintf "\tif (memcpy_s(%s, %s, %s, %s)) {" in_ptr_dst_name len_var tmp_ptr_name len_var;
+              "\t\tstatus = SGX_ERROR_UNEXPECTED;";
+              "\t\tgoto err;";
+              sprintf "\t}\n%s" struct_deep_copy_pre;
+              ]
             in
             let s1 = List.fold_left (fun acc s -> acc ^ pre_indent ^ s ^ "\n") "" code_template in
             let s2 =
@@ -988,8 +1302,12 @@ let gen_parm_ptr_direction_pre (plist: Ast.pdecl list) =
               else s1 in
             sprintf "%s\t}\n" s2
         | Ast.PtrOut ->
-            let code_template = [
+            let code_template =
+              [
               sprintf "if (%s != NULL && %s != 0) {" tmp_ptr_name len_var;
+              ]
+              @ check_size @
+              [
               sprintf "\tif ((%s = (%s)malloc(%s)) == NULL) {" in_ptr_name in_ptr_type len_var;
               "\t\tstatus = SGX_ERROR_OUT_OF_MEMORY;";
               "\t\tgoto err;";
@@ -1007,17 +1325,78 @@ let gen_parm_ptr_direction_pre (plist: Ast.pdecl list) =
               Ast.PTVal _          -> acc
             | Ast.PTPtr (ty, attr) -> acc ^ clone_in_ptr ty attr declr) "" plist
 
+(* Generate the code to handle tructure pointer deep copy,
+ * which is to be inserted after finishing calling the trusted function.
+ *)
+let gen_struct_ptr_direction_post (param_direction: Ast.ptr_direction) (struct_type: string) (struct_name: string) (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) =
+    let name        = declr.Ast.identifier in
+    let in_struct_name = mk_in_var struct_name in
+    let in_ptr_name = mk_in_var2 struct_name name in
+    let in_struct = sprintf "(%s + i)->%s" in_struct_name in
+    let in_struct_member = sprintf "%s" (in_struct name)  in
+    let in_len_ptr_var = mk_len_var2 struct_name name in
+    let out_len_ptr_var = mk_len_var2 ("out_" ^ struct_name) name in
+      match param_direction with
+          Ast.PtrIn -> ""
+        | Ast.PtrInOut ->
+            let check_size =
+                match ty with
+                Ast.Ptr(Ast.Void) | Ast.Ptr(Ast.Foreign(_)) | Ast.Foreign(_)  | Ast.Ptr(Ast.Struct(_)) -> ""
+                | _ -> sprintf " || (%s %% sizeof(*%s) != 0)" in_len_ptr_var in_struct_member (* "size x count" is a multiple of sizeof type *)
+            in
+            let code_template  = [
+                sprintf "%s = *(%s*)__tmp_%s;" in_ptr_name (Ast.get_tystr ty) in_struct_name;
+                sprintf "__tmp_%s = (void *)((size_t)__tmp_%s + sizeof(void*));" in_struct_name in_struct_name;
+                sprintf "%s = *(size_t*)__tmp_%s;" in_len_ptr_var in_struct_name;
+                sprintf "__tmp_%s = (void *)((size_t)__tmp_%s + sizeof(size_t));" in_struct_name in_struct_name;
+                gen_check_member_length ty attr declr in_struct "\t\t\t" ["\tstatus = SGX_ERROR_INVALID_PARAMETER;";"\tbreak;"];
+                sprintf "size_t %s = %s;" out_len_ptr_var  (gen_struct_ptr_size ty attr name in_struct);
+                sprintf "if(%s!= NULL &&" in_struct_member;
+                sprintf "\t\t%s != 0) {"  out_len_ptr_var;
+                sprintf "\tif (%s > %s%s) {" out_len_ptr_var  in_len_ptr_var check_size;
+                "\t\tstatus = SGX_ERROR_INVALID_PARAMETER;";
+                "\t\tbreak;";
+                "\t}";
+                sprintf "\tif (!sgx_is_within_enclave(%s, %s) ||" in_struct_member out_len_ptr_var;
+                sprintf "\t\t\t!sgx_is_outside_enclave(%s, %s)) {" in_ptr_name in_len_ptr_var;
+                "\t\tstatus = SGX_ERROR_INVALID_PARAMETER;";
+                "\t\tbreak;";
+                "\t}";
+                sprintf "\tif (memcpy_s(%s, %s, %s, %s)) {" in_ptr_name in_len_ptr_var in_struct_member out_len_ptr_var;
+                sprintf "\t\tstatus = SGX_ERROR_UNEXPECTED;";
+                "\t\tbreak;";
+                "\t}";
+                "}";
+                sprintf "%s = %s;" in_struct_member in_ptr_name;
+                sprintf "__tmp_%s = (void *)((size_t)__tmp_%s + %s);" in_struct_name in_struct_name in_len_ptr_var;
+                ]
+          in
+          List.fold_left (fun acc s -> acc ^ "\t\t\t" ^ s ^ "\n") "" code_template
+        | _ -> ""
+
 (* Generate the code to handle function pointer parameter direction,
  * which is to be inserted after finishing calling the trusted function.
  *)
 let gen_parm_ptr_direction_post (plist: Ast.pdecl list) =
-  let copy_and_free (attr: Ast.ptr_attr) (declr: Ast.declarator) =
+  let copy_and_free (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) =
     let name        = declr.Ast.identifier in
     let in_ptr_name = mk_in_var name in
     let len_var     = mk_len_var name in
-    let in_ptr_dst_name = mk_in_ptr_dst_name attr.Ast.pa_rdonly in_ptr_name in
+    let struct_deep_copy_post = 
+          let pre struct_type name =
+            let code_template  = [
+                sprintf "__tmp_%s = _in_member_%s;" (mk_in_var name) name;
+                sprintf "for (i = 0; i < %s / sizeof(struct %s); i++){"  (mk_len_var name) struct_type;
+                "\tif (status != SGX_SUCCESS)";
+                "\t\tbreak;";
+                ]
+            in
+            List.fold_left (fun acc s -> acc ^ "\t\t" ^ s ^ "\n") "" code_template
+          in
+          invoke_if_struct ty attr.Ast.pa_direction name pre gen_struct_ptr_direction_post "\t\t}\n"
+      in
       match attr.Ast.pa_direction with
-          Ast.PtrIn -> sprintf "\tif (%s) free(%s);\n" in_ptr_name in_ptr_dst_name
+        Ast.PtrIn -> ""
         | Ast.PtrInOut | Ast.PtrOut ->
           if attr.Ast.pa_isstr then
                 let code_template  = [
@@ -1025,8 +1404,10 @@ let gen_parm_ptr_direction_post (plist: Ast.pdecl list) =
                   "\t{";
                   sprintf "\t\t%s[%s - 1] = '\\0';" in_ptr_name len_var;
                   sprintf "\t\t%s = strlen(%s) + 1;" len_var in_ptr_name;
-                  sprintf "\t\tmemcpy((void*)%s, %s, %s);" (mk_tmp_var name) in_ptr_name len_var;
-                  sprintf "\t\tfree(%s);" in_ptr_name;
+                  sprintf "\t\tif (memcpy_s((void*)%s, %s, %s, %s)) {" (mk_tmp_var name) len_var in_ptr_name len_var;
+                  "\t\t\tstatus = SGX_ERROR_UNEXPECTED;";
+                  "\t\t\tgoto err;";
+                  "\t\t}";
                   "\t}";
                   ]
                 in
@@ -1037,25 +1418,32 @@ let gen_parm_ptr_direction_post (plist: Ast.pdecl list) =
                   "\t{";
                   sprintf "\t\t%s[(%s - sizeof(wchar_t))/sizeof(wchar_t)] = (wchar_t)0;" in_ptr_name len_var;
                   sprintf "\t\t%s = (wcslen(%s) + 1) * sizeof(wchar_t);" len_var in_ptr_name;
-                  sprintf "\t\tmemcpy((void*)%s, %s, %s);" (mk_tmp_var name) in_ptr_name len_var;
-                  sprintf "\t\tfree(%s);" in_ptr_name;
+                  sprintf "\t\tif (memcpy_s((void*)%s, %s, %s, %s)) {" (mk_tmp_var name) len_var in_ptr_name len_var;
+                  "\t\t\tstatus = SGX_ERROR_UNEXPECTED;";
+                  "\t\t\tgoto err;";
+                  "\t\t}";
                   "\t}";
                   ]
                 in  
                 List.fold_left (fun acc s -> acc ^ s ^ "\n") "" code_template
             else
-              sprintf "\tif (%s) {\n\t\tmemcpy(%s, %s, %s);\n\t\tfree(%s);\n\t}\n"
-                      in_ptr_name
-                      (mk_tmp_var name)
-                      in_ptr_name
-                      len_var
-                      in_ptr_name
+                let code_template  = [ 
+                  sprintf "\tif (%s) {" in_ptr_name;
+                  sprintf "%s\t\tif (memcpy_s(%s, %s, %s, %s)) {" struct_deep_copy_post (mk_tmp_var name) len_var in_ptr_name len_var;
+                  "\t\t\tstatus = SGX_ERROR_UNEXPECTED;";
+                  "\t\t\tgoto err;";
+                  "\t\t}";
+                  "\t}";
+                  ]
+                in
+                List.fold_left (fun acc s -> acc ^ s ^ "\n") "" code_template
         | _ -> ""
-  in List.fold_left
-       (fun acc (pty, declr) ->
+  in
+  List.fold_left
+      (fun acc (pty, declr) ->
           match pty with
               Ast.PTVal _          -> acc
-            | Ast.PTPtr (ty, attr) -> acc ^ copy_and_free attr declr) "" plist
+            | Ast.PTPtr (ty, attr) -> acc ^ copy_and_free ty attr declr) "" plist
 
 
 (* Generate an "err:" goto mark if necessary. *)
@@ -1069,6 +1457,39 @@ let gen_err_mark (plist: Ast.pdecl list) =
                         | Ast.PTPtr(_, attr) -> has_inout_p attr) plist
     then "err:"
     else ""
+
+(* Generate the code to handle function pointer parameter direction,
+ * which is to be inserted after finishing calling the trusted function.
+ *)
+let gen_parm_ptr_free_post (plist: Ast.pdecl list) =
+  let copy_and_free (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) =
+    let name        = declr.Ast.identifier in
+    let in_ptr_name = mk_in_var name in
+    let in_ptr_dst_name = mk_in_ptr_dst_name ty attr in_ptr_name in
+      match attr.Ast.pa_direction with
+        Ast.PtrIn ->
+            let struct_free =
+                match ty with
+                  Ast.Ptr(Ast.Struct(struct_type)) ->
+                        if is_structure_defined struct_type then
+                          let (_, deep_copy)= get_struct_def struct_type
+                          in
+                          if deep_copy then
+                             sprintf "\tif (_in_member_%s) free(_in_member_%s);\n" name name
+                          else ""
+                        else ""
+                  | _ -> ""
+            in
+            sprintf "\tif (%s) free(%s);\n%s" in_ptr_name in_ptr_dst_name struct_free
+        | Ast.PtrInOut | Ast.PtrOut ->
+                  sprintf "\tif (%s) free(%s);\n" in_ptr_name in_ptr_name
+        | _ -> ""
+  in
+  List.fold_left
+      (fun acc (pty, declr) ->
+          match pty with
+              Ast.PTVal _          -> acc
+            | Ast.PTPtr (ty, attr) -> acc ^ copy_and_free ty attr declr) "" plist
 
 (* It is used to save the parameters used as the value of size/count attribute. *)
 let param_cache = Hashtbl.create 1
@@ -1141,20 +1562,32 @@ let mk_parm_name_tbridge (pt: Ast.parameter_type) (declr: Ast.declarator) =
 (* Generate local variables required for the trusted bridge. *)
 let gen_tbridge_local_vars (plist: Ast.pdecl list) =
   let status_var = "\tsgx_status_t status = SGX_SUCCESS;\n" in
-  let do_gen_local_var (ty: Ast.atype) (attr: Ast.ptr_attr) (name: string) =
+  let do_gen_local_var (pt: Ast.parameter_type) (attr: Ast.ptr_attr) (name: string) =
+    let qual = if is_const_ptr pt then "const " else "" in
+    let ty = Ast.get_param_atype pt in
     let tmp_var =
       (* Save a copy of pointer in case it might be modified in the marshaling structure. *)
-      sprintf "\t%s %s = %s;\n" (Ast.get_tystr ty) (mk_tmp_var name) (mk_parm_accessor name)
+      sprintf "\t%s%s %s = %s;\n" qual (Ast.get_tystr ty) (mk_tmp_var name) (mk_parm_accessor name)
     in
     let len_var =
       if not attr.Ast.pa_chkptr then ""
       else gen_tmp_size attr plist ^ "\t" ^ gen_ptr_size ty attr name mk_tmp_var in
     let in_ptr =
       match attr.Ast.pa_direction with
-      Ast.PtrNoDirection -> ""
-    | _ -> sprintf "\t%s %s = NULL;\n" (Ast.get_tystr ty) (mk_in_var name)
+          Ast.PtrNoDirection -> ""
+        | _ -> sprintf "\t%s %s = NULL;\n" (Ast.get_tystr ty) (mk_in_var name)
     in
-      tmp_var ^ len_var ^ in_ptr
+    let in_ptr_struct_var =
+      if not attr.Ast.pa_chkptr then ""
+      else
+       let gen_struct_local_var (param_direction: Ast.ptr_direction) (struct_type: string) (struct_name: string) (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator)=
+           let in_ptr_name = mk_in_var2 struct_name declr.Ast.identifier in
+           let in_len_ptr_name = mk_len_var2 struct_name declr.Ast.identifier in
+           sprintf "\t%s %s = NULL;\n\tsize_t %s = 0;\n" (Ast.get_tystr ty) in_ptr_name in_len_ptr_name 
+       in
+       invoke_if_struct ty attr.Ast.pa_direction name  (fun _ name -> sprintf "\tvoid* __tmp_%s = NULL;\n\tsize_t _%s_malloc_size = 0;\n\tvoid* _in_member_%s = NULL;\n" (mk_in_var name) name name) gen_struct_local_var ""
+    in
+      (tmp_var ^ len_var ^ in_ptr ^ in_ptr_struct_var, if in_ptr_struct_var <> "" then true else false)
   in
   let gen_local_var_for_foreign_array (ty: Ast.atype) (attr: Ast.ptr_attr) (name: string) =
     let tystr = Ast.get_tystr ty in
@@ -1172,16 +1605,19 @@ let gen_tbridge_local_vars (plist: Ast.pdecl list) =
   let gen_local_var (pd: Ast.pdecl) =
     let (pty, declr) = pd in
       match pty with
-      Ast.PTVal _          -> ""
-    | Ast.PTPtr (ty, attr) ->
+          Ast.PTVal _          -> ("", false)
+        | Ast.PTPtr (ty, attr) ->
             if is_foreign_array pty
-            then gen_local_var_for_foreign_array ty attr declr.Ast.identifier
-            else do_gen_local_var ty attr declr.Ast.identifier
+            then (gen_local_var_for_foreign_array ty attr declr.Ast.identifier, false)
+            else do_gen_local_var pty attr declr.Ast.identifier
   in
   let new_param_list = List.map conv_array_to_ptr plist
   in
+  let (str, deep_copy) =
     Hashtbl.clear param_cache;
-    List.fold_left (fun acc pd -> acc ^ gen_local_var pd) status_var new_param_list
+    List.fold_left (fun acc pd -> let (str, deep_copy) =  (gen_local_var pd) in (fst acc ^ str, snd acc || deep_copy)) (status_var, false) new_param_list
+  in
+    str ^ if deep_copy then "\tsize_t i = 0;\n" else ""
 
 (* It generates trusted bridge code for a trusted function. *)
 let gen_func_tbridge (fd: Ast.func_decl) (dummy_var: string) =
@@ -1209,7 +1645,7 @@ let gen_func_tbridge (fd: Ast.func_decl) (dummy_var: string) =
       in
         sprintf "%s%s%s\t%s\n\t%s\n%s" func_open local_vars dummy_var check_pms invoke_func func_close
     else
-      sprintf "%s%s\t%s\n%s\n%s%s\n%s\n\t%s\n%s\n%s\n%s"
+      sprintf "%s%s\t%s\n%s\n%s%s\n%s\n\t%s\n%s\n%s\n%s%s"
         func_open
         (mk_check_pms fd.Ast.fname)
         declare_ms_ptr
@@ -1218,8 +1654,9 @@ let gen_func_tbridge (fd: Ast.func_decl) (dummy_var: string) =
         (gen_check_tbridge_ptr_parms fd.Ast.plist)
         (gen_parm_ptr_direction_pre fd.Ast.plist)
         (if fd.Ast.rtype <> Ast.Void then update_retval else invoke_func)
-        (gen_err_mark fd.Ast.plist)
         (gen_parm_ptr_direction_post fd.Ast.plist)
+        (gen_err_mark fd.Ast.plist)
+        (gen_parm_ptr_free_post fd.Ast.plist)
         func_close
 
 let tproxy_fill_ms_field (pd: Ast.pdecl) (is_ocall_switchless: bool) =
@@ -1232,78 +1669,182 @@ let tproxy_fill_ms_field (pd: Ast.pdecl) (is_ocall_switchless: bool) =
         Ast.PTVal _ -> fill_ms_field true pd
       | Ast.PTPtr(ty, attr) ->
               let is_ary = (Ast.is_array declr || attr.Ast.pa_isary) in
-              let tystr = sprintf "%s%s" (get_param_tystr pt) (if is_ary then "*" else "") in
-              if not attr.Ast.pa_chkptr (* [user_check] specified *)
-              then sprintf "%s = SGX_CAST(%s, %s);" parm_accessor tystr name
+              let tystr = sprintf "%s%s%s" (if is_const_ptr pt then "const " else"")(get_param_tystr pt) (if is_ary then "*" else "") in
+              if not attr.Ast.pa_chkptr then (* [user_check] specified *) 
+                if is_ary then sprintf "%s = SGX_CAST(%s, %s);" parm_accessor tystr name
+                else sprintf "%s = %s;" parm_accessor name
               else
+                let check_size =
+                    match ty with
+                    Ast.Ptr(Ast.Void) | Ast.Ptr(Ast.Foreign(_)) | Ast.Foreign(_)  -> []
+                   | Ast.Ptr(Ast.Struct(struct_type)) ->
+                            if is_structure_defined struct_type then
+                              let (_, deep_copy)= get_struct_def struct_type
+                              in
+                              if deep_copy then
+                                [
+                                   sprintf "\tif (%s %% sizeof(*%s) != 0) {" len_var name;
+                                   sprintf "\t\t%s();" sgx_ocfree_fn;
+                                   "\t\treturn SGX_ERROR_INVALID_PARAMETER;";
+                                   "\t}";
+                                ]
+                                else []
+                            else []
+                   | _ ->
+                    [
+                       sprintf "\tif (%s %% sizeof(*%s) != 0) {" len_var name;
+                       sprintf "\t\t%s();" sgx_ocfree_fn;
+                       "\t\treturn SGX_ERROR_INVALID_PARAMETER;";
+                       "\t}";
+                    ]
+                in
                 match attr.Ast.pa_direction with
                   Ast.PtrOut ->
                     let code_template =
-                      [sprintf "if (%s != NULL && sgx_is_within_enclave(%s, %s)) {" name name len_var;
+                      [sprintf "if (%s != NULL) {" name;
                        sprintf "\t%s = (%s)__tmp;" parm_accessor tystr;
                        sprintf "\t__tmp_%s = __tmp;" name;
+                      ]
+                      @ check_size @
+                      [
                        sprintf "\tmemset(__tmp_%s, 0, %s);" name len_var;
                        sprintf "\t__tmp = (void *)((size_t)__tmp + %s);" len_var;
-                       sprintf "} else if (%s == NULL) {" name;
-                       sprintf "\t%s = NULL;" parm_accessor;
+                       sprintf "\tocalloc_size -= %s;" len_var;
                        "} else {";
-                       "\tsgx_ocfree();";
-                       "\treturn SGX_ERROR_INVALID_PARAMETER;";
+                       sprintf "\t%s = NULL;" parm_accessor;
                        "}"
                       ]
                     in List.fold_left (fun acc s -> acc ^ s ^ "\n\t") "" code_template
                 | Ast.PtrInOut ->
                     let code_template =
-                      [sprintf "if (%s != NULL && sgx_is_within_enclave(%s, %s)) {" name name len_var;
+                      [sprintf "if (%s != NULL) {" name;
                        sprintf "\t%s = (%s)__tmp;" parm_accessor tystr;
                        sprintf "\t__tmp_%s = __tmp;" name;
-                       sprintf "\tmemcpy(__tmp_%s, %s, %s);" name name len_var;
+                      ]
+                      @ check_size @
+                      [
+                       sprintf "\tif (memcpy_s(__tmp_%s, ocalloc_size, %s, %s)) {" name name len_var;
+                       sprintf "\t\t%s();" sgx_ocfree_fn;
+                       "\t\treturn SGX_ERROR_UNEXPECTED;";
+                       "\t}";
                        sprintf "\t__tmp = (void *)((size_t)__tmp + %s);" len_var;
-                       sprintf "} else if (%s == NULL) {" name;
-                       sprintf "\t%s = NULL;" parm_accessor;
+                       sprintf "\tocalloc_size -= %s;" len_var;
                        "} else {";
-                       sprintf "\t%s();" sgx_ocfree_fn;
-                       "\treturn SGX_ERROR_INVALID_PARAMETER;";
+                       sprintf "\t%s = NULL;" parm_accessor;
                        "}"
                       ]
                     in List.fold_left (fun acc s -> acc ^ s ^ "\n\t") "" code_template
                 | _ ->
                     let code_template =
-              [sprintf "if (%s != NULL && sgx_is_within_enclave(%s, %s)) {" name name len_var;
-               sprintf "\t%s = (%s)__tmp;" parm_accessor tystr;
-               sprintf "\tmemcpy(__tmp, %s, %s);" name len_var;
-               sprintf "\t__tmp = (void *)((size_t)__tmp + %s);" len_var;
-               sprintf "} else if (%s == NULL) {" name;
-               sprintf "\t%s = NULL;" parm_accessor;
-               "} else {";
-               sprintf "\t%s();" sgx_ocfree_fn;
-               "\treturn SGX_ERROR_INVALID_PARAMETER;";
-               "}"
-              ]
+					  [sprintf "if (%s != NULL) {" name;
+					   sprintf "\t%s = (%s)__tmp;" parm_accessor tystr;
+                      ]
+                      @ check_size @
+                      [
+					   sprintf "\tif (memcpy_s(__tmp, ocalloc_size, %s, %s)) {"  name len_var;
+					   sprintf "\t\t%s();" sgx_ocfree_fn;
+					   "\t\treturn SGX_ERROR_UNEXPECTED;";
+					   "\t}";
+					   sprintf "\t__tmp = (void *)((size_t)__tmp + %s);" len_var;
+					   sprintf "\tocalloc_size -= %s;" len_var;
+					   "} else {";
+					   sprintf "\t%s = NULL;" parm_accessor;
+					   "}"
+					  ]
                     in List.fold_left (fun acc s -> acc ^ s ^ "\n\t") "" code_template
 
-(* Generate local variables required for the trusted proxy. *)
+(* Attach data pointed by structure member pointer at the end of ms. *)
+let tproxy_fill_structure(pd: Ast.pdecl) (is_ocall_switchless: bool)=
+  let (pt, declr)   = pd in
+  let name          = declr.Ast.identifier in
+  let parm_accessor = mk_parm_accessor name in
+  let sgx_ocfree_fn = get_sgx_fname SGX_OCFREE is_ocall_switchless in
+  let fill_structure(param_direction: Ast.ptr_direction) (struct_type: string) (struct_name: string)  (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) =
+    let member_name        = declr.Ast.identifier in
+    let len_member_name = mk_len_var2 struct_name member_name in
+    let in_struct = sprintf "(%s + i)->%s" parm_accessor in
+    let in_struct_member = sprintf "%s" (in_struct member_name)  in
+    let para_struct = sprintf "(%s + i)->%s" name in
+    let para_struct_member = sprintf "%s" (para_struct member_name)  in
+                match param_direction with
+                | Ast.PtrInOut | Ast.PtrIn  ->
+                    let code_template =
+                      [
+                       sprintf "%s = %s;"  len_member_name (gen_struct_ptr_size ty attr name para_struct);
+                       sprintf "\tif (%s != NULL && %s != 0) {" para_struct_member len_member_name;
+                       sprintf "\t\tif (memcpy_s(__tmp, %s, %s, %s)) {" len_member_name para_struct_member len_member_name;
+                       sprintf "\t\t\t%s();" sgx_ocfree_fn;
+                       "\t\t\treturn SGX_ERROR_UNEXPECTED;";
+                       "\t\t}";
+                       sprintf "\t\t%s = (%s)__tmp;" in_struct_member (Ast.get_tystr ty);
+                       sprintf "\t\t__tmp = (void *)((size_t)__tmp + %s);" len_member_name;
+                       sprintf "\t\tocalloc_size -= %s;" len_member_name;
+                       "\t} else {";
+                       sprintf "\t\t%s = NULL;" in_struct_member;
+                       "\t}"
+                      ]
+                    in List.fold_left (fun acc s -> acc ^ "\t\t\t" ^ s ^ "\n") "" code_template
+                | _ -> ""
+    in
+        match pt with
+              Ast.PTPtr(ty, attr) ->
+                let pre struct_type name = 
+                  let code_template =
+                    if attr.Ast.pa_direction = Ast.PtrInOut then
+                                  [sprintf "if (%s != NULL && %s != 0 ) {" name (mk_len_var name);
+                                   sprintf "\t__tmp_member_%s = __tmp;" name;
+                                   sprintf "\tfor (i = 0; i < %s / sizeof(struct %s); i++){"  (mk_len_var name) struct_type
+                                  ]
+                    else
+                                  [sprintf "if (%s != NULL && %s != 0 ) {" name (mk_len_var name);
+                                   sprintf "\tfor (i = 0; i < %s / sizeof(struct %s); i++){"  (mk_len_var name) struct_type
+                                  ]
+                  in 
+                  List.fold_left (fun acc s -> acc ^ "\t" ^ s ^ "\n") "" code_template
+                  in
+                  invoke_if_struct ty attr.Ast.pa_direction name  pre fill_structure "\t\t}\n\t}\n"
+              | _ -> ""
+
+(* Generate local variables required for the trusted proxy, inclidng variables required by structure deep copy. *)
 let gen_tproxy_local_vars (plist: Ast.pdecl list) =
   let status_var = "sgx_status_t status = SGX_SUCCESS;\n" in
-  let do_gen_local_var (ty: Ast.atype) (attr: Ast.ptr_attr) (name: string) =
-    if not attr.Ast.pa_chkptr then ""
-    else "\t" ^ gen_ptr_size ty attr name (fun x -> x)
+  let do_gen_local_vars (ty: Ast.atype) (attr: Ast.ptr_attr) (name: string) =
+    let do_gen_local_var =
+      if not attr.Ast.pa_chkptr then ""
+      else "\t" ^ gen_ptr_size ty attr name (fun x -> x)
+    in
+    let in_ptr_struct_var =
+      if not attr.Ast.pa_chkptr then ""
+      else
+         let gen_in_ptr_struct_var (_: Ast.ptr_direction) (_: string) (struct_name: string) (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) =
+           let member_name = declr.Ast.identifier in
+           let in_len_ptr_name = mk_len_var2 struct_name member_name in
+           sprintf "\tsize_t %s = 0;\n" in_len_ptr_name 
+         in
+         invoke_if_struct ty attr.Ast.pa_direction name  (fun _ name -> if attr.Ast.pa_direction = Ast.PtrInOut then sprintf"\tvoid* __tmp_member_%s = NULL;\n" name else "") gen_in_ptr_struct_var ""
+    in 
+    (do_gen_local_var ^ in_ptr_struct_var, if in_ptr_struct_var <> "" then true else false)
   in
   let gen_local_var (pd: Ast.pdecl) =
     let (pty, declr) = pd in
       match pty with
-          Ast.PTVal _          -> ""
-        | Ast.PTPtr (ty, attr) -> do_gen_local_var ty attr declr.Ast.identifier
+          Ast.PTVal _          -> ("", false)
+        | Ast.PTPtr (ty, attr) -> do_gen_local_vars ty attr declr.Ast.identifier
   in
   let new_param_list = List.map conv_array_to_ptr plist
   in
-    List.fold_left (fun acc pd -> acc ^ gen_local_var pd) status_var new_param_list
+  let (str, deep_copy) =
+    List.fold_left (fun acc pd -> let (str, deep_copy) =  (gen_local_var pd) in (fst acc ^ str, snd acc || deep_copy)) (status_var, false) new_param_list
+  in
+    str ^ if deep_copy then "\tsize_t i = 0;\n" else ""
+    
 
 (* Generate only one ocalloc block required for the trusted proxy. *)
 let gen_ocalloc_block (fname: string) (plist: Ast.pdecl list) (is_switchless: bool) =
   let ms_struct_name = mk_ms_struct_name fname in
+  let new_param_list = List.map conv_array_to_ptr plist in
   let local_vars_block = sprintf "%s* %s = NULL;\n\tsize_t ocalloc_size = sizeof(%s);\n\tvoid *__tmp = NULL;\n\n" ms_struct_name ms_struct_val ms_struct_name in
-  let local_var (attr: Ast.ptr_attr) (name: string) =
+  let local_var (ty: Ast.atype) (attr: Ast.ptr_attr) (name: string) =
     if not attr.Ast.pa_chkptr then ""
     else
       match attr.Ast.pa_direction with
@@ -1314,11 +1855,29 @@ let gen_ocalloc_block (fname: string) (plist: Ast.pdecl list) (is_switchless: bo
     let (pty, declr) = pd in
       match pty with
         Ast.PTVal _         -> ""
-      | Ast.PTPtr (_, attr) -> local_var attr declr.Ast.identifier
+      | Ast.PTPtr (ty, attr) -> local_var ty attr declr.Ast.identifier
   in
+  let mk_check_enclave_ptr (name: string) (lenvar: string) =
+    let checker = "CHECK_ENCLAVE_POINTER" in
+    sprintf "%s(%s, %s)" checker name lenvar
+  in
+  let check_enclave_ptr_block =
+    let check_enclave_ptr (pd: Ast.pdecl) =
+      let (pty, declr) = pd in
+        match pty with
+          Ast.PTVal _          -> ""
+        | Ast.PTPtr (ty, attr) -> 
+           if not attr.Ast.pa_chkptr then ""
+           else "\t" ^ mk_check_enclave_ptr declr.Ast.identifier (mk_len_var declr.Ast.identifier) ^ ";\n"
+    in 
+    let do_check_enclave_ptr = List.fold_left (fun acc pd -> acc ^ check_enclave_ptr pd) "" new_param_list in
+    let break_line = if do_check_enclave_ptr = "" then "" else "\n" in
+    break_line ^ do_check_enclave_ptr ^ break_line
+  in
+
   let count_ocalloc_size (ty: Ast.atype) (attr: Ast.ptr_attr) (name: string) =
     if not attr.Ast.pa_chkptr then ""
-    else sprintf "\tocalloc_size += (%s != NULL && sgx_is_within_enclave(%s, %s)) ? %s : 0;\n" name name (mk_len_var name) (mk_len_var name)
+    else sprintf "\tif (ADD_ASSIGN_OVERFLOW(ocalloc_size, (%s != NULL) ? %s : 0))\n\t\treturn SGX_ERROR_INVALID_PARAMETER;\n" name (mk_len_var name)
   in
   let do_count_ocalloc_size (pd: Ast.pdecl) =
     let (pty, declr) = pd in
@@ -1336,14 +1895,82 @@ let gen_ocalloc_block (fname: string) (plist: Ast.pdecl list) (is_switchless: bo
       "\t}\n";
       sprintf "\t%s = (%s*)__tmp;\n" ms_struct_val ms_struct_name;
       sprintf "\t__tmp = (void *)((size_t)__tmp + sizeof(%s));\n" ms_struct_name;
+      sprintf "\tocalloc_size -= sizeof(%s);\n" ms_struct_name;
       ]
   in
-  let new_param_list = List.map conv_array_to_ptr plist
-  in
   let s1 = List.fold_left (fun acc pd -> acc ^ do_local_var pd) local_vars_block new_param_list in
-  let s2 = List.fold_left (fun acc pd -> acc ^ do_count_ocalloc_size pd) s1 new_param_list in
+  let s2 = List.fold_left (fun acc pd -> acc ^ do_count_ocalloc_size pd) (s1 ^ check_enclave_ptr_block) new_param_list in
      List.fold_left (fun acc s -> acc ^ s) s2 do_gen_ocalloc_block
-  
+
+(* Generate only one ocalloc block required for the trusted proxy. *)
+let gen_ocalloc_block_struct_deep_copy (fname: string) (plist: Ast.pdecl list) (is_ocall_switchless: bool)=
+  let new_param_list = List.map conv_array_to_ptr plist in
+  let sgx_ocalloc_fn = get_sgx_fname SGX_OCALLOC is_ocall_switchless in
+  let sgx_ocfree_fn = get_sgx_fname SGX_OCFREE is_ocall_switchless in
+  let count_ocalloc_size (ty: Ast.atype) (attr: Ast.ptr_attr) (name: string) =
+    if not attr.Ast.pa_chkptr then ""
+    else 
+      let count_struct_ocalloc_size =  
+         let gen_member_size (_: Ast.ptr_direction) (_: string) (struct_name: string)  (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) =
+           let in_len_ptr_var = mk_len_var2 struct_name declr.Ast.identifier in
+           let para_struct = sprintf "(%s + i)->%s"  struct_name in
+           let check_size =
+                match ty with
+                Ast.Ptr(Ast.Void) | Ast.Ptr(Ast.Foreign(_)) | Ast.Foreign(_)  | Ast.Ptr(Ast.Struct(_)) -> []
+                | _ ->
+                    [
+                       sprintf "if (%s %% sizeof(*%s) != 0) {" in_len_ptr_var (para_struct declr.Ast.identifier); (* "size x count" is a multiple of sizeof type *)
+                       sprintf "\t%s();" sgx_ocfree_fn;
+                       "\treturn SGX_ERROR_INVALID_PARAMETER;";
+                       "}";
+                    ]
+           in
+           let code_template = 
+               [
+               gen_check_member_length ty attr declr para_struct "\t\t\t" [(sprintf "\t%s();" sgx_ocfree_fn);"\treturn SGX_ERROR_INVALID_PARAMETER;"];
+               sprintf "%s = %s;" in_len_ptr_var (gen_struct_ptr_size ty attr struct_name para_struct);
+               ]
+               @ check_size @
+               [
+               sprintf "if (%s && ! sgx_is_within_enclave(%s, %s)) {" (para_struct declr.Ast.identifier)  (para_struct declr.Ast.identifier) in_len_ptr_var;
+               sprintf "\t%s();" sgx_ocfree_fn;
+               "\treturn SGX_ERROR_INVALID_PARAMETER;";
+               "}";
+               sprintf "\tif (ADD_ASSIGN_OVERFLOW(ocalloc_size, (%s != NULL) ? %s : 0)) {" (para_struct declr.Ast.identifier) in_len_ptr_var;
+               sprintf "\t%s();" sgx_ocfree_fn;
+               "\treturn SGX_ERROR_INVALID_PARAMETER;";
+               "}";
+               ]
+           in
+           List.fold_left (fun acc s -> acc ^ "\t\t\t" ^ s ^ "\n") "" code_template
+         in
+         invoke_if_struct ty attr.Ast.pa_direction name (fun struct_type name -> sprintf "\t\tfor (i = 0; i < %s / sizeof(struct %s); i++){\n"  (mk_len_var name) struct_type) gen_member_size "\t\t}\n"
+      in
+      if count_struct_ocalloc_size <> "" then
+                  sprintf "\tif (%s != NULL && %s != 0){\n" name (mk_len_var name) ^
+                  sprintf "%s" count_struct_ocalloc_size ^
+                  "\t}\n"
+      else ""
+  in
+  let do_count_ocalloc_size (pd: Ast.pdecl) =
+    let (pty, declr) = pd in
+      match pty with
+        Ast.PTVal _          -> ""
+      | Ast.PTPtr (ty, attr) -> count_ocalloc_size ty attr declr.Ast.identifier
+  in
+  let do_gen_ocalloc_block = [
+      sprintf "\n\t__tmp = %s(ocalloc_size);\n" sgx_ocalloc_fn;
+      "\tif (__tmp == NULL) {\n";
+      sprintf "\t\t%s();\n" sgx_ocfree_fn;
+      "\t\treturn SGX_ERROR_UNEXPECTED;\n";
+      "\t}\n";
+      ]
+  in
+  let s2 = List.fold_left (fun acc pd -> acc ^ do_count_ocalloc_size pd) "" new_param_list in
+  if s2 = "" then ""
+  else
+     List.fold_left (fun acc s -> acc ^ s) s2 do_gen_ocalloc_block
+
 (* Generate trusted proxy code for a given untrusted function. *)
 let gen_func_tproxy (ufunc: Ast.untrusted_func) (idx: int) =
   let fd = ufunc.Ast.uf_fdecl in
@@ -1351,21 +1978,24 @@ let gen_func_tproxy (ufunc: Ast.untrusted_func) (idx: int) =
   let func_open = sprintf "%s\n{\n" (gen_tproxy_proto fd) in
   let local_vars = gen_tproxy_local_vars fd.Ast.plist in
   let ocalloc_ms_struct = gen_ocalloc_block fd.Ast.fname fd.Ast.plist ufunc.Ast.uf_is_switchless in
+  let ocalloc_struct_deep_copy = gen_ocalloc_block_struct_deep_copy fd.Ast.fname fd.Ast.plist in
   let sgx_ocfree_fn = get_sgx_fname SGX_OCFREE ufunc.Ast.uf_is_switchless in
   let gen_ocfree rtype plist =
     if rtype = Ast.Void && plist = [] && propagate_errno = false then "" else sprintf "\t%s();\n" sgx_ocfree_fn
   in
   let handle_out_ptr plist =
-    let copy_memory (attr: Ast.ptr_attr) (declr: Ast.declarator) =
+    let copy_memory (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) =
       let name = declr.Ast.identifier in
         match attr.Ast.pa_direction with
             Ast.PtrInOut | Ast.PtrOut ->
               if attr.Ast.pa_isstr then
                 let code_template  = [
-                  sprintf "\tif (%s)" name;
-                  "\t{";
+                  sprintf "\tif (%s) {" name;
                   sprintf "\t\tsize_t __tmp%s;" (mk_len_var name);
-                  sprintf "\t\tmemcpy((void*)%s, __tmp_%s, %s);"  name name (mk_len_var name);
+                  sprintf "\t\tif (memcpy_s((void*)%s, %s, __tmp_%s, %s)) {"  name (mk_len_var name) name (mk_len_var name);
+                  sprintf "\t\t\t%s();" sgx_ocfree_fn;
+                  "\t\t\treturn SGX_ERROR_UNEXPECTED;";
+                  "\t\t}";
                   sprintf "\t\t((char*)%s)[%s - 1] = '\\0';" name (mk_len_var name);
                   sprintf "\t\t__tmp%s = strlen(%s) + 1;" (mk_len_var name) name;
                   sprintf "\t\tmemset(%s +__tmp%s - 1, 0, %s -__tmp%s);" name (mk_len_var name) (mk_len_var name) (mk_len_var name);
@@ -1375,10 +2005,12 @@ let gen_func_tproxy (ufunc: Ast.untrusted_func) (idx: int) =
                 List.fold_left (fun acc s -> acc ^ "\t" ^ s ^ "\n") "" code_template
               else if attr.Ast.pa_iswstr then
                 let code_template  = [ 
-                  sprintf "\tif (%s)" name;
-                  "\t{";
+                  sprintf "\tif (%s) {" name;
                   sprintf "\t\tsize_t __tmp%s;" (mk_len_var name);
-                  sprintf "\t\tmemcpy((void*)%s, __tmp_%s, %s);"  name name (mk_len_var name);
+                  sprintf "\t\tif (memcpy_s((void*)%s, %s, __tmp_%s, %s)) {"  name (mk_len_var name) name (mk_len_var name);
+                  sprintf "\t\t\t%s();" sgx_ocfree_fn;
+                  "\t\t\treturn SGX_ERROR_UNEXPECTED;";
+                  "\t\t}";
                   sprintf "\t\t((wchar_t*)%s)[(%s - sizeof(wchar_t))/sizeof(wchar_t)] = (wchar_t)0;" name (mk_len_var name);
                   sprintf "\t\t__tmp%s = (wcslen(%s) + 1) * sizeof(wchar_t);" (mk_len_var name) name;
                   sprintf "\t\tmemset(((uint8_t*)%s) + __tmp%s - sizeof(wchar_t), 0, %s -__tmp%s);" name (mk_len_var name) (mk_len_var name) (mk_len_var name);
@@ -1387,13 +2019,91 @@ let gen_func_tproxy (ufunc: Ast.untrusted_func) (idx: int) =
                 in  
                 List.fold_left (fun acc s -> acc ^ "\t" ^ s ^ "\n") "" code_template
               else
-                sprintf "\t\tif (%s) memcpy((void*)%s, __tmp_%s, %s);\n" name name name (mk_len_var name)
+                let struct_deep_copy_post =
+                    let copy_and_free_struct_member  (_: Ast.ptr_direction) (_: string) (struct_name: string)  (ty: Ast.atype) (attr: Ast.ptr_attr) (declr: Ast.declarator) = 
+                        let name        = declr.Ast.identifier in
+                        let para_struct = sprintf "(%s + i)->%s" struct_name in
+                        let para_struct_member = sprintf "%s" (para_struct name)  in
+                        let local_struct = sprintf "__local_%s.%s" struct_name in
+                        let in_len_ptr_var = mk_len_var2 struct_name name in
+                        let out_len_ptr_var = mk_len_var2 ("out_" ^ struct_name) name in
+                        let check_size =
+                            match ty with
+                            Ast.Ptr(Ast.Void) ->  ""
+                            | _ -> sprintf " || (%s %% sizeof(*%s) != 0)" out_len_ptr_var para_struct_member (* "size x count" is a multiple of sizeof type *)
+                        in
+                        let code_template  = [
+                            sprintf "size_t %s = 0;" out_len_ptr_var;
+                            gen_check_member_length ty attr declr local_struct "\t\t\t\t" [(sprintf "\t%s();" sgx_ocfree_fn);"\treturn SGX_ERROR_INVALID_PARAMETER;"];
+                            sprintf "%s = %s;"  in_len_ptr_var (gen_struct_ptr_size ty attr name para_struct);
+                            sprintf "if(%s!= NULL &&" para_struct_member;
+                            sprintf "\t\t(%s = %s) != 0) {"  out_len_ptr_var (gen_struct_ptr_size ty attr name local_struct);
+                            sprintf "\tif (%s != __tmp_member_%s ||" (local_struct name) struct_name;(*pointer is not changed by untrusted code *)
+                            sprintf "\t\t\t%s > %s%s) {"  out_len_ptr_var in_len_ptr_var check_size;
+                            sprintf "\t\t%s();" sgx_ocfree_fn;
+                            "\t\treturn SGX_ERROR_INVALID_PARAMETER;";
+                            "\t}";
+                            sprintf "\tif (memcpy_s(%s, %s, __tmp_member_%s, %s)) {" para_struct_member in_len_ptr_var struct_name out_len_ptr_var;
+                            sprintf "\t\t%s();" sgx_ocfree_fn;
+                            "\t\treturn SGX_ERROR_UNEXPECTED;";
+                            "\t}";
+                            "}";
+                            sprintf "%s = %s;" (local_struct name) para_struct_member;
+                            sprintf "__tmp_member_%s = (void *)((size_t)__tmp_member_%s + (%s != NULL? %s : 0));" struct_name struct_name para_struct_member in_len_ptr_var;
+
+                            ]
+                        in
+                        List.fold_left (fun acc s -> acc ^ "\t\t\t\t" ^ s ^ "\n") "" code_template
+                    in
+                    let pre (struct_type: string) (name: string) =
+                        let code_template2 = [
+                            sprintf "for (i = 0; i < %s / sizeof(struct %s); i++){" (mk_len_var name) struct_type;
+                            sprintf "\t%s __local_%s;" struct_type name;
+                            sprintf "\tif (memcpy_s(&__local_%s, sizeof(%s), ((%s*)__tmp_%s + i), sizeof(%s))) {"name struct_type struct_type name struct_type;
+                            sprintf "\t\t%s();" sgx_ocfree_fn;
+                            "\t\treturn SGX_ERROR_UNEXPECTED;";
+                            "\t}";
+                            ]
+                        in
+                        List.fold_left (fun acc s -> acc ^ "\t\t\t" ^ s ^ "\n") "\n" code_template2
+                    in
+                    let post =
+                        let code_template3 = [
+                            sprintf "\tif (memcpy_s((void*)(%s + i), sizeof(__local_%s), &__local_%s, sizeof(__local_%s))) {" name name name name;
+                            sprintf "\t\t%s();" sgx_ocfree_fn;
+                            "\t\treturn SGX_ERROR_UNEXPECTED;";
+                            "\t}";
+                            "}";
+                            ]
+                        in
+                        List.fold_left (fun acc s -> acc ^ "\t\t\t" ^ s ^ "\n") "\n" code_template3
+                    in
+                    invoke_if_struct ty attr.Ast.pa_direction name pre copy_and_free_struct_member post
+                in
+                let code_template  = 
+                  if struct_deep_copy_post = "" then
+                      [
+                      sprintf "\tif (%s) {" name;
+                      sprintf "\t\tif (memcpy_s((void*)%s, %s, __tmp_%s, %s)) {" name (mk_len_var name) name (mk_len_var name);
+                      sprintf "\t\t\t%s();" sgx_ocfree_fn;
+                      "\t\t\treturn SGX_ERROR_UNEXPECTED;";
+                      "\t\t}";
+                      "\t}" ;
+                      ]
+                  else
+                      [
+                      sprintf "\tif (%s) {%s" name struct_deep_copy_post;
+                      "\t}" ;
+                      ]
+                in
+                List.fold_left (fun acc s -> acc ^ "\t" ^ s ^ "\n") "" code_template
 
           | _ -> ""
-    in List.fold_left (fun acc (pty, declr) ->
+    in
+    List.fold_left (fun acc (pty, declr) ->
              match pty with
                              Ast.PTVal _ -> acc
-               | Ast.PTPtr(ty, attr) -> acc ^ copy_memory attr declr) "" plist in
+               | Ast.PTPtr(ty, attr) -> acc ^ copy_memory ty attr declr) "" plist in
 
   let set_errno = if propagate_errno then "\t\terrno = ms->ocall_errno;\n" else "" in
   let func_close = sprintf "%s%s%s\n%s%s\n"
@@ -1415,10 +2125,12 @@ let gen_func_tproxy (ufunc: Ast.untrusted_func) (idx: int) =
         func_body := local_vars :: !func_body;
         func_body := ocalloc_ms_struct:: !func_body;
         List.iter (fun pd -> func_body := tproxy_fill_ms_field pd ufunc.Ast.uf_is_switchless :: !func_body ) fd.Ast.plist;
+        func_body := ocalloc_struct_deep_copy ufunc.Ast.uf_is_switchless :: !func_body;
+        List.iter (fun pd -> func_body := tproxy_fill_structure pd ufunc.Ast.uf_is_switchless:: !func_body) fd.Ast.plist;
         func_body := ocall_with_ms :: !func_body;
         func_body := "if (status == SGX_SUCCESS) {" :: !func_body;
         if fd.Ast.rtype <> Ast.Void then func_body := update_retval :: !func_body;
-        List.fold_left (fun acc s -> acc ^ "\t" ^ s ^ "\n") func_open (List.rev !func_body) ^ func_close
+        List.fold_left (fun acc s -> if s = "" then acc else acc ^ "\t" ^ s ^ "\n") func_open (List.rev !func_body) ^ func_close
       end
 
 (* It generates OCALL table and the untrusted proxy to setup OCALL table. *)
@@ -1473,7 +2185,7 @@ let gen_trusted_source (ec: enclave_content) =
 #include \"sgx_trts.h\" /* for sgx_ocalloc, sgx_is_outside_enclave */\n\
 #include \"sgx_lfence.h\" /* for sgx_lfence */\n\n\
 #include <errno.h>\n\
-#include <string.h> /* for memcpy etc */\n\
+#include <mbusafecrt.h> /* for memcpy_s etc */\n\
 #include <stdlib.h> /* for malloc/free etc */\n\
 \n\
 #define CHECK_REF_POINTER(ptr, siz) do {\t\\\n\
@@ -1485,7 +2197,17 @@ let gen_trusted_source (ec: enclave_content) =
 \tif ((ptr) && ! sgx_is_outside_enclave((ptr), (siz)))\t\\\n\
 \t\treturn SGX_ERROR_INVALID_PARAMETER;\\\n\
 } while (0)\n\
-\n" in
+\n\
+#define CHECK_ENCLAVE_POINTER(ptr, siz) do {\t\\\n\
+\tif ((ptr) && ! sgx_is_within_enclave((ptr), (siz)))\t\\\n\
+\t\treturn SGX_ERROR_INVALID_PARAMETER;\\\n\
+} while (0)\n\
+\n\
+#define ADD_ASSIGN_OVERFLOW(a, b) (\t\\\n\
+\t((a) += (b)) < (b)\t\\\n\
+)\n\
+\n"
+  in
   let trusted_fds = tf_list_to_fd_list ec.tfunc_decls in
   let tbridge_list =
     let dummy_var = tbridge_gen_dummy_variable ec in
@@ -1712,6 +2434,7 @@ let gen_enclave_code (e: Ast.enclave) (ep: edger8r_params) =
     create_dir ep.untrusted_dir;
     create_dir ep.trusted_dir;
     check_duplication ec;
+    check_structure ec;
     check_allow_list ec;
     (if not ep.header_only then check_priv_funcs ec);
     if Plugin.available() then

--- a/tools/oeedger8r/intel/Edger8r.ml
+++ b/tools/oeedger8r/intel/Edger8r.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2011-2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/tools/oeedger8r/intel/Lexer.mll
+++ b/tools/oeedger8r/intel/Lexer.mll
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2011-2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/tools/oeedger8r/intel/Makefile
+++ b/tools/oeedger8r/intel/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2018 Intel Corporation. All rights reserved.
+# Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/tools/oeedger8r/intel/Parser.mly
+++ b/tools/oeedger8r/intel/Parser.mly
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -127,6 +127,17 @@ let get_ptr_attr (attr_list: (string * Ast.attr_value) list) =
         [] -> res_attr
       | (k,v) :: xs -> do_get_ptr_attr xs (update_attr k v res_attr)
   in
+    do_get_ptr_attr attr_list            { Ast.pa_direction = Ast.PtrNoDirection;
+                                           Ast.pa_size = Ast.empty_ptr_size;
+                                           Ast.pa_isptr = false;
+                                           Ast.pa_isary = false;
+                                           Ast.pa_isstr = false;
+                                           Ast.pa_iswstr = false;
+                                           Ast.pa_rdonly = false;
+                                           Ast.pa_chkptr = true;
+                                         }
+
+let get_param_ptr_attr (attr_list: (string * Ast.attr_value) list) =
   let has_str_attr (pattr: Ast.ptr_attr) =
     if pattr.Ast.pa_isstr && pattr.Ast.pa_iswstr
     then failwith "`string' and `wstring' are mutual exclusive"
@@ -168,19 +179,20 @@ let get_ptr_attr (attr_list: (string * Ast.attr_value) list) =
         then failwith "`isary' cannot be used with `string/wstring' together"
         else failwith "`isary' cannot be used with `isptr' together"
   in
-  let pattr = do_get_ptr_attr attr_list { Ast.pa_direction = Ast.PtrNoDirection;
-                                          Ast.pa_size = Ast.empty_ptr_size;
-                                          Ast.pa_isptr = false;
-                                          Ast.pa_isary = false;
-                                          Ast.pa_isstr = false;
-                                          Ast.pa_iswstr = false;
-                                          Ast.pa_rdonly = false;
-                                          Ast.pa_chkptr = true;
-                                        }
+  let pattr = get_ptr_attr attr_list in
+  if pattr.Ast.pa_isary
+  then check_invalid_ary_attr pattr
+  else check_invalid_ptr_size pattr |> check_ptr_dir
+
+    
+let get_member_ptr_attr (attr_list: (string * Ast.attr_value) list) =
+  let check_invalid_ptr_size (pattr: Ast.ptr_attr) =
+          if pattr.Ast.pa_size = Ast.empty_ptr_size
+          then failwith "size/count attributes must be used"
+          else pattr
   in
-    if pattr.Ast.pa_isary
-    then check_invalid_ary_attr pattr
-    else check_invalid_ptr_size pattr |> check_ptr_dir
+  let pattr = get_ptr_attr attr_list in
+  check_invalid_ptr_size pattr
 
 (* Untrusted functions can have these attributes:
  *
@@ -406,7 +418,7 @@ declarator: Tidentifier    { { Ast.identifier = $1; Ast.array_dims = []; } }
  * to tell whether the identifier is followed by array dimensions.
 */
 param_type: attr_block all_type {
-    let attr = get_ptr_attr $1 in
+    let attr = get_param_ptr_attr $1 in
     (*check the type is build in type or used defined type.*)
     let rec is_foreign s =
       match s with
@@ -430,10 +442,9 @@ param_type: attr_block all_type {
     else if attr.Ast.pa_rdonly && not (attr.Ast.pa_isptr) then
       failwithf "'readonly' attribute is only used with 'isptr' attribute."    else
     match $2 with
-      Ast.Ptr _ -> fun x -> Ast.PTPtr($2, get_ptr_attr $1)
+      Ast.Ptr _ -> fun x -> Ast.PTPtr($2, get_param_ptr_attr $1)
     | _         ->
       if $1 <> [] then
-        let attr = get_ptr_attr $1 in
         match $2 with
           Ast.Foreign s ->
             if attr.Ast.pa_isptr || attr.Ast.pa_isary then fun x -> Ast.PTPtr($2, attr)
@@ -448,8 +459,68 @@ param_type: attr_block all_type {
             else failwithf "unexpected pointer attributes for `%s'" (Ast.get_tystr $2)
       else
         fun is_ary ->
-          if is_ary then Ast.PTPtr($2, get_ptr_attr [])
+          if is_ary then Ast.PTPtr($2, get_param_ptr_attr [])
           else  Ast.PTVal $2
+    }
+  | all_type {
+    match $1 with
+      Ast.Ptr _ -> fun x -> Ast.PTPtr($1, get_param_ptr_attr [])
+    | _         ->
+      fun is_ary ->
+        if is_ary then Ast.PTPtr($1, get_param_ptr_attr [])
+        else  Ast.PTVal $1
+    }
+  | attr_block Tconst type_spec pointer {
+      let attr = get_param_ptr_attr $1
+      in fun x -> Ast.PTPtr($4 $3, { attr with Ast.pa_rdonly = true })
+    }
+  | Tconst type_spec pointer {
+      let attr = get_param_ptr_attr []
+      in fun x -> Ast.PTPtr($3 $2, { attr with Ast.pa_rdonly = true })
+    }
+  ;
+
+
+/* Available types as struct member.
+ *
+ * Instead of returning an value of 'Ast.parameter_type', we return
+ * a lambda which wraps the actual type since so far there is no way
+ * to tell whether the identifier is followed by array dimensions.
+*/
+smember_type: attr_block all_type {
+    let attr = get_member_ptr_attr $1 in
+    (*'isptr', 'isary', 'readonly' not allowed.*)
+    if attr.Ast.pa_direction <> Ast.PtrNoDirection then
+      failwithf "direction attribute is not allowed for structure member."
+    else if attr.Ast.pa_isptr then
+      failwithf "'isptr', attribute is not allowed for structure member."
+    else if attr.Ast.pa_isary then
+      failwithf "'isary', attribute is not allowed for structure member."
+    else if attr.Ast.pa_rdonly then
+      failwithf "'readonly'attribute is not allowed for structure member."
+    else if attr.Ast.pa_isstr then
+      failwithf "'string'attribute is not allowed for structure member."
+    else if attr.Ast.pa_iswstr then
+      failwithf "'wstring' attribute is not allowed for structure member."
+    else
+    match $2 with
+      Ast.Ptr _ -> fun x -> Ast.PTPtr($2, get_member_ptr_attr $1)
+    | _         ->
+      if $1 <> [] then
+        match $2 with
+          Ast.Foreign s ->
+              (* thinking about 'user_defined_type var[4]' *)
+              fun is_ary ->
+                if is_ary then Ast.PTPtr($2, attr)
+                else failwithf "`%s' is considered plain type but decorated with pointer attributes" s
+        | _ ->
+          fun is_ary ->
+            if is_ary then Ast.PTPtr($2, attr)
+            else failwithf "unexpected pointer attributes for `%s'" (Ast.get_tystr $2)
+      else
+        fun is_ary ->
+          if is_ary then Ast.PTPtr($2, get_ptr_attr [])
+          else Ast.PTVal $2
     }
   | all_type {
     match $1 with
@@ -458,17 +529,8 @@ param_type: attr_block all_type {
       fun is_ary ->
         if is_ary then Ast.PTPtr($1, get_ptr_attr [])
         else  Ast.PTVal $1
-    }
-  | attr_block Tconst type_spec pointer {
-      let attr = get_ptr_attr $1
-      in fun x -> Ast.PTPtr($4 $3, { attr with Ast.pa_rdonly = true })
-    }
-  | Tconst type_spec pointer {
-      let attr = get_ptr_attr []
-      in fun x -> Ast.PTPtr($3 $2, { attr with Ast.pa_rdonly = true })
-    }
+  }
   ;
-
 
 attr_block: TLBrack TRBrack       { failwith "no attribute specified." }
   | TLBrack key_val_pairs TRBrack { $2 }
@@ -487,15 +549,15 @@ struct_specifier: Tstruct Tidentifier { Ast.Struct($2) }
 union_specifier:  Tunion  Tidentifier { Ast.Union($2) }
 enum_specifier:   Tenum   Tidentifier { Ast.Enum($2) }
 
-struct_definition: struct_specifier TLBrace member_list TRBrace {
+struct_definition: struct_specifier TLBrace struct_member_list TRBrace {
     let s = { Ast.sname = (match $1 with Ast.Struct s -> s | _ -> "");
-              Ast.mlist = List.rev $3; }
+              Ast.smlist = List.rev $3; }
     in Ast.StructDef(s)
   }
 
-union_definition: union_specifier TLBrace member_list TRBrace {
-    let s = { Ast.sname = (match $1 with Ast.Union s -> s | _ -> "");
-              Ast.mlist = List.rev $3; }
+union_definition: union_specifier TLBrace union_member_list TRBrace {
+    let s = { Ast.uname = (match $1 with Ast.Union s -> s | _ -> "");
+              Ast.umlist = List.rev $3; }
     in Ast.UnionDef(s)
   }
 
@@ -529,11 +591,33 @@ composite_defs: struct_definition     { $1 }
   | enum_definition                   { $1 }
   ;
 
-member_list: member_def TSemicolon    { [$1] }
-  | member_list member_def TSemicolon { $2 :: $1 }
+struct_member_list: struct_member_def TSemicolon    { [$1] }
+  | struct_member_list struct_member_def TSemicolon { $2 :: $1 }
   ;
 
-member_def: all_type declarator { ($1, $2) }
+union_member_list: union_member_def TSemicolon    { [$1] }
+  | union_member_list union_member_def TSemicolon { $2 :: $1 }
+  ;
+
+struct_member_def: smember_type declarator {
+    let pt = $1 (Ast.is_array $2) in
+    let is_void =
+      match pt with
+        Ast.PTVal v -> v = Ast.Void
+      | _           -> false
+    in
+    if is_void then
+      failwithf "parameter `%s' has `void' type." $2.Ast.identifier
+    else
+      (pt, $2)
+}
+
+union_member_def: all_type declarator {
+    if $1 = Ast.Void then
+      failwithf "union member `%s' has `void' type." $2.Ast.identifier
+    else
+      ($1, $2)
+}
 
 /* Importing declarations.
  * ------------------------------------------------------------------------
@@ -637,15 +721,19 @@ propagate_errno: /* nothing */ { false }
   | Tpropagate_errno           { true  }
   ;
 
-untrusted_func_def: attr_block func_def allow_list propagate_errno switchless_annotation {
+untrusted_prefixes: /* nothing */ { [] }
+  | attr_block           { $1  }
+  ;
+
+untrusted_postfixes:  /* nothing */  {  (false, false) }
+  | Tpropagate_errno switchless_annotation  { (true, $2) }
+  | Tswitchless propagate_errno  { ($2, true) }
+  ;
+
+untrusted_func_def: untrusted_prefixes func_def allow_list untrusted_postfixes {
       check_ptr_attr $2 (symbol_start_pos(), symbol_end_pos());
       let fattr = get_func_attr $1 in
-      Ast.Untrusted { Ast.uf_fdecl = $2; Ast.uf_fattr = fattr; Ast.uf_allow_list = $3; Ast.uf_propagate_errno = $4; Ast.uf_is_switchless = $5; }
-    }
-  | func_def allow_list propagate_errno switchless_annotation {
-      check_ptr_attr $1 (symbol_start_pos(), symbol_end_pos());
-      let fattr = get_func_attr [] in
-      Ast.Untrusted { Ast.uf_fdecl = $1; Ast.uf_fattr = fattr; Ast.uf_allow_list = $2; Ast.uf_propagate_errno = $3; Ast.uf_is_switchless = $4; }
+      Ast.Untrusted { Ast.uf_fdecl = $2; Ast.uf_fattr = fattr; Ast.uf_allow_list = $3; Ast.uf_propagate_errno = fst $4; Ast.uf_is_switchless = snd $4; }
     }
   ;
 

--- a/tools/oeedger8r/intel/Plugin.ml
+++ b/tools/oeedger8r/intel/Plugin.ml
@@ -1,3 +1,34 @@
+(*
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *)
+
 (* 
     Dependency injection plugin to allow custom code generation
     from EDL. CodeGen.ml calls into Plugin.available to check 

--- a/tools/oeedger8r/intel/Preprocessor.ml
+++ b/tools/oeedger8r/intel/Preprocessor.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2011-2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,12 +51,6 @@ let read_process (command : string) : Unix.process_status * string =
 
 (*Return None if gcc not found, caller should handle it*)
 let processor_macro ( full_path : string) : string option=
-  None
- (* 
-  Preprocessor is disabled because:
-    1. It causes edger8r to print incorrect line numbers in error messages.
-    2. It does not work in windows.
-
   let gcc_path = snd (read_process "which gcc") in
   if not (String.contains gcc_path  '/' ) then
     (eprintf "warning: preprocessor is not found\n"; None)
@@ -72,4 +66,3 @@ let processor_macro ( full_path : string) : string option=
         else
           Some(snd output)
       | _ -> failwithf "Preprocessor stopped by signal\n"  
-*)

--- a/tools/oeedger8r/intel/SimpleStack.ml
+++ b/tools/oeedger8r/intel/SimpleStack.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2011-2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/tools/oeedger8r/intel/Util.ml
+++ b/tools/oeedger8r/intel/Util.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2011-2018 Intel Corporation. All rights reserved.
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
This is copied from https://github.com/intel/linux-sgx at tag `sgx_2.5`.

It is a straight copy, meaning any and all of our modifications are now
gone, but this is intentional as patches should be applied on top only
as needed.

Really the only change we need to deal with immediately is that `struct`
and `union` types are now represented slightly differently (in order to
support nesting types in structs). This gets us back to the status quo,
and enables us to start developing deep copy support.