### PR TITLE
Remove OE_USE_LIBSGX on verifying report.

### DIFF
--- a/common/sgx/qeidentity.c
+++ b/common/sgx/qeidentity.c
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#ifdef OE_USE_LIBSGX
 #include "qeidentity.h"
 #include <openenclave/internal/raise.h>
 #include <openenclave/internal/utils.h>
@@ -58,17 +57,18 @@ oe_result_t oe_enforce_qe_identity(sgx_report_body_t* qe_report_body)
         // enclave's mrsigner.
         if (!oe_constant_time_mem_equal(
                 qe_report_body->mrsigner, g_qe_mrsigner, sizeof(g_qe_mrsigner)))
-            OE_RAISE_MSG(OE_VERIFY_FAILED, "mrsigner mismatch");
+            OE_RAISE_MSG(OE_VERIFY_FAILED, "mrsigner mismatch", NULL);
 
         if (qe_report_body->isvprodid != g_qe_isvprodid)
-            OE_RAISE_MSG(OE_VERIFY_FAILED, "isvprodid mismatch");
+            OE_RAISE_MSG(OE_VERIFY_FAILED, "isvprodid mismatch", NULL);
 
         if (qe_report_body->isvsvn < g_qeisvsvn)
-            OE_RAISE_MSG(OE_VERIFY_FAILED, "isvsvn is out-of-date");
+            OE_RAISE_MSG(OE_VERIFY_FAILED, "isvsvn is out-of-date", NULL);
 
         // Ensure that the QE is not a debug supporting enclave.
         if (qe_report_body->attributes.flags & SGX_FLAGS_DEBUG)
-            OE_RAISE_MSG(OE_VERIFY_FAILED, "QE has SGX_FLAGS_DEBUG set!!");
+            OE_RAISE_MSG(
+                OE_VERIFY_FAILED, "QE has SGX_FLAGS_DEBUG set!!", NULL);
 
         result = OE_OK;
         goto done;
@@ -182,4 +182,3 @@ done:
         oe_cert_chain_free(&pck_cert_chain);
     return result;
 }
-#endif

--- a/common/sgx/qeidentity.h
+++ b/common/sgx/qeidentity.h
@@ -12,8 +12,6 @@
 
 OE_EXTERNC_BEGIN
 
-#ifdef OE_USE_LIBSGX
-
 oe_result_t oe_enforce_qe_identity(sgx_report_body_t* qe_report_body);
 
 // Fetch qe identity info using the specified args structure.
@@ -23,7 +21,6 @@ oe_result_t oe_get_qe_identity_info(oe_get_qe_identity_info_args_t* args);
 void oe_cleanup_qe_identity_info_args(oe_get_qe_identity_info_args_t* args);
 
 void dump_info(char* title, uint8_t* data, uint8_t count);
-#endif
 
 OE_EXTERNC_END
 

--- a/common/sgx/quote.c
+++ b/common/sgx/quote.c
@@ -12,8 +12,6 @@
 #include "qeidentity.h"
 #include "revocation.h"
 
-#ifdef OE_USE_LIBSGX
-
 // Public key of Intel's root certificate.
 static const char* g_expected_root_certificate_key =
     "-----BEGIN PUBLIC KEY-----\n"
@@ -304,28 +302,3 @@ done:
     oe_cert_chain_free(&pck_cert_chain);
     return result;
 }
-
-#else
-
-oe_result_t VerifyQuoteImpl(
-    const uint8_t* enc_quote,
-    size_t quote_size,
-    const uint8_t* enc_pem_pck_certificate,
-    size_t pem_pck_certificate_size,
-    const uint8_t* enc_pck_crl,
-    size_t enc_pck_crl_size,
-    const uint8_t* enc_tcb_info_json,
-    size_t enc_tcb_info_json_size)
-{
-    OE_UNUSED(enc_quote);
-    OE_UNUSED(quote_size);
-    OE_UNUSED(enc_pem_pck_certificate);
-    OE_UNUSED(pem_pck_certificate_size);
-    OE_UNUSED(enc_pck_crl);
-    OE_UNUSED(enc_pck_crl_size);
-    OE_UNUSED(enc_tcb_info_json);
-    OE_UNUSED(enc_tcb_info_json_size);
-
-    return OE_UNSUPPORTED;
-}
-#endif

--- a/common/sgx/revocation.c
+++ b/common/sgx/revocation.c
@@ -14,13 +14,10 @@
 #include <openenclave/internal/report.h>
 #include <openenclave/internal/sgxcertextensions.h>
 #include <openenclave/internal/sha.h>
