### PR TITLE
Make VSExtension work for edge modules

### DIFF
--- a/new_platforms/vsextension/ProjectWizard/ImportEnclaveCommand.cs
+++ b/new_platforms/vsextension/ProjectWizard/ImportEnclaveCommand.cs
@@ -129,7 +129,7 @@ namespace OpenEnclaveSDK
 
             // Add the configuration to the project.
             var dte = Package.GetGlobalService(typeof(SDTE)) as DTE;
-            Configurations projectConfigs = project.ConfigurationManager.AddConfigurationRow(newName, baseName, true);
+            project.ConfigurationManager.AddConfigurationRow(newName, baseName, true);
 
             // Set the VcpkgConfiguration property of each new configuration to the baseName.
             var vcProject = project.Object as VCProject;


### PR DESCRIPTION
Edge module projects only have x64 not Win32 platform by default.
Also, the VcpkgConfiguration property is needed to compile any configuration other than 'Debug' and 'Release'.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>