### PR TITLE
Introduce OE_CRYPTO_ERROR code to replace OE_FAILURE in crypto wrappers

### DIFF
--- a/common/result.c
+++ b/common/result.c
@@ -103,6 +103,8 @@ const char* oe_result_str(oe_result_t result)
             return "OE_VERIFY_CRL_MISSING";
         case OE_VERIFY_REVOKED:
             return "OE_VERIFY_REVOKED";
+        case OE_CRYPTO_ERROR:
+            return "OE_CRYPTO_ERROR";
         case __OE_RESULT_MAX:
             break;
     }

--- a/enclave/asn1.c
+++ b/enclave/asn1.c
@@ -53,7 +53,7 @@ static oe_result_t _get_length(oe_asn1_t* asn1, size_t* length)
 
     rc = mbedtls_asn1_get_len(_pptr(asn1), _end(asn1), length);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     result = OE_OK;
 
@@ -133,7 +133,7 @@ oe_result_t oe_asn1_get_integer(oe_asn1_t* asn1, int* value)
 
     rc = mbedtls_asn1_get_int(_pptr(asn1), _end(asn1), value);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     result = OE_OK;
 
@@ -156,7 +156,7 @@ oe_result_t oe_asn1_get_oid(oe_asn1_t* asn1, oe_oid_string_t* oid)
 
     rc = mbedtls_asn1_get_tag(_pptr(asn1), _end(asn1), &length, tag);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     if (tag != MBEDTLS_ASN1_OID)
         OE_RAISE(OE_FAILURE);
@@ -172,7 +172,7 @@ oe_result_t oe_asn1_get_oid(oe_asn1_t* asn1, oe_oid_string_t* oid)
 
         rc = mbedtls_oid_get_numeric_string(oid->buf, sizeof(*oid), &buf);
         if (rc < 0)
-            OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+            OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
     }
 
     asn1->ptr += length;