-#include <openenclave/internal/thread.h>
 #include <openenclave/internal/trace.h>
 #include <openenclave/internal/utils.h>
 #include "../common.h"
 #include "tcbinfo.h"
-
-#ifdef OE_USE_LIBSGX
 
 // Defaults to Intel SGX 1.8 Release Date.
 oe_datetime_t _sgx_minimim_crl_tcb_issue_date = {2017, 3, 17};
@@ -309,5 +306,3 @@ done:
 
     return result;
 }
-
-#endif

--- a/common/sgx/revocation.h
+++ b/common/sgx/revocation.h
@@ -12,8 +12,6 @@
 
 OE_EXTERNC_BEGIN
 
-#ifdef OE_USE_LIBSGX
-
 oe_result_t oe_enforce_revocation(
     oe_cert_t* leaf_cert,
     oe_cert_t* intermediate_cert,
@@ -24,8 +22,6 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args);
 
 // Cleanup the args structure.
 void oe_cleanup_get_revocation_info_args(oe_get_revocation_info_args_t* args);
-
-#endif
 
 OE_EXTERNC_END
 

--- a/common/sgx/tcbinfo.c
+++ b/common/sgx/tcbinfo.c
@@ -8,8 +8,6 @@
 #include <openenclave/internal/utils.h>
 #include "../common.h"
 
-#ifdef OE_USE_LIBSGX
-
 // Public key of Intel's root certificate.
 static const char* _trusted_root_key_pem =
     "-----BEGIN PUBLIC KEY-----\n"
@@ -819,5 +817,3 @@ done:
 
     return result;
 }
-
-#endif

--- a/common/sgx/tcbinfo.h
+++ b/common/sgx/tcbinfo.h
@@ -13,8 +13,6 @@
 
 OE_EXTERNC_BEGIN
 
-#ifdef OE_USE_LIBSGX
-
 typedef enum _oe_tcb_level_status
 {
     OE_TCB_LEVEL_STATUS_UNKNOWN,
@@ -100,7 +98,6 @@ oe_result_t oe_parse_qe_identity_info_json(
     const uint8_t* info_json,
     size_t info_json_size,
     oe_parsed_qe_identity_info_t* parsed_info);
-#endif
 
 OE_EXTERNC_END
 

--- a/host/sgx/linux/sgxquoteprovider.c
+++ b/host/sgx/linux/sgxquoteprovider.c
@@ -15,8 +15,6 @@
 #include "../platformquoteprovider.h"
 #include "../sgxquoteprovider.h"
 
-#ifdef OE_USE_LIBSGX
-
 /**
  * This file manages the libdcap_quoteprov.so shared library.
  * It loads the .so during program startup and keeps it loaded till application
@@ -141,9 +139,7 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
     uint8_t* p = 0;
     uint8_t* p_end = 0;
 
-#if defined(OE_USE_LIBSGX)
     OE_CHECK(oe_initialize_quote_provider());
-#endif
 
     if (!_get_revocation_info || !_free_revocation_info)
         OE_RAISE(OE_QUOTE_PROVIDER_LOAD_ERROR);
@@ -333,9 +329,7 @@ oe_result_t oe_get_qe_identity_info(oe_get_qe_identity_info_args_t* args)
     uint8_t* p_end = 0;
     OE_TRACE_INFO("Calling %s\n", __PRETTY_FUNCTION__);
 
-#if defined(OE_USE_LIBSGX)
     OE_CHECK(oe_initialize_quote_provider());
-#endif
 
     if (!_get_qe_identity_info || !_free_qe_identity_info)
     {
@@ -421,4 +415,3 @@ void oe_cleanup_qe_identity_info_args(oe_get_qe_identity_info_args_t* args)
             free(args->host_out_buffer);
     }
 }
-#endif

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -291,10 +291,6 @@ oe_result_t oe_verify_report(
     oe_verify_report_args_t arg = {0};
     oe_report_header_t* header = (oe_report_header_t*)report;
 
-    // The two host side attestation API's are oe_get_report and
-    // oe_verify_report. Initialize the quote provider in both these APIs.
-    OE_CHECK(oe_initialize_quote_provider());
-
     if (report == NULL)
         OE_RAISE(OE_INVALID_PARAMETER);
 
@@ -306,6 +302,12 @@ oe_result_t oe_verify_report(
 
     if (header->report_type == OE_REPORT_TYPE_SGX_REMOTE)
     {
+        // Intialize the quote provider if we want to verify a remote quote.
+        // Note that we don't have the OE_USE_LIBSGX guard here since we don't
+        // need the sgx libraries to verify the quote. All we need is the quote
+        // provider.
+        OE_CHECK(oe_initialize_quote_provider());
+
         // Quote attestation can be done entirely on the host side.
         OE_CHECK(VerifyQuoteImpl(
             header->report, header->report_size, NULL, 0, NULL, 0, NULL, 0));

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -12,9 +12,7 @@
 #include "../common/sgx/quote.h"
 #include "quote.h"
 
-#if defined(OE_USE_LIBSGX)
 #include "sgxquoteprovider.h"
-#endif
 
 OE_STATIC_ASSERT(OE_REPORT_DATA_SIZE == sizeof(sgx_report_data_t));
 
@@ -293,11 +291,9 @@ oe_result_t oe_verify_report(
     oe_verify_report_args_t arg = {0};
     oe_report_header_t* header = (oe_report_header_t*)report;
 
-#if defined(OE_USE_LIBSGX)
     // The two host side attestation API's are oe_get_report and
     // oe_verify_report. Initialize the quote provider in both these APIs.
     OE_CHECK(oe_initialize_quote_provider());
-#endif
 
     if (report == NULL)
         OE_RAISE(OE_INVALID_PARAMETER);

--- a/include/openenclave/internal/sgxtypes.h
+++ b/include/openenclave/internal/sgxtypes.h
@@ -738,7 +738,6 @@ OE_CHECK_SIZE(sizeof(sgx_report_t), 432);
 **
 **==============================================================================
 */
-#if defined OE_USE_LIBSGX
 
 OE_PACK_BEGIN
 typedef struct _sgx_quote
@@ -890,47 +889,6 @@ typedef enum _oe_sgx_pckid
 } oe_sgx_pckid_t;
 
 OE_STATIC_ASSERT(sizeof(oe_sgx_pckid_t) == sizeof(unsigned int));
