### PR TITLE
Add (ignored) oeedger8r tests for deep copy scenarios

### DIFF
--- a/include/openenclave/internal/tests.h
+++ b/include/openenclave/internal/tests.h
@@ -21,7 +21,7 @@
 
 OE_EXTERNC_BEGIN
 
-#define OE_TEST(COND)                           \
+#define OE_TEST_IF(COND, OE_TEST_ABORT)         \
     do                                          \
     {                                           \
         if (!(COND))                            \
@@ -33,9 +33,14 @@ OE_EXTERNC_BEGIN
                 __LINE__,                       \
                 __FUNCTION__,                   \
                 #COND);                         \
-            OE_ABORT();                         \
+            if (OE_TEST_ABORT)                  \
+                OE_ABORT();                     \
         }                                       \
     } while (0)
+
+#define OE_TEST(COND) OE_TEST_IF(COND, true)
+
+#define OE_TEST_IGNORE(COND) OE_TEST_IF(COND, false)
 
 /*
  * Return flags to pass to oe_create_enclave() based on the OE_SIMULATION

--- a/tests/oeedger8r/behavior/CMakeLists.txt
+++ b/tests/oeedger8r/behavior/CMakeLists.txt
@@ -73,3 +73,7 @@ set_tests_properties(edger8r_count_signedness_warning PROPERTIES
 add_test(NAME edger8r_size_and_count_warning COMMAND edger8r ${EDGER8R_ARGS} size_and_count.edl)
 set_tests_properties(edger8r_size_and_count_warning PROPERTIES
   PASS_REGULAR_EXPRESSION "Function 'size_and_count': simultaneous 'size' and 'count' parameters 'size' and 'count' are not supported by oeedger8r.")
+
+add_test(NAME edger8r_deepcopy_value_warning COMMAND edger8r ${EDGER8R_ARGS} deepcopy_value.edl)
+set_tests_properties(edger8r_deepcopy_value_warning PROPERTIES
+  PASS_REGULAR_EXPRESSION "error: the structure declaration \"MyStruct\" specifies a deep copy is expected. Referenced by value in function \"deepcopy_value\" detected.")

--- a/tests/oeedger8r/behavior/deepcopy_value.edl
+++ b/tests/oeedger8r/behavior/deepcopy_value.edl
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+  struct MyStruct {
+    [count=8] int* ptr;
+  };
+
+  trusted {
+    // This should error because the count parameter attached to
+    // `s.ptr` will be ignored since `s` is being passed by value.
+    // That is, the `struct` definition and its usage are a
+    // contradiction.
+    public void deepcopy_value(struct MyStruct s);
+  };
+};

--- a/tests/oeedger8r/edl/all.edl
+++ b/tests/oeedger8r/edl/all.edl
@@ -6,6 +6,7 @@ enclave  {
     from "aliasing.edl" import *;
     from "array.edl"    import *;
     from "basic.edl"    import *;
+    from "deepcopy.edl" import *;
     from "enum.edl"     import *;
     from "errno.edl"    import *;
     from "foreign.edl"  import *;

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -16,6 +16,12 @@ enclave {
     [count=3] uint64_t* ptr;
   };
 
+  struct CountParamStruct {
+    uint64_t count;
+    size_t size;
+    [count=count] uint64_t* ptr;
+  };
+
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
     public void deepcopy_value(ShallowStruct s, [user_check] uint64_t* ptr);
@@ -27,5 +33,9 @@ enclave {
     // Deep copy of one `CountStruct` with an embedded array should
     // take place.
     public void deepcopy_count([in, count=1] CountStruct* s);
+
+    // Deep copy of one `CountParamStruct` with an embedded array
+    // should take place.
+    public void deepcopy_countparam([in, count=1] CountParamStruct* s);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -28,6 +28,12 @@ enclave {
     [size=size] uint64_t* ptr;
   };
 
+  struct CountSizeParamStruct {
+    uint64_t count;
+    size_t size;
+    [count=count, size=size] uint64_t* ptr;
+  };
+
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
     public void deepcopy_value(ShallowStruct s, [user_check] uint64_t* ptr);
@@ -50,5 +56,9 @@ enclave {
     // Deep copy of one `SizeParamStruct` with an embedded array
     // should take place.
     public void deepcopy_sizeparam([in, count=1] SizeParamStruct* s);
+
+    // Deep copy of one `CountSizeParamStruct` with an embedded array
+    // should take place.
+    public void deepcopy_countsizeparam([in, count=1] CountSizeParamStruct* s);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -68,5 +68,9 @@ enclave {
     // Deep copy of two `SizeParamStruct`s each with an embedded
     // array and different sizes should take place.
     public void deepcopy_sizeparamarray([in, count=2] SizeParamStruct* s);
+
+    // Deep copy of two `CountSizeParamStruct`s each with an embedded
+    // array and different counts should take place.
+    public void deepcopy_countsizeparamarray([in, count=2] CountSizeParamStruct* s);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -4,7 +4,7 @@
 enclave {
   include "stdint.h"
 
-  struct MyStruct {
+  struct ShallowStruct {
     uint64_t count;
     size_t size;
     uint64_t* ptr;
@@ -12,10 +12,10 @@ enclave {
 
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
-    public void deepcopy_value(struct MyStruct s, [user_check] uint64_t* ptr);
+    public void deepcopy_value(ShallowStruct s, [user_check] uint64_t* ptr);
 
     // Although `s` is passed by pointer, because `s.ptr` does not
     // have any attribute, it is still not deep copied.
-    public void deepcopy_shallow([in, count=1] struct MyStruct* s, [user_check] uint64_t* ptr);
+    public void deepcopy_shallow([in, count=1] ShallowStruct* s, [user_check] uint64_t* ptr);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -22,6 +22,12 @@ enclave {
     [count=count] uint64_t* ptr;
   };
 
+  struct SizeParamStruct {
+    uint64_t count;
+    size_t size;
+    [size=size] uint64_t* ptr;
+  };
+
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
     public void deepcopy_value(ShallowStruct s, [user_check] uint64_t* ptr);
@@ -37,5 +43,12 @@ enclave {
     // Deep copy of one `CountParamStruct` with an embedded array
     // should take place.
     public void deepcopy_countparam([in, count=1] CountParamStruct* s);
+
+    // TODO: We should have a `SizeStruct` to test deep copying where
+    // the size attribute is correctly used with a hard-coded value.
+
+    // Deep copy of one `SizeParamStruct` with an embedded array
+    // should take place.
+    public void deepcopy_sizeparam([in, count=1] SizeParamStruct* s);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+  include "stdint.h"
+
+  struct MyStruct {
+    uint64_t count;
+    size_t size;
+    uint64_t* ptr;
+  };
+
+  trusted {
+    // Since `s` is passed by value, `s.ptr` is not deep copied.
+    public void deepcopy_value(struct MyStruct s, [user_check] uint64_t* ptr);
+  };
+};

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -13,5 +13,9 @@ enclave {
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
     public void deepcopy_value(struct MyStruct s, [user_check] uint64_t* ptr);
+
+    // Although `s` is passed by pointer, because `s.ptr` does not
+    // have any attribute, it is still not deep copied.
+    public void deepcopy_shallow([in, count=1] struct MyStruct* s, [user_check] uint64_t* ptr);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -64,5 +64,9 @@ enclave {
     // Deep copy of two `CountParamStruct`s each with an embedded
     // array and different counts should take place.
     public void deepcopy_countparamarray([in, count=2] CountParamStruct* s);
+
+    // Deep copy of two `SizeParamStruct`s each with an embedded
+    // array and different sizes should take place.
+    public void deepcopy_sizeparamarray([in, count=2] SizeParamStruct* s);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -60,5 +60,9 @@ enclave {
     // Deep copy of one `CountSizeParamStruct` with an embedded array
     // should take place.
     public void deepcopy_countsizeparam([in, count=1] CountSizeParamStruct* s);
+
+    // Deep copy of two `CountParamStruct`s each with an embedded
+    // array and different counts should take place.
+    public void deepcopy_countparamarray([in, count=2] CountParamStruct* s);
   };
 };

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -10,6 +10,12 @@ enclave {
     uint64_t* ptr;
   };
 
+  struct CountStruct {
+    uint64_t count;
+    size_t size;
+    [count=3] uint64_t* ptr;
+  };
+
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
     public void deepcopy_value(ShallowStruct s, [user_check] uint64_t* ptr);
@@ -17,5 +23,9 @@ enclave {
     // Although `s` is passed by pointer, because `s.ptr` does not
     // have any attribute, it is still not deep copied.
     public void deepcopy_shallow([in, count=1] ShallowStruct* s, [user_check] uint64_t* ptr);
+
+    // Deep copy of one `CountStruct` with an embedded array should
+    // take place.
+    public void deepcopy_count([in, count=1] CountStruct* s);
   };
 };

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_custom_command(
   OUTPUT all_t.h all_t.c all_args.h
   DEPENDS
+  edger8r
   ../edl/aliasing.edl
   ../edl/all.edl
   ../edl/array.edl

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -8,6 +8,7 @@ add_custom_command(
   ../edl/all.edl
   ../edl/array.edl
   ../edl/basic.edl
+  ../edl/deepcopy.edl
   ../edl/enum.edl
   ../edl/errno.edl
   ../edl/foreign.edl
@@ -36,6 +37,7 @@ add_enclave(TARGET edl_enc CXX
     testaliasing.cpp
     testarray.cpp
     testbasic.cpp
+    testdeepcopy.cpp
     testenum.cpp
     testerrno.cpp
     testforeign.cpp

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -45,7 +45,7 @@ void deepcopy_count(CountStruct* s)
     OE_TEST(s->size == 64);
     for (size_t i = 0; i < 3; ++i)
         OE_TEST(s->ptr[i] == data[i]);
-    OE_TEST(oe_is_within_enclave(s->ptr, 3 * sizeof(uint64_t)));
+    OE_TEST_IGNORE(oe_is_within_enclave(s->ptr, 3 * sizeof(uint64_t)));
 }
 
 // Assert that the struct is deep-copied such that `s->ptr` has a copy
@@ -56,7 +56,7 @@ void deepcopy_countparam(CountParamStruct* s)
     OE_TEST(s->size == 64);
     for (size_t i = 0; i < s->count; ++i)
         OE_TEST(s->ptr[i] == data[i]);
-    OE_TEST(oe_is_within_enclave(s->ptr, s->count * sizeof(uint64_t)));
+    OE_TEST_IGNORE(oe_is_within_enclave(s->ptr, s->count * sizeof(uint64_t)));
 }
 
 // Assert that the struct is deep-copied such that `s->ptr` has a copy
@@ -67,7 +67,7 @@ void deepcopy_sizeparam(SizeParamStruct* s)
     OE_TEST(s->size == 64);
     for (size_t i = 0; i < s->size / sizeof(uint64_t); ++i)
         OE_TEST(s->ptr[i] == data[i]);
-    OE_TEST(oe_is_within_enclave(s->ptr, s->size));
+    OE_TEST_IGNORE(oe_is_within_enclave(s->ptr, s->size));
 }
 
 // Assert that the struct is deep-copied such that `s->ptr` has a copy
@@ -78,7 +78,7 @@ void deepcopy_countsizeparam(CountSizeParamStruct* s)
     OE_TEST(s->size == 4);
     for (size_t i = 0; i < (s->count * s->size) / sizeof(uint64_t); ++i)
         OE_TEST(s->ptr[i] == data[i]);
-    OE_TEST(oe_is_within_enclave(s->ptr, s->count * s->size));
+    OE_TEST_IGNORE(oe_is_within_enclave(s->ptr, s->count * s->size));
 }
 
 // Assert that the struct array is deep-copied such that each
@@ -90,11 +90,13 @@ void deepcopy_countparamarray(CountParamStruct* s)
     OE_TEST(s[0].size == 64);
     for (size_t i = 0; i < s[0].count; ++i)
         OE_TEST(s[0].ptr[i] == data[i]);
-    OE_TEST(oe_is_within_enclave(s[0].ptr, s->count * sizeof(uint64_t)));
+    OE_TEST_IGNORE(
+        oe_is_within_enclave(s[0].ptr, s[0].count * sizeof(uint64_t)));
 
     OE_TEST(s[1].count == 3);
     OE_TEST(s[1].size == 32);
     for (size_t i = 0; i < s[1].count; ++i)
         OE_TEST(s[1].ptr[i] == data[4 + i]);
-    OE_TEST(oe_is_within_enclave(s[1].ptr, s->count * sizeof(uint64_t)));
+    OE_TEST_IGNORE(
+        oe_is_within_enclave(s[1].ptr, s[1].count * sizeof(uint64_t)));
 }

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -69,3 +69,14 @@ void deepcopy_sizeparam(SizeParamStruct* s)
         OE_TEST(s->ptr[i] == data[i]);
     OE_TEST(oe_is_within_enclave(s->ptr, s->size));
 }
+
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of `s->count * s->size` bytes of `data` in enclave memory.
+void deepcopy_countsizeparam(CountSizeParamStruct* s)
+{
+    OE_TEST(s->count == 8);
+    OE_TEST(s->size == 4);
+    for (size_t i = 0; i < (s->count * s->size) / sizeof(uint64_t); ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, s->count * s->size));
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -118,3 +118,21 @@ void deepcopy_sizeparamarray(SizeParamStruct* s)
         OE_TEST(s[1].ptr[i] == data[4 + i]);
     OE_TEST_IGNORE(oe_is_within_enclave(s[1].ptr, s[1].size));
 }
+
+// Assert that the struct array is deep-copied such that each
+// element's `ptr` has a copy of its `count * size` bytes of `data` in
+// enclave memory.
+void deepcopy_countsizeparamarray(CountSizeParamStruct* s)
+{
+    OE_TEST(s[0].count == 8);
+    OE_TEST(s[0].size == 4);
+    for (size_t i = 0; i < (s[0].count * s[0].size) / sizeof(uint64_t); ++i)
+        OE_TEST(s[0].ptr[i] == data[i]);
+    OE_TEST_IGNORE(oe_is_within_enclave(s[0].ptr, s[0].count * s[0].size));
+
+    OE_TEST(s[1].count == 3);
+    OE_TEST(s[1].size == 8);
+    for (size_t i = 0; i < (s[1].count * s[1].size) / sizeof(uint64_t); ++i)
+        OE_TEST(s[1].ptr[i] == data[4 + i]);
+    OE_TEST_IGNORE(oe_is_within_enclave(s[1].ptr, s[1].count * s[1].size));
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -58,3 +58,14 @@ void deepcopy_countparam(CountParamStruct* s)
         OE_TEST(s->ptr[i] == data[i]);
     OE_TEST(oe_is_within_enclave(s->ptr, s->count * sizeof(uint64_t)));
 }
+
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of `s->size` bytes of `data` in enclave memory.
+void deepcopy_sizeparam(SizeParamStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < s->size / sizeof(uint64_t); ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, s->size));
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -47,3 +47,14 @@ void deepcopy_count(CountStruct* s)
         OE_TEST(s->ptr[i] == data[i]);
     OE_TEST(oe_is_within_enclave(s->ptr, 3 * sizeof(uint64_t)));
 }
+
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of `s->count` elements of `data` in enclave memory.
+void deepcopy_countparam(CountParamStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < s->count; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, s->count * sizeof(uint64_t)));
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -16,3 +16,14 @@ void deepcopy_value(struct MyStruct s, uint64_t* ptr)
     OE_TEST(s.ptr == ptr);
     OE_TEST(oe_is_outside_enclave(s.ptr, sizeof(uint64_t)));
 }
+
+// Assert that the struct is shallow-copied (even though it is passed
+// by pointer), such that `s->ptr` is the address of `data[]` in the
+// host (also passed via `ptr`).
+void deepcopy_shallow(struct MyStruct* s, uint64_t* ptr)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    OE_TEST(s->ptr == ptr);
+    OE_TEST(oe_is_outside_enclave(s->ptr, sizeof(uint64_t)));
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -9,7 +9,7 @@
 
 // Assert that the struct is copied by value, such that `s.ptr` is the
 // address of `data[]` in the host (also passed via `ptr`).
-void deepcopy_value(struct MyStruct s, uint64_t* ptr)
+void deepcopy_value(ShallowStruct s, uint64_t* ptr)
 {
     OE_TEST(s.count == 7);
     OE_TEST(s.size == 64);
@@ -20,7 +20,7 @@ void deepcopy_value(struct MyStruct s, uint64_t* ptr)
 // Assert that the struct is shallow-copied (even though it is passed
 // by pointer), such that `s->ptr` is the address of `data[]` in the
 // host (also passed via `ptr`).
-void deepcopy_shallow(struct MyStruct* s, uint64_t* ptr)
+void deepcopy_shallow(ShallowStruct* s, uint64_t* ptr)
 {
     OE_TEST(s->count == 7);
     OE_TEST(s->size == 64);

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../edltestutils.h"
+
+#include <openenclave/enclave.h>
+#include <openenclave/internal/tests.h>
+#include "all_t.h"
+
+// Assert that the struct is copied by value, such that `s.ptr` is the
+// address of `data[]` in the host (also passed via `ptr`).
+void deepcopy_value(struct MyStruct s, uint64_t* ptr)
+{
+    OE_TEST(s.count == 7);
+    OE_TEST(s.size == 64);
+    OE_TEST(s.ptr == ptr);
+    OE_TEST(oe_is_outside_enclave(s.ptr, sizeof(uint64_t)));
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -80,3 +80,21 @@ void deepcopy_countsizeparam(CountSizeParamStruct* s)
         OE_TEST(s->ptr[i] == data[i]);
     OE_TEST(oe_is_within_enclave(s->ptr, s->count * s->size));
 }
+
+// Assert that the struct array is deep-copied such that each
+// element's `ptr` has a copy of its `count` elements of `data` in
+// enclave memory.
+void deepcopy_countparamarray(CountParamStruct* s)
+{
+    OE_TEST(s[0].count == 7);
+    OE_TEST(s[0].size == 64);
+    for (size_t i = 0; i < s[0].count; ++i)
+        OE_TEST(s[0].ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s[0].ptr, s->count * sizeof(uint64_t)));
+
+    OE_TEST(s[1].count == 3);
+    OE_TEST(s[1].size == 32);
+    for (size_t i = 0; i < s[1].count; ++i)
+        OE_TEST(s[1].ptr[i] == data[4 + i]);
+    OE_TEST(oe_is_within_enclave(s[1].ptr, s->count * sizeof(uint64_t)));
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -100,3 +100,21 @@ void deepcopy_countparamarray(CountParamStruct* s)
     OE_TEST_IGNORE(
         oe_is_within_enclave(s[1].ptr, s[1].count * sizeof(uint64_t)));
 }
+
+// Assert that the struct array is deep-copied such that each
+// element's `ptr` has a copy of its `size` bytes of `data` in enclave
+// memory.
+void deepcopy_sizeparamarray(SizeParamStruct* s)
+{
+    OE_TEST(s[0].count == 7);
+    OE_TEST(s[0].size == 64);
+    for (size_t i = 0; i < s[0].size / sizeof(uint64_t); ++i)
+        OE_TEST(s[0].ptr[i] == data[i]);
+    OE_TEST_IGNORE(oe_is_within_enclave(s[0].ptr, s[0].size));
+
+    OE_TEST(s[1].count == 3);
+    OE_TEST(s[1].size == 32);
+    for (size_t i = 0; i < s[1].size / sizeof(uint64_t); ++i)
+        OE_TEST(s[1].ptr[i] == data[4 + i]);
+    OE_TEST_IGNORE(oe_is_within_enclave(s[1].ptr, s[1].size));
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -7,6 +7,15 @@
 #include <openenclave/internal/tests.h>
 #include "all_t.h"
 
+static uint64_t data[8] = {0x1112131415161718,
+                           0x2122232425262728,
+                           0x3132333435363738,
+                           0x4142434445464748,
+                           0x5152535455565758,
+                           0x6162636465666768,
+                           0x7172737475767778,
+                           0x8182838485868788};
+
 // Assert that the struct is copied by value, such that `s.ptr` is the
 // address of `data[]` in the host (also passed via `ptr`).
 void deepcopy_value(ShallowStruct s, uint64_t* ptr)
@@ -26,4 +35,15 @@ void deepcopy_shallow(ShallowStruct* s, uint64_t* ptr)
     OE_TEST(s->size == 64);
     OE_TEST(s->ptr == ptr);
     OE_TEST(oe_is_outside_enclave(s->ptr, sizeof(uint64_t)));
+}
+
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of three elements of `data` in enclave memory.
+void deepcopy_count(CountStruct* s)
+{
+    OE_TEST(s->count == 7);
+    OE_TEST(s->size == 64);
+    for (size_t i = 0; i < 3; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, 3 * sizeof(uint64_t)));
 }

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -8,6 +8,7 @@ add_custom_command(
   ../edl/all.edl
   ../edl/array.edl
   ../edl/basic.edl
+  ../edl/deepcopy.edl
   ../edl/enum.edl
   ../edl/errno.edl
   ../edl/foreign.edl
@@ -36,6 +37,7 @@ add_executable(edl_host
     foo.cpp
     testarray.cpp
     testbasic.cpp
+    testdeepcopy.cpp
     testenum.cpp
     testerrno.cpp
     testforeign.cpp

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_custom_command(
   OUTPUT all_u.h all_u.c all_args.h
   DEPENDS
+  edger8r
   ../edl/aliasing.edl
   ../edl/all.edl
   ../edl/array.edl

--- a/tests/oeedger8r/host/main.cpp
+++ b/tests/oeedger8r/host/main.cpp
@@ -23,6 +23,7 @@ void test_struct_edl_ecalls(oe_enclave_t* enclave);
 void test_enum_edl_ecalls(oe_enclave_t* enclave);
 void test_foreign_edl_ecalls(oe_enclave_t* enclave);
 void test_other_edl_ecalls(oe_enclave_t* enclave);
+void test_deepcopy_edl_ecalls(oe_enclave_t* enclave);
 
 int main(int argc, const char* argv[])
 {
@@ -64,6 +65,7 @@ int main(int argc, const char* argv[])
 
     OE_TEST(configure(enclave, g_enabled) == OE_OK);
 
+    // TODO: Sort these alphabetically.
     test_basic_edl_ecalls(enclave);
     OE_TEST(test_basic_edl_ocalls(enclave) == OE_OK);
 
@@ -92,6 +94,8 @@ int main(int argc, const char* argv[])
 
     test_foreign_edl_ecalls(enclave);
     OE_TEST(test_foreign_edl_ocalls(enclave) == OE_OK);
+
+    test_deepcopy_edl_ecalls(enclave);
 
 done:
     oe_terminate_enclave(enclave);

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -56,5 +56,13 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(deepcopy_sizeparam(enclave, &s[0]) == OE_OK);
     }
 
+    {
+        // TODO: This should succeed only once deep copy is enabled.
+        auto s = init_structs<CountSizeParamStruct>();
+        s[0].count = 8;
+        s[0].size = 4;
+        OE_TEST(deepcopy_countsizeparam(enclave, &s[0]) == OE_OK);
+    }
+
     printf("=== test_deepcopy_edl_ecalls passed\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -38,26 +38,26 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(deepcopy_shallow(enclave, &s[0], data) == OE_OK);
     }
 
+    // TODO: These should succeed only once deep copy is enabled, so
+    // for now we ignore their failures.
+    fprintf(stderr, "=== test_deepcopy_edl_ecalls ignoring failures...\n");
+
     {
-        // TODO: This should succeed only once deep copy is enabled.
         auto s = init_structs<CountStruct>();
         OE_TEST(deepcopy_count(enclave, &s[0]) == OE_OK);
     }
 
     {
-        // TODO: This should succeed only once deep copy is enabled.
         auto s = init_structs<CountParamStruct>();
         OE_TEST(deepcopy_countparam(enclave, &s[0]) == OE_OK);
     }
 
     {
-        // TODO: This should succeed only once deep copy is enabled.
         auto s = init_structs<SizeParamStruct>();
         OE_TEST(deepcopy_sizeparam(enclave, &s[0]) == OE_OK);
     }
 
     {
-        // TODO: This should succeed only once deep copy is enabled.
         auto s = init_structs<CountSizeParamStruct>();
         s[0].count = 8;
         s[0].size = 4;
@@ -65,10 +65,9 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
     }
 
     {
-        // TODO: This should succeed only once deep copy is enabled.
         auto s = init_structs<CountParamStruct>();
         OE_TEST(deepcopy_countparamarray(enclave, s.data()) == OE_OK);
     }
 
-    printf("=== test_deepcopy_edl_ecalls passed\n");
+    printf("=== test_deepcopy_edl_ecalls failures ignored!\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../edltestutils.h"
+
+#include <openenclave/host.h>
+#include <openenclave/internal/tests.h>
+#include "all_u.h"
+
+void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
+{
+    uint64_t data[8] = {0x1112131415161718,
+                        0x2122232425262728,
+                        0x3132333435363738,
+                        0x4142434445464748,
+                        0x5152535455565758,
+                        0x6162636465666768,
+                        0x7172737475767778,
+                        0x8182838485868788};
+
+    struct MyStruct s[] = {{7ULL, 64ULL, data}, {3ULL, 32ULL, &data[4]}};
+    OE_TEST(s[0].ptr[0] == data[0]);
+    OE_TEST(s[0].ptr[7] == data[7]);
+    OE_TEST(s[1].ptr[0] == data[4]);
+    OE_TEST(s[1].ptr[3] == data[7]);
+
+    OE_TEST(deepcopy_value(enclave, s[0], data) == OE_OK);
+
+    printf("=== test_deepcopy_edl_ecalls passed\n");
+}

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -30,9 +30,15 @@ std::array<T, 2> init_structs()
 
 void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
 {
+    // NOTE: These test backwards-compatibility and so should succeed
+    // without deep copy support.
     auto shallow = init_structs<ShallowStruct>();
     OE_TEST(deepcopy_value(enclave, shallow[0], data) == OE_OK);
     OE_TEST(deepcopy_shallow(enclave, &shallow[0], data) == OE_OK);
+
+    // TODO: This should succeed only once deep copy is enabled.
+    auto count = init_structs<CountStruct>();
+    OE_TEST(deepcopy_count(enclave, &count[0]) == OE_OK);
 
     printf("=== test_deepcopy_edl_ecalls passed\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -25,6 +25,7 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
     OE_TEST(s[1].ptr[3] == data[7]);
 
     OE_TEST(deepcopy_value(enclave, s[0], data) == OE_OK);
+    OE_TEST(deepcopy_shallow(enclave, &s[0], data) == OE_OK);
 
     printf("=== test_deepcopy_edl_ecalls passed\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -64,5 +64,11 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(deepcopy_countsizeparam(enclave, &s[0]) == OE_OK);
     }
 
+    {
+        // TODO: This should succeed only once deep copy is enabled.
+        auto s = init_structs<CountParamStruct>();
+        OE_TEST(deepcopy_countparamarray(enclave, s.data()) == OE_OK);
+    }
+
     printf("=== test_deepcopy_edl_ecalls passed\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -69,5 +69,10 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(deepcopy_countparamarray(enclave, s.data()) == OE_OK);
     }
 
+    {
+        auto s = init_structs<SizeParamStruct>();
+        OE_TEST(deepcopy_sizeparamarray(enclave, s.data()) == OE_OK);
+    }
+
     printf("=== test_deepcopy_edl_ecalls failures ignored!\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -30,15 +30,25 @@ std::array<T, 2> init_structs()
 
 void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
 {
-    // NOTE: These test backwards-compatibility and so should succeed
-    // without deep copy support.
-    auto shallow = init_structs<ShallowStruct>();
-    OE_TEST(deepcopy_value(enclave, shallow[0], data) == OE_OK);
-    OE_TEST(deepcopy_shallow(enclave, &shallow[0], data) == OE_OK);
+    {
+        // NOTE: These test backwards-compatibility and so should
+        // succeed without deep copy support.
+        auto s = init_structs<ShallowStruct>();
+        OE_TEST(deepcopy_value(enclave, s[0], data) == OE_OK);
+        OE_TEST(deepcopy_shallow(enclave, &s[0], data) == OE_OK);
+    }
 
-    // TODO: This should succeed only once deep copy is enabled.
-    auto count = init_structs<CountStruct>();
-    OE_TEST(deepcopy_count(enclave, &count[0]) == OE_OK);
+    {
+        // TODO: This should succeed only once deep copy is enabled.
+        auto s = init_structs<CountStruct>();
+        OE_TEST(deepcopy_count(enclave, &s[0]) == OE_OK);
+    }
+
+    {
+        // TODO: This should succeed only once deep copy is enabled.
+        auto s = init_structs<CountParamStruct>();
+        OE_TEST(deepcopy_countparam(enclave, &s[0]) == OE_OK);
+    }
 
     printf("=== test_deepcopy_edl_ecalls passed\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -5,27 +5,34 @@
 
 #include <openenclave/host.h>
 #include <openenclave/internal/tests.h>
+#include <array>
 #include "all_u.h"
 
-void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
-{
-    uint64_t data[8] = {0x1112131415161718,
-                        0x2122232425262728,
-                        0x3132333435363738,
-                        0x4142434445464748,
-                        0x5152535455565758,
-                        0x6162636465666768,
-                        0x7172737475767778,
-                        0x8182838485868788};
+static uint64_t data[8] = {0x1112131415161718,
+                           0x2122232425262728,
+                           0x3132333435363738,
+                           0x4142434445464748,
+                           0x5152535455565758,
+                           0x6162636465666768,
+                           0x7172737475767778,
+                           0x8182838485868788};
 
-    struct MyStruct s[] = {{7ULL, 64ULL, data}, {3ULL, 32ULL, &data[4]}};
+template <typename T>
+std::array<T, 2> init_structs()
+{
+    std::array<T, 2> s = {T{7ULL, 64ULL, data}, T{3ULL, 32ULL, &data[4]}};
     OE_TEST(s[0].ptr[0] == data[0]);
     OE_TEST(s[0].ptr[7] == data[7]);
     OE_TEST(s[1].ptr[0] == data[4]);
     OE_TEST(s[1].ptr[3] == data[7]);
+    return s;
+}
 
-    OE_TEST(deepcopy_value(enclave, s[0], data) == OE_OK);
-    OE_TEST(deepcopy_shallow(enclave, &s[0], data) == OE_OK);
+void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
+{
+    auto shallow = init_structs<ShallowStruct>();
+    OE_TEST(deepcopy_value(enclave, shallow[0], data) == OE_OK);
+    OE_TEST(deepcopy_shallow(enclave, &shallow[0], data) == OE_OK);
 
     printf("=== test_deepcopy_edl_ecalls passed\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -74,5 +74,14 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(deepcopy_sizeparamarray(enclave, s.data()) == OE_OK);
     }
 
+    {
+        auto s = init_structs<CountSizeParamStruct>();
+        s[0].count = 8;
+        s[0].size = 4;
+        s[1].count = 3;
+        s[1].size = 8;
+        OE_TEST(deepcopy_countsizeparamarray(enclave, s.data()) == OE_OK);
+    }
+
     printf("=== test_deepcopy_edl_ecalls failures ignored!\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -50,5 +50,11 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(deepcopy_countparam(enclave, &s[0]) == OE_OK);
     }
 
+    {
+        // TODO: This should succeed only once deep copy is enabled.
+        auto s = init_structs<SizeParamStruct>();
+        OE_TEST(deepcopy_sizeparam(enclave, &s[0]) == OE_OK);
+    }
+
     printf("=== test_deepcopy_edl_ecalls passed\n");
 }


### PR DESCRIPTION
This adds (and ignores the expected failures of) unit tests for the edger8r covering a set of scenarios on an internal document.

As we implement deep-copy support, we can enable these tests by changing `OE_TEST_IGNORE` to `OE_TEST`.