### PR TITLE
Copy TA Dev Kits into predictable locations

### DIFF
--- a/new_platforms/CMakeLists.txt
+++ b/new_platforms/CMakeLists.txt
@@ -158,3 +158,11 @@ add_subdirectory(tests)
 if(WIN32 AND TZ AND SIM)
     add_subdirectory(opteesim)
 endif()
+
+if(TZ)
+    file(GLOB TA_DEV_KIT
+        LIST_DIRECTORIES true
+        ${TA_DEV_KIT_DIR}/*)
+    file(COPY ${TA_DEV_KIT}
+        DESTINATION ${CMAKE_BINARY_DIR}/out/devkit)
+endif()

--- a/new_platforms/CMakeLists.txt
+++ b/new_platforms/CMakeLists.txt
@@ -159,7 +159,7 @@ if(WIN32 AND TZ AND SIM)
     add_subdirectory(opteesim)
 endif()
 
-if(TZ)
+if(UNIX AND TZ AND NOT OE_USE_SIMULATION)
     file(GLOB TA_DEV_KIT
         LIST_DIRECTORIES true
         ${TA_DEV_KIT_DIR}/*)

--- a/new_platforms/scripts/05_prepare_nuget.sh
+++ b/new_platforms/scripts/05_prepare_nuget.sh
@@ -25,15 +25,23 @@ declare -a PLATFORMS=(
     "ls-ls1012grapeboard"
 )
 
-mkdir -p $TARGET || exit 1
+mkdir $TARGET || exit 1
 mkdir -p nuget/tools || exit 1
 
-for PLATFORM in "${PLATFORMS[@]}"
-do
-    mkdir -p $TARGET/$PLATFORM || exit 1
-    cp -R optee/$PLATFORM/export-ta_arm* $TARGET/$PLATFORM || exit 1
-done
+# Copy the TA Dev Kits used to build the SDK into the NuGet package.
+PLATFORM=vexpress-qemu_virt
+mkdir $TARGET/$PLATFORM || exit 1
+cp -R optee/$PLATFORM/export-ta_arm32 $TARGET/$PLATFORM/devkit || exit 1
 
+PLATFORM=vexpress-qemu_armv8a
+mkdir $TARGET/$PLATFORM || exit 1
+cp -R optee/$PLATFORM/export-ta_arm64 $TARGET/$PLATFORM/devkit || exit 1
+
+PLATFORM=ls-ls1012grapeboard
+mkdir $TARGET/$PLATFORM || exit 1
+cp -R optee/$PLATFORM/export-ta_arm64 $TARGET/$PLATFORM/devkit || exit 1
+
+# Copy the SDK binaries into the NuGet package.
 for LIBRARY in "${LIBRARIES[@]}"
 do
     for PLATFORM in "${PLATFORMS[@]}"
@@ -42,4 +50,5 @@ do
     done
 done
 
+# Copy the oeedger8r tool into the NuGet package, too.
 cp build/oeedger8r nuget/tools || exit 1

--- a/new_platforms/scripts/05_prepare_nuget.sh
+++ b/new_platforms/scripts/05_prepare_nuget.sh
@@ -25,7 +25,7 @@ declare -a PLATFORMS=(
     "ls-ls1012grapeboard"
 )
 
-mkdir $TARGET || exit 1
+mkdir -p $TARGET || exit 1
 mkdir -p nuget/tools || exit 1
 
 # Copy the TA Dev Kits used to build the SDK into the NuGet package.


### PR DESCRIPTION
This PR copies the TA Dev Kit used to build the SDK into the output directory. Similarly, it removes copies of Dev Kits that are not used from the NuGet package.