### PR TITLE
Disable simulation mode on Windows because of sporadic crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ if (USE_DEBUG_MALLOC AND WIN32)
 endif ()
 
 option(ADD_WINDOWS_ENCLAVE_TESTS "Build Windows enclave tests" OFF)
+# Warning: turning on simulation mode on Windows may cause test failures and random crashes
 option(WIN32_SIMULATION "Windows Simulation Mode" OFF)
 
 find_program(VALGRIND "valgrind")

--- a/host/sgx/create.c
+++ b/host/sgx/create.c
@@ -647,6 +647,9 @@ oe_result_t oe_create_enclave(
         OE_RAISE(OE_OUT_OF_MEMORY);
 
 #if defined(_WIN32)
+    /* Disable simulation mode on windows */
+    if (flags & OE_ENCLAVE_FLAG_SIMULATE)
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Create Windows events for each TCS binding. Enclaves use
      * this event when calling into the host to handle waits/wakes


### PR DESCRIPTION
Fixes #1753 and description from issue is given below:

We need to disable simulation mode Windows because it crashes sporadically. Linux uses the FS register for pthreads and leaves the GS register unused. Simulation mode on Linux takes over the GS register. But Windows uses the FS and GS register and these are corrupted when calling into the enclave in simulation mode.

