### PR TITLE
Update VS extension to use latest nuget package

### DIFF
--- a/new_platforms/vsextension/ItemTemplates/oehost/host.vstemplate
+++ b/new_platforms/vsextension/ItemTemplates/oehost/host.vstemplate
@@ -17,7 +17,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="openenclave" version="0.2.0-CI-20190409-193849" />
+      <package id="openenclave" version="0.2.0-CI-20190521-020719" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave/MyEnclave.vcxproj
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave/MyEnclave.vcxproj
@@ -399,7 +399,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="ecalls.c" />
+    <ClCompile Include="$projectname$_ecalls.c" />
     <ClCompile Include="$projectname$_t.c" />
   </ItemGroup>
   <ItemGroup>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave/enclave.vstemplate
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave/enclave.vstemplate
@@ -15,7 +15,7 @@
   <TemplateContent>
     <Project TargetFileName="$projectname$.vcxproj" File="MyEnclave.vcxproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="$projectname$.vcxproj.filters">MyEnclave.vcxproj.filters</ProjectItem>
-      <ProjectItem ReplaceParameters="true">ecalls.c</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="$projectname$_ecalls.c">ecalls.c</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="$projectname$.edl">MyEnclave.edl</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="$projectname$.config.xml">MyEnclave.config.xml</ProjectItem>
       <ProjectItem ReplaceParameters="true" TargetFileName="$projectname$_private.pem">MyEnclave_private.pem</ProjectItem>
@@ -35,7 +35,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="openenclave" version="0.2.0-CI-20190409-193849" />
+      <package id="openenclave" version="0.2.0-CI-20190521-020719" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave/sub.mk
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave/sub.mk
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-OE_SDK_PATH=../../packages/openenclave.0.2.0-CI-20190409-193849
+OE_SDK_PATH=../../packages/openenclave.0.2.0-CI-20190521-020719
 OE_SDK_INC_PATH=$(OE_SDK_PATH)/build/native/include
 OEEDGER8R=$(OE_SDK_PATH)/tools/oeedger8r
 
@@ -26,7 +26,7 @@ libdirs += $OELibPath$
 srcs-y             += ../$projectname$_t.c
 
 # Add additional sources here
-srcs-y             += ../ecalls.c
+srcs-y             += ../$projectname$_ecalls.c
 
 libnames           += oeenclave
 libnames           += oestdio_enc

--- a/new_platforms/vsextension/ProjectWizard/ImportEnclaveCommand.cs
+++ b/new_platforms/vsextension/ProjectWizard/ImportEnclaveCommand.cs
@@ -310,7 +310,7 @@ namespace OpenEnclaveSDK
                     // Add nuget package to project.
                     // See https://stackoverflow.com/questions/41803738/how-to-programmatically-install-a-nuget-package/41895490#41895490
                     // and more particularly https://docs.microsoft.com/en-us/nuget/visual-studio-extensibility/nuget-api-in-visual-studio
-                    var packageVersions = new Dictionary<string, string>() { { "openenclave", "0.2.0-CI-20190409-193849" } };
+                    var packageVersions = new Dictionary<string, string>() { { "openenclave", "0.2.0-CI-20190521-020719" } };
                     var componentModel = (IComponentModel)(await this.ServiceProvider.GetServiceAsync(typeof(SComponentModel)));
                     var packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
                     packageInstaller.InstallPackagesFromVSExtensionRepository(

--- a/new_platforms/vsextension/ProjectWizard/VS Extension.csproj
+++ b/new_platforms/vsextension/ProjectWizard/VS Extension.csproj
@@ -134,7 +134,7 @@
       <ResourceName>Menus.ctmenu</ResourceName>
       <SubType>Designer</SubType>
     </VSCTCompile>
-    <Content Include="Packages\openenclave.0.2.0-CI-20190409-193849.nupkg">
+    <Content Include="Packages\openenclave.0.2.0-CI-20190521-020719.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <None Include="source.extension.vsixmanifest">

--- a/new_platforms/vsextension/ProjectWizard/WizardImplementation.cs
+++ b/new_platforms/vsextension/ProjectWizard/WizardImplementation.cs
@@ -115,7 +115,7 @@ namespace OpenEnclaveSDK
                 // User picked a specific board for which we have binaries in the nuget package.
                 string solutionDirectory;
                 replacementsDictionary.TryGetValue("$solutiondirectory$", out solutionDirectory);
-                oeFolder = Path.Combine(solutionDirectory, "packages\\openenclave.0.2.0-CI-20190409-193849\\lib\\native\\gcc6\\optee\\v3.3.0\\" + board);
+                oeFolder = Path.Combine(solutionDirectory, "packages\\openenclave.0.2.0-CI-20190521-020719\\lib\\native\\gcc6\\optee\\v3.3.0\\" + board);
             }
             else
             {

--- a/new_platforms/vsextension/ProjectWizard/source.extension.vsixmanifest
+++ b/new_platforms/vsextension/ProjectWizard/source.extension.vsixmanifest
@@ -15,7 +15,7 @@
     <Assets>
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveProject.zip" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
-        <Asset Type="openenclave.0.2.0-CI-20190409-193849.nupkg" d:Source="File" Path="Packages\openenclave.0.2.0-CI-20190409-193849.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="openenclave.0.2.0-CI-20190521-020719.nupkg" d:Source="File" Path="Packages\openenclave.0.2.0-CI-20190521-020719.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="ItemTemplates\Built\OEHostItem.zip" />
     </Assets>


### PR DESCRIPTION
Also fix an issue when using multiple enclave projects, where each
project had an ecalls.c file, leading to clobbering the same object
file, and making it harder to distinguish source files in VS editor
windows.  This makes the ecalls.c file have a unique name, like other
files already did.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>