@@ -203,7 +203,7 @@ oe_result_t oe_asn1_get_octet_string(
 
     rc = mbedtls_asn1_get_tag(_pptr(asn1), _end(asn1), length, tag);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     *data = asn1->ptr;
     asn1->ptr += *length;

--- a/enclave/cert.c
+++ b/enclave/cert.c
@@ -491,7 +491,7 @@ static int _parse_extensions(
         rc = mbedtls_asn1_get_tag(&p, end, &len, tag);
         if (rc != 0)
         {
-            OE_TRACE_ERROR("mbedtls_asn1_get_tag rc= 0x%x\n", rc);
+            OE_TRACE_ERROR("mbedtls_asn1_get_tag rc = 0x%x\n", rc);
             goto done;
         }
     }
@@ -515,7 +515,7 @@ static int _parse_extensions(
                 rc = mbedtls_asn1_get_tag(&p, end, &len, tag);
                 if (rc != 0)
                 {
-                    OE_TRACE_ERROR("mbedtls_asn1_get_tag rc= 0x%x\n", rc);
+                    OE_TRACE_ERROR("mbedtls_asn1_get_tag rc = 0x%x\n", rc);
                     goto done;
                 }
 
@@ -527,7 +527,7 @@ static int _parse_extensions(
                 rc = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_OID);
                 if (rc != 0)
                 {
-                    OE_TRACE_ERROR("mbedtls_asn1_get_tag rc= 0x%x\n", rc);
+                    OE_TRACE_ERROR("mbedtls_asn1_get_tag rc = 0x%x\n", rc);
                     goto done;
                 }
 
@@ -541,7 +541,8 @@ static int _parse_extensions(
                 oidstr.buf, sizeof(oidstr.buf), &oid);
             if (rc < 0)
             {
-                OE_TRACE_ERROR("mbedtls_oid_get_numeric_string rc= 0x%x\n", rc);
+                OE_TRACE_ERROR(
+                    "mbedtls_oid_get_numeric_string rc = 0x%x\n", rc);
                 goto done;
             }
         }
@@ -551,7 +552,7 @@ static int _parse_extensions(
             rc = (mbedtls_asn1_get_bool(&p, end, &is_critical));
             if (rc != 0 && rc != MBEDTLS_ERR_ASN1_UNEXPECTED_TAG)
             {
-                OE_TRACE_ERROR("mbedtls_asn1_get_bool rc= 0x%x\n", rc);
+                OE_TRACE_ERROR("mbedtls_asn1_get_bool rc = 0x%x\n", rc);
                 goto done;
             }
         }
@@ -562,7 +563,7 @@ static int _parse_extensions(
             rc = mbedtls_asn1_get_tag(&p, end, &len, tag);
             if (rc != 0)
             {
-                OE_TRACE_ERROR("mbedtls_asn1_get_tag rc= 0x%x\n", rc);
+                OE_TRACE_ERROR("mbedtls_asn1_get_tag rc = 0x%x\n", rc);
                 goto done;
             }
 
@@ -628,7 +629,7 @@ oe_result_t oe_cert_read_pem(
     /* Read the PEM buffer into DER format */
     rc = mbedtls_x509_crt_parse(crt, (const uint8_t*)pem_data, pem_size);
     if (rc != 0)
-        OE_RAISE(OE_FAILURE, "mbedtls_x509_crt_parse rc= 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "mbedtls_x509_crt_parse rc = 0x%x\n", rc);
 
     /* Initialize the implementation */
     _cert_init(impl, crt, NULL);
@@ -696,7 +697,7 @@ oe_result_t oe_cert_chain_read_pem(
     rc = mbedtls_x509_crt_parse(
         referent->crt, (const uint8_t*)pem_data, pem_size);
     if (rc != 0)
-        OE_RAISE(OE_FAILURE, "mbedtls_x509_crt_parse rc= 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "mbedtls_x509_crt_parse rc = 0x%x\n", rc);
 
     /* Reorder certs in the chain to preferred order */
     referent->crt = _sort_certs_by_issue_date(referent->crt);

--- a/enclave/cmac.c
+++ b/enclave/cmac.c
@@ -33,7 +33,7 @@ oe_result_t oe_aes_cmac_sign(
 
     info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_128_ECB);
     if (info == NULL)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     oe_secure_zero_fill(aes_cmac->impl, sizeof(*aes_cmac));
 
@@ -44,7 +44,7 @@ oe_result_t oe_aes_cmac_sign(
             message,
             message_length,
             (uint8_t*)aes_cmac->impl) != 0)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     result = OE_OK;
 

--- a/enclave/crl.c
+++ b/enclave/crl.c
@@ -62,7 +62,7 @@ oe_result_t oe_crl_read_der(
     /* Parse the DER data to populate the mbedtls_x509_crl struct */
     rc = mbedtls_x509_crl_parse_der(x509_crl, der_data, der_size);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     /* Initialize the implementation */
     _crl_init(impl, x509_crl);

--- a/enclave/hmac.c
+++ b/enclave/hmac.c
@@ -38,13 +38,13 @@ oe_result_t oe_hmac_sha256_init(
         &impl->ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1);
 
     if (mbedtls_result != 0)
-        OE_RAISE_MSG(OE_FAILURE, "mbedtls error: 0x%x", mbedtls_result);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "mbedtls error: 0x%x", mbedtls_result);
 
     mbedtls_result = mbedtls_md_hmac_starts(&impl->ctx, key, keysize);
     if (mbedtls_result != 0)
     {
         mbedtls_md_free(&impl->ctx);
-        OE_RAISE_MSG(OE_FAILURE, "mbedtls error: 0x%x", mbedtls_result);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "mbedtls error: 0x%x", mbedtls_result);
     }
 
     result = OE_OK;
@@ -68,7 +68,7 @@ oe_result_t oe_hmac_sha256_update(
 
     res = mbedtls_md_hmac_update(&impl->ctx, (const uint8_t*)data, size);
     if (res != 0)
-        OE_RAISE_MSG(OE_FAILURE, "mbedtls error: 0x%x", res);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "mbedtls error: 0x%x", res);
 
     result = OE_OK;
 
@@ -90,7 +90,7 @@ oe_result_t oe_hmac_sha256_final(
 
     res = mbedtls_md_hmac_finish(&impl->ctx, sha256->buf);
     if (res != 0)
-        OE_RAISE_MSG(OE_FAILURE, "mbedtls error: 0x%x", res);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "mbedtls error: 0x%x", res);
 
     result = OE_OK;
 

--- a/enclave/key.c
+++ b/enclave/key.c
@@ -153,7 +153,7 @@ oe_result_t oe_private_key_read_pem(
     /* Parse PEM format into key structure */
     rc = mbedtls_pk_parse_key(&private_key->pk, pem_data, pem_size, NULL, 0);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     /* Fail if PEM data did not contain this type of key */
     if (private_key->pk.pk_info != mbedtls_pk_info_from_type(key_type))
@@ -191,7 +191,7 @@ oe_result_t oe_private_key_write_pem(
     rc = mbedtls_pk_write_key_pem(
         (mbedtls_pk_context*)&private_key->pk, buf, sizeof(buf));
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     /* Handle case where caller's buffer is too small */
     {
@@ -238,7 +238,7 @@ oe_result_t oe_public_key_read_pem(
     /* Parse PEM format into key structure */
     rc = mbedtls_pk_parse_public_key(&public_key->pk, pem_data, pem_size);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     /* Fail if PEM data did not contain an EC key */
     if (public_key->pk.pk_info != mbedtls_pk_info_from_type(key_type))
@@ -276,7 +276,7 @@ oe_result_t oe_public_key_write_pem(
     rc = mbedtls_pk_write_pubkey_pem(
         (mbedtls_pk_context*)&public_key->pk, buf, sizeof(buf));
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     /* Handle case where caller's buffer is too small */
     {
@@ -373,7 +373,7 @@ oe_result_t oe_private_key_sign(
         NULL,
         NULL);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     // If signature buffer parameter is too small:
     if (*signature_size < buffer_size)

--- a/enclave/random.c
+++ b/enclave/random.c
@@ -80,7 +80,7 @@ oe_result_t oe_random_internal(void* data, size_t size)
     /* Generate random data (synchronize access to _drbg instance) */
     rc = mbedtls_ctr_drbg_random(&_drbg, data, size);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     result = OE_OK;
 done:

--- a/enclave/rsa.c
+++ b/enclave/rsa.c
@@ -38,12 +38,12 @@ static oe_result_t _copy_key(
 
     /* If not an RSA key */
     if (src->pk_info != info)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     /* Setup the context for this key type */
     rc = mbedtls_pk_setup(dest, info);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     /* Get the context for this key type */
     if (!(rsa = dest->pk_ctx))
@@ -51,7 +51,7 @@ static oe_result_t _copy_key(
 
     /* Initialize the RSA key from the source */
     if (mbedtls_rsa_copy(rsa, mbedtls_pk_rsa(*src)) != 0)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     /* If not a private key, then clear private key fields */
     if (!copy_private_fields)
@@ -118,7 +118,7 @@ static oe_result_t _get_public_key_modulus_or_exponent(
 
     /* Copy key bytes to the caller's buffer */
     if (mbedtls_mpi_write_binary(mpi, buffer, required_size) != 0)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     *buffer_size = required_size;
 
@@ -159,12 +159,12 @@ static oe_result_t _generate_key_pair(
 
     /* Get the random number generator */
     if (!(drbg = oe_mbedtls_get_drbg()))
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     /* Create key struct */
     rc = mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA));
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     /* Generate the RSA key */
     rc = mbedtls_rsa_gen_key(
@@ -174,7 +174,7 @@ static oe_result_t _generate_key_pair(
         (unsigned int)bits,
         (int)exponent);
     if (rc != 0)
-        OE_RAISE_MSG(OE_FAILURE, "rc = 0x%x\n", rc);
+        OE_RAISE_MSG(OE_CRYPTO_ERROR, "rc = 0x%x\n", rc);
 
     /* Initialize the private key parameter */
     OE_CHECK(

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -39,6 +39,7 @@ if (UNIX)
     crypto/openssl/key.c
     crypto/openssl/random.c
     crypto/openssl/rsa.c
+    crypto/openssl/sha.c
     linux/hostthread.c
     linux/posix.c
     linux/time.c
@@ -47,7 +48,9 @@ elseif (WIN32)
   set(PLATFORM_SRC
     ../3rdparty/mbedtls/mbedtls/library/bignum.c
     crypto/bcrypt/hmac.c
+    crypto/bcrypt/random.c
     crypto/bcrypt/rsa.c
+    crypto/bcrypt/sha.c
     windows/hostthread.c
     windows/posix.c
     windows/time.c)
@@ -131,7 +134,6 @@ add_library(oehost STATIC
   signkey.c
   strings.c
   tests.c
-  crypto/sha.c
   ${PLATFORM_SRC})
 
 target_link_libraries(oehost PUBLIC oe_includes)

--- a/host/crypto/bcrypt/hmac.c
+++ b/host/crypto/bcrypt/hmac.c
@@ -36,8 +36,8 @@ oe_result_t oe_hmac_sha256_init(
         (ULONG)keysize,
         0);
 
-    if (status != STATUS_SUCCESS)
-        OE_RAISE(OE_FAILURE);
+    if (!BCRYPT_SUCCESS(status))
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     ((oe_hmac_sha256_context_impl_t*)context)->handle = handle;
     result = OE_OK;
@@ -61,8 +61,8 @@ oe_result_t oe_hmac_sha256_update(
 
     status = BCryptHashData(impl->handle, (PUCHAR)data, (ULONG)size, 0);
 
-    if (status != STATUS_SUCCESS)
-        OE_RAISE(OE_FAILURE);
+    if (!BCRYPT_SUCCESS(status))
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     result = OE_OK;
 
@@ -85,8 +85,8 @@ oe_result_t oe_hmac_sha256_final(
     status =
         BCryptFinishHash(impl->handle, sha256->buf, sizeof(sha256->buf), 0);
 
-    if (status != STATUS_SUCCESS)
-        OE_RAISE(OE_FAILURE);
+    if (!BCRYPT_SUCCESS(status))
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     result = OE_OK;
 
@@ -97,14 +97,17 @@ done:
 oe_result_t oe_hmac_sha256_free(oe_hmac_sha256_context_t* context)
 {
     oe_result_t result = OE_UNEXPECTED;
+    NTSTATUS status;
     oe_hmac_sha256_context_impl_t* impl =
         (oe_hmac_sha256_context_impl_t*)context;
 
     if (!context)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-    if (BCryptDestroyHash(impl->handle) != STATUS_SUCCESS)
-        OE_RAISE(OE_FAILURE);
+    status = BCryptDestroyHash(impl->handle);
+
+    if (!BCRYPT_SUCCESS(status))
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     result = OE_OK;
 

--- a/host/crypto/bcrypt/random.c
+++ b/host/crypto/bcrypt/random.c
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/internal/raise.h>
+#include <openenclave/internal/random.h>
+#include "bcrypt.h"
+
+oe_result_t oe_random_internal(void* data, size_t size)
+{
+    oe_result_t result = OE_UNEXPECTED;
+
+    /* For consistency with OpenSSL, keep this to int max */
+    if (size > OE_INT_MAX)
+        return OE_INVALID_PARAMETER;
+
+    NTSTATUS status = BCryptGenRandom(
+        NULL, data, (ULONG)size, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+
+    if (!BCRYPT_SUCCESS(status))
+        OE_RAISE_MSG(
+            OE_CRYPTO_ERROR, "BcryptGenRandom failed (err=%#x)\n", status);
+
+    result = OE_OK;
+
+done:
+    return result;
+}

--- a/host/crypto/bcrypt/rsa.c
+++ b/host/crypto/bcrypt/rsa.c
@@ -81,7 +81,7 @@ static oe_result_t _rsa_pem_to_der(
 
     /* With a null buffer, CryptStringToA returns true and sets the size. */
     if (!success)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     der_local = (uint8_t*)malloc(der_local_size);
     if (der_local == NULL)
@@ -97,7 +97,7 @@ static oe_result_t _rsa_pem_to_der(
         NULL);
 
     if (!success)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     *der_data = der_local;
     *der_size = der_local_size;
@@ -146,7 +146,7 @@ oe_result_t oe_rsa_private_key_read_pem(
             &rsa_blob_size);
 
         if (!success)
-            OE_RAISE(OE_FAILURE);
+            OE_RAISE(OE_CRYPTO_ERROR);
     }
 
     /* Step 3: Convert the Crypt object to a BCrypt Key. */
@@ -160,8 +160,8 @@ oe_result_t oe_rsa_private_key_read_pem(
             rsa_blob_size,
             0);
 
-        if (status != STATUS_SUCCESS)
-            OE_RAISE(OE_FAILURE);
+        if (!BCRYPT_SUCCESS(status))
+            OE_RAISE(OE_CRYPTO_ERROR);
     }
 
     /* Step 4: Convery BCrypt Handle to OE type. */
@@ -307,8 +307,8 @@ oe_result_t oe_rsa_private_key_sign(
             &sig_size,
             BCRYPT_PAD_PKCS1);
 
-        if (status != STATUS_SUCCESS)
-            OE_RAISE(OE_FAILURE);
+        if (!BCRYPT_SUCCESS(status))
+            OE_RAISE(OE_CRYPTO_ERROR);
 
         *signature_size = sig_size;
     }
@@ -336,8 +336,8 @@ static oe_result_t _get_public_rsa_blob_info(
     status = BCryptExportKey(
         key, NULL, BCRYPT_RSAPUBLIC_BLOB, NULL, 0, &buffer_local_size, 0);
 
-    if (status != STATUS_SUCCESS)
-        OE_RAISE(OE_FAILURE);
+    if (!BCRYPT_SUCCESS(status))
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     buffer_local = (uint8_t*)malloc(buffer_local_size);
     if (buffer_local == NULL)
@@ -352,13 +352,13 @@ static oe_result_t _get_public_rsa_blob_info(
         &buffer_local_size,
         0);
 
-    if (status != STATUS_SUCCESS)
-        OE_RAISE(OE_FAILURE);
+    if (!BCRYPT_SUCCESS(status))
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     /* Sanity check to ensure we get modulus and public exponent. */
     key_header = (BCRYPT_RSAKEY_BLOB*)buffer_local;
     if (key_header->cbPublicExp == 0 || key_header->cbModulus == 0)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     *buffer = buffer_local;
     *buffer_size = buffer_local_size;
@@ -408,8 +408,8 @@ oe_result_t oe_rsa_get_public_key_from_private(
             keybuf_size,
             0);
 
-        if (status != STATUS_SUCCESS)
-            OE_RAISE(OE_FAILURE);
+        if (!BCRYPT_SUCCESS(status))
+            OE_RAISE(OE_CRYPTO_ERROR);
 
         ((oe_public_key_t*)public_key)->magic = _PUBLIC_KEY_MAGIC;
         ((oe_public_key_t*)public_key)->pkey = public_key_handle;

--- a/host/crypto/openssl/asn1.c
+++ b/host/crypto/openssl/asn1.c
@@ -133,11 +133,11 @@ oe_result_t oe_asn1_get_oid(oe_asn1_t* asn1, oe_oid_string_t* oid)
 
         /* Convert OID to an ASN1 object */
         if (!(obj = d2i_ASN1_OBJECT(&obj, &ptr, (long)oe_asn1_remaining(asn1))))
-            OE_RAISE(OE_FAILURE);
+            OE_RAISE(OE_CRYPTO_ERROR);
 
         /* Convert OID to string format */
         if (!OBJ_obj2txt(oid->buf, sizeof(oe_oid_string_t), obj, 1))
-            OE_RAISE(OE_FAILURE);
+            OE_RAISE(OE_CRYPTO_ERROR);
 
         asn1->ptr = ptr;
     }

--- a/host/crypto/openssl/crl.c
+++ b/host/crypto/openssl/crl.c
@@ -62,7 +62,7 @@ oe_result_t oe_crl_read_der(
     const uint8_t* der_data,
     size_t der_size)
 {
-    oe_result_t result = OE_UNEXPECTED;
+    oe_result_t result = OE_CRYPTO_ERROR;
     crl_t* impl = (crl_t*)crl;
     BIO* bio = NULL;
     X509_CRL* x509_crl = NULL;
@@ -73,7 +73,7 @@ oe_result_t oe_crl_read_der(
 
     /* Check for invalid parameters */
     if (!der_data || !der_size || der_size > OE_INT_MAX || !crl)
-        OE_RAISE(OE_UNEXPECTED);
+        OE_RAISE(OE_INVALID_PARAMETER);
 
     /* Create a BIO for reading the DER-formatted data */
     if (!(bio = BIO_new_mem_buf(der_data, (int)der_size)))
@@ -188,16 +188,16 @@ static oe_result_t _asn1_time_to_date(
     const char null_terminator = '\0';
 
     if (!(bio = BIO_new(BIO_s_mem())))
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     if (!ASN1_TIME_print(bio, time))
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     if (!BIO_get_mem_ptr(bio, &mem))
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     if (BIO_write(bio, &null_terminator, sizeof(null_terminator)) <= 0)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     OE_CHECK(_string_to_date(mem->data, date));
 
@@ -233,7 +233,7 @@ oe_result_t oe_crl_get_update_dates(
         const ASN1_TIME* time;
 
         if (!(time = X509_CRL_get0_lastUpdate(impl->crl)))
-            OE_RAISE(OE_FAILURE);
+            OE_RAISE(OE_CRYPTO_ERROR);
 
         OE_CHECK(_asn1_time_to_date(time, last));
     }
@@ -243,7 +243,7 @@ oe_result_t oe_crl_get_update_dates(
         const ASN1_TIME* time;
 
         if (!(time = X509_CRL_get0_nextUpdate(impl->crl)))
-            OE_RAISE(OE_FAILURE);
+            OE_RAISE(OE_CRYPTO_ERROR);
 
         OE_CHECK(_asn1_time_to_date(time, next));
     }

--- a/host/crypto/openssl/hmac.c
+++ b/host/crypto/openssl/hmac.c
@@ -55,7 +55,7 @@ oe_result_t oe_hmac_sha256_init(
         HMAC_Init_ex(ctx, (const void*)key, (int)keysize, EVP_sha256(), NULL);
 
     if (openssl_result == 0)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     ((oe_hmac_sha256_context_impl_t*)context)->ctx = ctx;
     ctx = NULL;
@@ -81,7 +81,7 @@ oe_result_t oe_hmac_sha256_update(
         OE_RAISE(OE_INVALID_PARAMETER);
 
     if (HMAC_Update(impl->ctx, (const uint8_t*)data, size) == 0)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     result = OE_OK;
 
@@ -102,10 +102,10 @@ oe_result_t oe_hmac_sha256_final(
         OE_RAISE(OE_INVALID_PARAMETER);
 
     if (HMAC_Final(impl->ctx, sha256->buf, &hmac_size) == 0)
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     if (hmac_size != sizeof(sha256->buf))
-        OE_RAISE(OE_FAILURE);
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     result = OE_OK;
 

--- a/host/crypto/openssl/random.c
+++ b/host/crypto/openssl/random.c
@@ -10,7 +10,7 @@ oe_result_t oe_random_internal(void* data, size_t size)
         return OE_INVALID_PARAMETER;
 
     if (!RAND_bytes(data, (int)size))
-        return OE_FAILURE;
+        return OE_CRYPTO_ERROR;
 
     return OE_OK;
 }

--- a/host/crypto/openssl/sha.c
+++ b/host/crypto/openssl/sha.c
@@ -1,26 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if defined(__linux__)
-#include <openssl/sha.h>
-#elif defined(_WIN32)
-#include "bcrypt/bcrypt.h"
-#endif
-
 #include <openenclave/host.h>
 #include <openenclave/internal/defs.h>
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/sha.h>
+#include <openssl/sha.h>
 #include <stdio.h>
 #include <string.h>
 
 typedef struct _oe_sha256_context_impl
 {
-#if defined(__linux__)
     SHA256_CTX ctx;
-#elif defined(_WIN32)
-    BCRYPT_HASH_HANDLE handle;
-#endif
 } oe_sha256_context_impl_t;
 
 OE_STATIC_ASSERT(
@@ -34,17 +25,8 @@ oe_result_t oe_sha256_init(oe_sha256_context_t* context)
     if (!context)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-#if defined(__linux__)
     if (!SHA256_Init(&impl->ctx))
-        OE_RAISE(OE_FAILURE);
-#elif defined(_WIN32)
-    if (BCryptCreateHash(
-            BCRYPT_SHA256_ALG_HANDLE, &impl->handle, NULL, 0, NULL, 0, 0) !=
-        STATUS_SUCCESS)
-    {
-        OE_RAISE(OE_FAILURE);
-    }
-#endif
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     result = OE_OK;
 
@@ -63,16 +45,8 @@ oe_result_t oe_sha256_update(
     if (!context)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-#if defined(__linux__)
     if (!SHA256_Update(&impl->ctx, data, size))
-        OE_RAISE(OE_FAILURE);
-#elif defined(_WIN32)
-    if (BCryptHashData(impl->handle, (void*)data, (ULONG)size, 0) !=
-        STATUS_SUCCESS)
-    {
-        OE_RAISE(OE_FAILURE);
-    }
-#endif
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     result = OE_OK;
 
@@ -88,16 +62,8 @@ oe_result_t oe_sha256_final(oe_sha256_context_t* context, OE_SHA256* sha256)
     if (!context)
         OE_RAISE(OE_INVALID_PARAMETER);
 
-#if defined(__linux__)
     if (!SHA256_Final(sha256->buf, &impl->ctx))
-        OE_RAISE(OE_FAILURE);
-#elif defined(_WIN32)
-    if (BCryptFinishHash(impl->handle, sha256->buf, sizeof(OE_SHA256), 0) !=
-        STATUS_SUCCESS)
-    {
-        OE_RAISE(OE_FAILURE);
-    }
-#endif
+        OE_RAISE(OE_CRYPTO_ERROR);
 
     result = OE_OK;
 

--- a/include/openenclave/bits/result.h
+++ b/include/openenclave/bits/result.h
@@ -278,6 +278,10 @@ typedef enum _oe_result
      * The certificate or signature has been revoked.
      */
     OE_VERIFY_REVOKED,
+    /**
+     * An underlying crypto provider returned an error.
+     */
+    OE_CRYPTO_ERROR,
 
     __OE_RESULT_MAX = OE_ENUM_MAX,
 } oe_result_t;


### PR DESCRIPTION
- Add the new OE_CRYPTO_ERROR code to result.h and update existing OE crypto
  to return it instead of OE_FAILURE. This is intended to support debugging
  when failures in OE crypto wrappers are due to an underlying library error.
- Split sha.c into openssl & BCrypt-specific source files.
- Add BCrypt implementation for random.c.