-
-#else
-
-OE_PACK_BEGIN
-typedef struct _sgx_quote
-{
-    /* (0) */
-    uint16_t version;
-
-    /* (2) */
-    uint16_t sign_type;
-
-    /* (4) */
-    sgx_epid_group_id_t epid_group_id;
-
-    /* (8) */
-    uint16_t qe_svn;
-
-    /* (10) */
-    uint16_t pce_svn;
-
-    /* (12) */
-    uint32_t xeid;
-
-    /* (16) */
-    uint8_t basename[32];
-
-    /* (48) */
-    sgx_report_body_t report_body;
-
-    /* (432) */
-    uint32_t signature_len;
-
-    /* (436) signature array (varying length) */
-    OE_ZERO_SIZED_ARRAY uint8_t signature[];
-} sgx_quote_t;
-OE_PACK_END
-
-OE_CHECK_SIZE(sizeof(sgx_quote_t), 436);
-
-#endif
 
 #define OE_SGX_QUOTE_VERSION (3)
 

--- a/tests/qeidentity/common/includes.h
+++ b/tests/qeidentity/common/includes.h
@@ -7,10 +7,4 @@
 #include "../../../common/sgx/tcbinfo.h"
 #include "../../../host/sgx/quote.h"
 
-#ifndef OE_USE_LIBSGX
-// the following empty type was added to avoid build error in host/tests_u.h
-typedef struct
-{
-} oe_parsed_qe_identity_info_t;
-#endif
 #endif

--- a/tests/report/common/includes.h
+++ b/tests/report/common/includes.h
@@ -7,15 +7,4 @@
 #include "../../../common/sgx/tcbinfo.h"
 #include "../../../host/sgx/quote.h"
 
-#ifndef OE_USE_LIBSGX
-
-typedef struct
-{
-} oe_tcb_level_t;
-typedef struct
-{
-} oe_parsed_tcb_info_t;
-
-#endif
-
 #endif

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -46,11 +46,9 @@ void generate_and_save_report(oe_enclave_t* enclave)
 
 void load_and_verify_report()
 {
-#ifdef OE_USE_LIBSGX
     std::vector<uint8_t> report = FileToBytes("./data/generated_report.bytes");
     OE_TEST(
         oe_verify_report(NULL, &report[0], report.size() - 1, NULL) == OE_OK);
-#endif
 }
 
 int main(int argc, const char* argv[])

