### PR TITLE
Fix EDL dependencies in oeedger8r tests

### DIFF
--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -1,27 +1,38 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-oeedl_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/../edl/all.edl 
-    enclave
-    all_t
-    --edl-search-dir ../moreedl
-)
+add_custom_command(
+  OUTPUT all_t.h all_t.c all_args.h
+  DEPENDS
+  ../edl/aliasing.edl
+  ../edl/all.edl
+  ../edl/array.edl
+  ../edl/basic.edl
+  ../edl/enum.edl
+  ../edl/errno.edl
+  ../edl/foreign.edl
+  ../edl/other.edl
+  ../edl/pointer.edl
+  ../edl/string.edl
+  ../edl/struct.edl
+  COMMAND edger8r --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
 # Dummy target used for generating from EDL on demand.
-add_custom_target(edl_gen DEPENDS ${all_t})
+add_custom_target(edl_enc_trusted DEPENDS all_t.h all_t.c all_args.h)
 
-oeedl_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl/bar.edl 
-    enclave-headers
-    bar_t
-)
+add_custom_command(
+  OUTPUT bar_t.h bar_args.h
+  DEPENDS ../moreedl/bar.edl
+  COMMAND edger8r --trusted --header-only --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl bar.edl)
 
 add_enclave(TARGET edl_enc CXX
     SOURCES
+    all_t.c
+    bar_t.h
     bar.cpp
     config.cpp
     foo.cpp
+
     testaliasing.cpp
     testarray.cpp
     testbasic.cpp
@@ -30,16 +41,13 @@ add_enclave(TARGET edl_enc CXX
     testforeign.cpp
     testpointer.cpp
     teststring.cpp
-    teststruct.cpp
-    ${all_t}
-    ${bar_t}
-    )
+    teststruct.cpp)
 
 # The tests intentionally use floats etc in size context.
 # Disable warnings.
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang OR USE_CLANGW)
     set_source_files_properties(
-        ${all_t}
+        all_t.c
         PROPERTIES COMPILE_FLAGS "-Wno-conversion"
     )
     set_source_files_properties(

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -1,26 +1,36 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-oeedl_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/../edl/all.edl 
-    host
-    all_u
-    --edl-search-dir ../moreedl
-)
+add_custom_command(
+  OUTPUT all_u.h all_u.c all_args.h
+  DEPENDS
+  ../edl/aliasing.edl
+  ../edl/all.edl
+  ../edl/array.edl
+  ../edl/basic.edl
+  ../edl/enum.edl
+  ../edl/errno.edl
+  ../edl/foreign.edl
+  ../edl/other.edl
+  ../edl/pointer.edl
+  ../edl/string.edl
+  ../edl/struct.edl
+  COMMAND edger8r --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
-oeedl_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl/bar.edl 
-    host-headers
-    bar_u
-)
+add_custom_command(
+  OUTPUT bar_u.h bar_args.h
+  DEPENDS ../moreedl/bar.edl
+  COMMAND edger8r --untrusted --header-only --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl bar.edl)
 
-oeedl_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/../edl/other.edl
-    host
-    other_u
-)
+add_custom_command(
+  OUTPUT other_u.h other_u.c other_args.h
+  DEPENDS ../edl/other.edl
+  COMMAND edger8r --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl other.edl)
 
-add_executable(edl_host 
+add_executable(edl_host
+    all_u.c
+    bar_u.h
+    other_u.c
     main.cpp
     bar.cpp
     foo.cpp
@@ -33,16 +43,13 @@ add_executable(edl_host
     testpointer.cpp
     teststring.cpp
     teststruct.cpp
-    ${all_u}
-    ${bar_u}
-    ${other_u}
 )
 
 # The tests intentionally use floats etc in size context.
 # Disable warnings.
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang)
     set_source_files_properties(
-        ${all_u}
+        all_u.c
         PROPERTIES COMPILE_FLAGS "-Wno-conversion"
     )
     set_source_files_properties(


### PR DESCRIPTION
This removes the use of the (buggy) `oeedl_file` CMake script in favor
of using CMake custom commands directly. The script does not support
setting more dependencies easily, and abstracts too much making the
build code difficult to follow. Instead we use commands directly, which
means we can explicitly set our build dependencies to include the EDL
files imported in `all.edl`. This fixes the bug where the edger8r was
not rerun if an imported file was changed.