--- a/tests/report/host/host.cpp
+++ b/tests/report/host/host.cpp
@@ -19,7 +19,7 @@
 extern void TestVerifyTCBInfo(
     oe_enclave_t* enclave,
     const char* test_file_name);
-extern std::vector<uint8_t> FileToBytes(const char* path);
+extern int FileToBytes(const char* path, std::vector<uint8_t>* output);
 
 void generate_and_save_report(oe_enclave_t* enclave)
 {
@@ -44,11 +44,22 @@ void generate_and_save_report(oe_enclave_t* enclave)
 #endif
 }
 
-void load_and_verify_report()
+int load_and_verify_report()
 {
-    std::vector<uint8_t> report = FileToBytes("./data/generated_report.bytes");
+    std::vector<uint8_t> report;
+    int ret = FileToBytes("./data/generated_report.bytes", &report);
+
+    // File not found, so skip the verification.
+    if (ret != 0)
+    {
+        printf("load_and_verify_report(): Couldn't find report. Skipping...\n");
+        return SKIP_RETURN_CODE;
+    }
+
     OE_TEST(
         oe_verify_report(NULL, &report[0], report.size() - 1, NULL) == OE_OK);
+
+    return 0;
 }
 
 int main(int argc, const char* argv[])
@@ -68,8 +79,7 @@ int main(int argc, const char* argv[])
     // Load and attest report without creating any enclaves.
     if (argc == 3 && strcmp(argv[2], "--attest-generated-report") == 0)
     {
-        load_and_verify_report();
-        return 0;
+        return load_and_verify_report();
     }
 
     /* Check arguments */

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#ifdef OE_USE_LIBSGX
 
 #include <openenclave/host.h>
 #include <openenclave/internal/aesm.h>
@@ -222,5 +221,3 @@ void TestVerifyTCBInfo(oe_enclave_t* enclave, const char* test_filename)
             "TestVerifyTCBInfo: Negative Test %s passed\n", negative_files[i]);
     }
 }
-
-#endif

--- a/tests/report/host/tcbinfo.cpp
+++ b/tests/report/host/tcbinfo.cpp
@@ -18,7 +18,7 @@
 
 #define SKIP_RETURN_CODE 2
 
-std::vector<uint8_t> FileToBytes(const char* path)
+int FileToBytes(const char* path, std::vector<uint8_t>* out)
 {
     std::ifstream f(path, std::ios::binary);
     std::vector<uint8_t> bytes = std::vector<uint8_t>(
@@ -27,13 +27,14 @@ std::vector<uint8_t> FileToBytes(const char* path)
     if (bytes.empty())
     {
         printf("File %s not found\n", path);
-        exit(1);
+        return -1;
     }
 
     // Explicitly add null character so that the bytes can be printed out
     // safely as a string if needed.
     bytes.push_back('\0');
-    return bytes;
+    *out = bytes;
+    return 0;
 }
 
 void AssertParsedValues(oe_parsed_tcb_info_t& parsed_info)
@@ -75,7 +76,9 @@ void TestVerifyTCBInfo(
     oe_tcb_level_t* platform_tcb_level,
     oe_result_t expected)
 {
-    std::vector<uint8_t> tcbInfo = FileToBytes(test_filename);
+    std::vector<uint8_t> tcbInfo;
+    OE_TEST(FileToBytes(test_filename, &tcbInfo) == 0);
+
     oe_parsed_tcb_info_t parsed_info = {0};
     oe_result_t ecall_result = OE_FAILURE;
 
@@ -205,7 +208,9 @@ void TestVerifyTCBInfo(oe_enclave_t* enclave, const char* test_filename)
     for (size_t i = 0; i < sizeof(negative_files) / sizeof(negative_files[0]);
          ++i)
     {
-        std::vector<uint8_t> tcbInfo = FileToBytes(negative_files[i]);
+        std::vector<uint8_t> tcbInfo;
+        OE_TEST(FileToBytes(negative_files[i], &tcbInfo) == 0);
+
         oe_parsed_tcb_info_t parsed_info = {0};
         oe_tcb_level_t platform_tcb_level = {{0}};
         oe_result_t ecall_result = OE_FAILURE;


### PR DESCRIPTION
This allows remote quote verification without `OE_USE_LIBSGX`. It's essentially a piece of PR #1575 to unblock Cheng-mean's PR #1761.

A way to test this is to run the report test with a pre-generated report. That test should now pass.