### PR TITLE
Implement deep-copy prototype

### DIFF
--- a/include/openenclave/edger8r/common.h
+++ b/include/openenclave/edger8r/common.h
@@ -133,12 +133,12 @@ done:
 /**
  * Copy an input parameter to input buffer.
  */
-#define OE_WRITE_IN_PARAM(argname, argsize, argtype)                     \
-    if (argname)                                                         \
-    {                                                                    \
-        _args.argname = (argtype)(_input_buffer + _input_buffer_offset); \
-        OE_ADD_SIZE(_input_buffer_offset, (size_t)(argsize));            \
-        memcpy((void*)_args.argname, argname, (size_t)(argsize));        \
+#define OE_WRITE_IN_PARAM(argname, argsname, argsize, argtype)            \
+    if (argname)                                                          \
+    {                                                                     \
+        _args.argsname = (argtype)(_input_buffer + _input_buffer_offset); \
+        OE_ADD_SIZE(_input_buffer_offset, (size_t)(argsize));             \
+        memcpy((void*)_args.argsname, argname, (size_t)(argsize));        \
     }
 
 #define OE_WRITE_IN_OUT_PARAM OE_WRITE_IN_PARAM

--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -34,6 +34,13 @@ enclave {
     [count=count, size=size] uint64_t* ptr;
   };
 
+  struct NestedStruct {
+    int plain_int;
+    [count=4] int* array_of_int;
+    ShallowStruct* shallow_struct;
+    [count=3] CountStruct* array_of_struct;
+  };
+
   trusted {
     // Since `s` is passed by value, `s.ptr` is not deep copied.
     public void deepcopy_value(ShallowStruct s, [user_check] uint64_t* ptr);
@@ -72,5 +79,8 @@ enclave {
     // Deep copy of two `CountSizeParamStruct`s each with an embedded
     // array and different counts should take place.
     public void deepcopy_countsizeparamarray([in, count=2] CountSizeParamStruct* s);
+
+    // Maybe test for recursive copying.
+    public void deepcopy_nested([in, count=1] NestedStruct* n);
   };
 };

--- a/tests/oeedger8r/enc/CMakeLists.txt
+++ b/tests/oeedger8r/enc/CMakeLists.txt
@@ -17,7 +17,7 @@ add_custom_command(
   ../edl/pointer.edl
   ../edl/string.edl
   ../edl/struct.edl
-  COMMAND edger8r --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
+  COMMAND edger8r --experimental --trusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
 # Dummy target used for generating from EDL on demand.
 add_custom_target(edl_enc_trusted DEPENDS all_t.h all_t.c all_args.h)

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -136,3 +136,21 @@ void deepcopy_countsizeparamarray(CountSizeParamStruct* s)
         OE_TEST(s[1].ptr[i] == data[4 + i]);
     OE_TEST_IGNORE(oe_is_within_enclave(s[1].ptr, s[1].count * s[1].size));
 }
+
+void deepcopy_nested(NestedStruct* n)
+{
+    OE_TEST(oe_is_within_enclave(n, sizeof(NestedStruct)));
+
+    OE_TEST(n->plain_int == 13);
+
+    OE_TEST_IGNORE(oe_is_within_enclave(n->array_of_int, 4 * sizeof(int)));
+    for (int i = 0; i < 4; ++i)
+        OE_TEST(n->array_of_int[i] == i);
+
+    OE_TEST(oe_is_outside_enclave(n->shallow_struct, sizeof(ShallowStruct)));
+
+    OE_TEST_IGNORE(
+        oe_is_within_enclave(n->array_of_struct, 3 * sizeof(CountStruct)));
+    for (size_t i = 0; i < 3; ++i)
+        deepcopy_count(&(n->array_of_struct[i]));
+}

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -45,7 +45,7 @@ void deepcopy_count(CountStruct* s)
     OE_TEST(s->size == 64);
     for (size_t i = 0; i < 3; ++i)
         OE_TEST(s->ptr[i] == data[i]);
-    OE_TEST_IGNORE(oe_is_within_enclave(s->ptr, 3 * sizeof(uint64_t)));
+    OE_TEST(oe_is_within_enclave(s->ptr, 3 * sizeof(uint64_t)));
 }
 
 // Assert that the struct is deep-copied such that `s->ptr` has a copy
@@ -56,7 +56,7 @@ void deepcopy_countparam(CountParamStruct* s)
     OE_TEST(s->size == 64);
     for (size_t i = 0; i < s->count; ++i)
         OE_TEST(s->ptr[i] == data[i]);
-    OE_TEST_IGNORE(oe_is_within_enclave(s->ptr, s->count * sizeof(uint64_t)));
+    OE_TEST(oe_is_within_enclave(s->ptr, s->count * sizeof(uint64_t)));
 }
 
 // Assert that the struct is deep-copied such that `s->ptr` has a copy
@@ -67,7 +67,7 @@ void deepcopy_sizeparam(SizeParamStruct* s)
     OE_TEST(s->size == 64);
     for (size_t i = 0; i < s->size / sizeof(uint64_t); ++i)
         OE_TEST(s->ptr[i] == data[i]);
-    OE_TEST_IGNORE(oe_is_within_enclave(s->ptr, s->size));
+    OE_TEST(oe_is_within_enclave(s->ptr, s->size));
 }
 
 // Assert that the struct is deep-copied such that `s->ptr` has a copy
@@ -78,7 +78,7 @@ void deepcopy_countsizeparam(CountSizeParamStruct* s)
     OE_TEST(s->size == 4);
     for (size_t i = 0; i < (s->count * s->size) / sizeof(uint64_t); ++i)
         OE_TEST(s->ptr[i] == data[i]);
-    OE_TEST_IGNORE(oe_is_within_enclave(s->ptr, s->count * s->size));
+    OE_TEST(oe_is_within_enclave(s->ptr, s->count * s->size));
 }
 
 // Assert that the struct array is deep-copied such that each
@@ -90,15 +90,13 @@ void deepcopy_countparamarray(CountParamStruct* s)
     OE_TEST(s[0].size == 64);
     for (size_t i = 0; i < s[0].count; ++i)
         OE_TEST(s[0].ptr[i] == data[i]);
-    OE_TEST_IGNORE(
-        oe_is_within_enclave(s[0].ptr, s[0].count * sizeof(uint64_t)));
+    OE_TEST(oe_is_within_enclave(s[0].ptr, s[0].count * sizeof(uint64_t)));
 
     OE_TEST(s[1].count == 3);
     OE_TEST(s[1].size == 32);
     for (size_t i = 0; i < s[1].count; ++i)
         OE_TEST(s[1].ptr[i] == data[4 + i]);
-    OE_TEST_IGNORE(
-        oe_is_within_enclave(s[1].ptr, s[1].count * sizeof(uint64_t)));
+    OE_TEST(oe_is_within_enclave(s[1].ptr, s[1].count * sizeof(uint64_t)));
 }
 
 // Assert that the struct array is deep-copied such that each
@@ -110,13 +108,13 @@ void deepcopy_sizeparamarray(SizeParamStruct* s)
     OE_TEST(s[0].size == 64);
     for (size_t i = 0; i < s[0].size / sizeof(uint64_t); ++i)
         OE_TEST(s[0].ptr[i] == data[i]);
-    OE_TEST_IGNORE(oe_is_within_enclave(s[0].ptr, s[0].size));
+    OE_TEST(oe_is_within_enclave(s[0].ptr, s[0].size));
 
     OE_TEST(s[1].count == 3);
     OE_TEST(s[1].size == 32);
     for (size_t i = 0; i < s[1].size / sizeof(uint64_t); ++i)
         OE_TEST(s[1].ptr[i] == data[4 + i]);
-    OE_TEST_IGNORE(oe_is_within_enclave(s[1].ptr, s[1].size));
+    OE_TEST(oe_is_within_enclave(s[1].ptr, s[1].size));
 }
 
 // Assert that the struct array is deep-copied such that each
@@ -128,13 +126,13 @@ void deepcopy_countsizeparamarray(CountSizeParamStruct* s)
     OE_TEST(s[0].size == 4);
     for (size_t i = 0; i < (s[0].count * s[0].size) / sizeof(uint64_t); ++i)
         OE_TEST(s[0].ptr[i] == data[i]);
-    OE_TEST_IGNORE(oe_is_within_enclave(s[0].ptr, s[0].count * s[0].size));
+    OE_TEST(oe_is_within_enclave(s[0].ptr, s[0].count * s[0].size));
 
     OE_TEST(s[1].count == 3);
     OE_TEST(s[1].size == 8);
     for (size_t i = 0; i < (s[1].count * s[1].size) / sizeof(uint64_t); ++i)
         OE_TEST(s[1].ptr[i] == data[4 + i]);
-    OE_TEST_IGNORE(oe_is_within_enclave(s[1].ptr, s[1].count * s[1].size));
+    OE_TEST(oe_is_within_enclave(s[1].ptr, s[1].count * s[1].size));
 }
 
 void deepcopy_nested(NestedStruct* n)
@@ -143,14 +141,13 @@ void deepcopy_nested(NestedStruct* n)
 
     OE_TEST(n->plain_int == 13);
 
-    OE_TEST_IGNORE(oe_is_within_enclave(n->array_of_int, 4 * sizeof(int)));
+    OE_TEST(oe_is_within_enclave(n->array_of_int, 4 * sizeof(int)));
     for (int i = 0; i < 4; ++i)
         OE_TEST(n->array_of_int[i] == i);
 
     OE_TEST(oe_is_outside_enclave(n->shallow_struct, sizeof(ShallowStruct)));
 
-    OE_TEST_IGNORE(
-        oe_is_within_enclave(n->array_of_struct, 3 * sizeof(CountStruct)));
+    OE_TEST(oe_is_within_enclave(n->array_of_struct, 3 * sizeof(CountStruct)));
     for (size_t i = 0; i < 3; ++i)
         deepcopy_count(&(n->array_of_struct[i]));
 }

--- a/tests/oeedger8r/host/CMakeLists.txt
+++ b/tests/oeedger8r/host/CMakeLists.txt
@@ -17,7 +17,7 @@ add_custom_command(
   ../edl/pointer.edl
   ../edl/string.edl
   ../edl/struct.edl
-  COMMAND edger8r --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
+  COMMAND edger8r --experimental --untrusted --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../edl --search-path ${CMAKE_CURRENT_SOURCE_DIR}/../moreedl all.edl)
 
 add_custom_command(
   OUTPUT bar_u.h bar_args.h

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -83,5 +83,14 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(deepcopy_countsizeparamarray(enclave, s.data()) == OE_OK);
     }
 
+    {
+        auto s = init_structs<CountStruct>();
+        int ints[]{0, 1, 2, 3};
+        ShallowStruct shallow{1, 8, nullptr};
+        CountStruct counts[]{s[0], s[0], s[0]};
+        NestedStruct n{13, ints, &shallow, counts};
+        OE_TEST(deepcopy_nested(enclave, &n) == OE_OK);
+    }
+
     printf("=== test_deepcopy_edl_ecalls failures ignored!\n");
 }

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -38,10 +38,6 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(deepcopy_shallow(enclave, &s[0], data) == OE_OK);
     }
 
-    // TODO: These should succeed only once deep copy is enabled, so
-    // for now we ignore their failures.
-    fprintf(stderr, "=== test_deepcopy_edl_ecalls ignoring failures...\n");
-
     {
         auto s = init_structs<CountStruct>();
         OE_TEST(deepcopy_count(enclave, &s[0]) == OE_OK);
@@ -92,5 +88,5 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
         OE_TEST(deepcopy_nested(enclave, &n) == OE_OK);
     }
 
-    printf("=== test_deepcopy_edl_ecalls failures ignored!\n");
+    printf("=== test_deepcopy_edl_ecalls passed\n");
 }

--- a/tests/oeedger8r/host/teststring.cpp
+++ b/tests/oeedger8r/host/teststring.cpp
@@ -71,8 +71,8 @@ oe_result_t ecall_string_no_null_terminator_modified(
     _pargs_in = (ecall_string_no_null_terminator_args_t*)_input_buffer;
     OE_ADD_SIZE(_input_buffer_offset, sizeof(*_pargs_in));
 
-    OE_WRITE_IN_PARAM(s1, _args.s1_len * sizeof(char), char*);
-    OE_WRITE_IN_OUT_PARAM(s2, _args.s2_len * sizeof(char), char*);
+    OE_WRITE_IN_PARAM(s1, s1, _args.s1_len * sizeof(char), char*);
+    OE_WRITE_IN_OUT_PARAM(s2, s2, _args.s2_len * sizeof(char), char*);
 
     /* Copy args structure (now filled) to input buffer */
     memcpy(_pargs_in, &_args, sizeof(*_pargs_in));
@@ -177,8 +177,8 @@ oe_result_t ecall_wstring_no_null_terminator_modified(
     _pargs_in = (ecall_wstring_no_null_terminator_args_t*)_input_buffer;
     OE_ADD_SIZE(_input_buffer_offset, sizeof(*_pargs_in));
 
-    OE_WRITE_IN_PARAM(s1, _args.s1_len * sizeof(wchar_t), wchar_t*);
-    OE_WRITE_IN_OUT_PARAM(s2, _args.s2_len * sizeof(wchar_t), wchar_t*);
+    OE_WRITE_IN_PARAM(s1, s1, _args.s1_len * sizeof(wchar_t), wchar_t*);
+    OE_WRITE_IN_OUT_PARAM(s2, s2, _args.s2_len * sizeof(wchar_t), wchar_t*);
 
     /* Copy args structure (now filled) to input buffer */
     memcpy(_pargs_in, &_args, sizeof(*_pargs_in));

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -129,7 +129,11 @@ let get_deepcopy a structs ep =
   let get_struct = function
     | Ptr a -> (
       match a with
-      | Foreign n | Struct n -> List.assoc_opt n structs
+      | Foreign n | Struct n ->
+          (* TODO: This would simply be [List.assoc_opt] if we had at
+             least 4.05. *)
+          if List.mem_assoc n structs then Some (List.assoc n structs)
+          else None
       | _ -> None )
     | _ -> None
   in

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -154,8 +154,7 @@ let oe_gen_marshal_struct (fd : func_decl) (errno : bool) structs =
     in
     let argsname = prefix ^ decl.identifier in
     [ [sprintf "%s %s;" tystr argsname]
-    ; ( if need_strlen ptype then [sprintf "size_t %s_len;" decl.identifier]
-      else [] )
+    ; (if need_strlen ptype then [sprintf "size_t %s_len;" argsname] else [])
     ; flatten_map
         (gen_member_decl (argsname ^ "__"))
         (should_deepcopy aty structs) ]
@@ -423,20 +422,6 @@ let get_cast_to_mem_expr (ptype, decl) (parens : bool) =
       else if parens then sprintf "(%s)" tystr
       else tystr
 
-let oe_compute_input_buffer_size (plist : pdecl list) =
-  let params =
-    List.map
-      (fun (ptype, decl) ->
-        let size = oe_get_param_size (ptype, decl, "_args.") in
-        sprintf "if (%s) OE_ADD_SIZE(_input_buffer_size, %s);" decl.identifier
-          size )
-      (List.filter (fun (p, _) -> is_in_ptr p || is_inout_ptr p) plist)
-  in
-  (* Note that the indentation for the first line is applied by the
-     parent function. *)
-  if params <> [] then String.concat "\n    " params
-  else "/* There were no in nor in-out parameters. */"
-
 let oe_compute_output_buffer_size (plist : pdecl list) =
   let params =
     List.map
@@ -477,6 +462,25 @@ let oe_serialize_buffer_inputs (plist : pdecl list) structs =
 
 (** Prepare [input_buffer]. *)
 let oe_prepare_input_buffer (fd : func_decl) (alloc_func : string) structs =
+  let oe_compute_input_buffer_size (plist : pdecl list) =
+    let rec gen_add_size prefix (ptype, decl) =
+      let size = oe_get_param_size (ptype, decl, "_args." ^ prefix) in
+      let argname = prefix ^ decl.identifier in
+      [ [sprintf "if (%s) OE_ADD_SIZE(_input_buffer_size, %s);" argname size]
+      ; flatten_map
+          (gen_add_size (argname ^ "->"))
+          (should_deepcopy (get_param_atype ptype) structs) ]
+      |> List.flatten
+    in
+    let params =
+      flatten_map (gen_add_size "")
+        (List.filter (fun (p, _) -> is_in_ptr p || is_inout_ptr p) plist)
+    in
+    (* Note that the indentation for the first line is applied by the
+     parent function. *)
+    if params <> [] then String.concat "\n    " params
+    else "/* There were no in nor in-out parameters. */"
+  in
   [ "/* Compute input buffer size. Include in and in-out parameters. */"
   ; sprintf "OE_ADD_SIZE(_input_buffer_size, sizeof(%s_args_t));" fd.fname
   ; oe_compute_input_buffer_size fd.plist

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -73,6 +73,14 @@ let conv_array_to_ptr (pd : pdecl) : pdecl =
 
 (** ----- End code borrowed and tweaked from {!CodeGen.ml} ----- *)
 
+(* Helper to map and filter out None at the same time. *)
+let filter_map f l =
+  (* Would be [List.of_seq (Seq.filter_map f (List.to_seq l))] if we
+     had 4.07 everywhere. *)
+  List.map
+    (function Some x -> x | None -> invalid_arg "None")
+    (List.filter (function Some _ -> true | None -> false) (List.map f l))
+
 let is_in_ptr (ptype : parameter_type) =
   match ptype with
   | PTVal _ -> false
@@ -318,13 +326,6 @@ let emit_untrusted_function_ids (ufs : untrusted_func list) (name : string) =
   ; sprintf "    %s_fcn_id_untrusted_call_max = OE_ENUM_MAX" name
   ; "};" ]
 
-let get_structs cts =
-  (* Where is List.filter_map?! Transform the [struct_def list] into
-     an [assoc] list. *)
-  List.map
-    (function StructDef s -> (s.sname, s.smlist) | _ -> ("", []))
-    (List.filter (function StructDef _ -> true | _ -> false) cts)
-
 (** Generate [args.h] which contains [struct]s for ecalls and ocalls *)
 let oe_gen_args_header (ec : enclave_content) (dir : string) =
   let oe_gen_user_includes (includes : string list) =
@@ -336,7 +337,11 @@ let oe_gen_args_header (ec : enclave_content) (dir : string) =
     if cts <> [] then List.flatten (List.map emit_composite_type cts)
     else ["/* There were no user defined types. */"; ""]
   in
-  let structs = get_structs ec.comp_defs in
+  let structs =
+    filter_map
+      (function StructDef s -> Some (s.sname, s.smlist) | _ -> None)
+      ec.comp_defs
+  in
   let oe_gen_ecall_marshal_structs (tfs : trusted_func list) =
     if tfs <> [] then
       List.flatten

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -121,7 +121,7 @@ let oe_gen_marshal_struct =
     let need_strlen p =
       (is_str_ptr p || is_wstr_ptr p) && (is_in_ptr p || is_inout_ptr p)
     in
-    [ sprintf "%s %s%s;" tystr decl.identifier (get_array_dims decl.array_dims)
+    [ sprintf "%s %s;" tystr decl.identifier
     ; ( if need_strlen ptype then sprintf "size_t %s_len;" decl.identifier
       else "" ) ]
   in

--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -125,7 +125,7 @@ let open_file (filename : string) (dir : string) =
 (** We need to check Ptrs for Foreign or Struct types, then check
     those against the user's structs, and then check if any members
     should be deep copied. *)
-let should_deepcopy a structs =
+let get_deepcopy a structs ep =
   let get_struct = function
     | Ptr a -> (
       match a with
@@ -139,7 +139,9 @@ let should_deepcopy a structs =
     | PTPtr (_, attr) -> attr.pa_size <> empty_ptr_size
     | PTVal _ -> false
   in
-  match s with Some s -> List.filter should_deepcopy_member s | None -> []
+  if ep.experimental then
+    match s with Some s -> List.filter should_deepcopy_member s | None -> []
+  else []
 
 (** [oe_get_param_size] is the most complex function. For a parameter,
     get its size expression. *)
@@ -465,7 +467,7 @@ let get_cast_to_mem_expr (ptype, decl) (parens : bool) =
       else tystr
 
 (** Prepare [input_buffer]. *)
-let oe_prepare_input_buffer (fd : func_decl) (alloc_func : string) structs =
+let oe_prepare_input_buffer (fd : func_decl) (alloc_func : string) structs ep =
   let oe_compute_buffer_size (buffer : string)
       (predicate : parameter_type * declarator -> bool) (plist : pdecl list) =
     let rec gen_add_size prefix count (ptype, decl) =
@@ -478,7 +480,7 @@ let oe_prepare_input_buffer (fd : func_decl) (alloc_func : string) structs =
          in
          flatten_map
            (gen_add_size (arg ^ gen_c_deref param_count) param_count)
-           (should_deepcopy (get_param_atype ptype) structs)) ]
+           (get_deepcopy (get_param_atype ptype) structs ep)) ]
       |> List.flatten
     in
     let params =
@@ -512,7 +514,7 @@ let oe_prepare_input_buffer (fd : func_decl) (alloc_func : string) structs =
          in
          flatten_map
            (gen_serialize (arg ^ gen_c_deref param_count) param_count)
-           (should_deepcopy (get_param_atype ptype) structs)) ]
+           (get_deepcopy (get_param_atype ptype) structs ep)) ]
       |> List.flatten
     in
     let params =
@@ -626,7 +628,7 @@ let oe_gen_call_user_function (fd : func_decl) =
          fd.plist)
     ^ ");" ]
 
-let rec oe_gen_set_pointers prefix count structs setter (ptype, decl) =
+let rec oe_gen_set_pointers prefix count structs ep setter (ptype, decl) =
   let size = oe_get_param_size (ptype, decl, "pargs_in->" ^ prefix) in
   let tystr = get_cast_to_mem_expr (ptype, decl) false in
   let arg = prefix ^ decl.identifier in
@@ -638,14 +640,14 @@ let rec oe_gen_set_pointers prefix count structs setter (ptype, decl) =
      flatten_map
        (oe_gen_set_pointers
           (arg ^ gen_c_deref param_count)
-          param_count structs setter)
-       (should_deepcopy (get_param_atype ptype) structs)) ]
+          param_count structs ep setter)
+       (get_deepcopy (get_param_atype ptype) structs ep)) ]
   |> List.flatten
 
-let oe_gen_in_and_inout_setters (plist : pdecl list) structs =
+let oe_gen_in_and_inout_setters (plist : pdecl list) structs ep =
   let params =
     flatten_map
-      (oe_gen_set_pointers "" "1" structs (fun p ->
+      (oe_gen_set_pointers "" "1" structs ep (fun p ->
            if is_inout_ptr p then "SET_IN_OUT" else "SET_IN" ))
       (List.filter (fun (p, _) -> is_in_ptr p || is_inout_ptr p) plist)
   in
@@ -655,10 +657,10 @@ let oe_gen_in_and_inout_setters (plist : pdecl list) structs =
       ; ( if params <> [] then String.concat "\n    " params
         else "/* There were no in nor in-out parameters. */" ) ]
 
-let oe_gen_out_and_inout_setters (plist : pdecl list) structs =
+let oe_gen_out_and_inout_setters (plist : pdecl list) structs ep =
   let params =
     flatten_map
-      (oe_gen_set_pointers "" "1" structs (fun p ->
+      (oe_gen_set_pointers "" "1" structs ep (fun p ->
            if is_inout_ptr p then "COPY_AND_SET_IN_OUT" else "SET_OUT" ))
       (List.filter (fun (p, _) -> is_out_ptr p || is_inout_ptr p) plist)
   in
@@ -670,7 +672,7 @@ let oe_gen_out_and_inout_setters (plist : pdecl list) structs =
         else "/* There were no out nor in-out parameters. */" ) ]
 
 (** Generate ecall function. *)
-let oe_gen_ecall_function structs (tf : trusted_func) =
+let oe_gen_ecall_function structs ep (tf : trusted_func) =
   let fd = tf.tf_fdecl in
   [ sprintf "void ecall_%s(" fd.fname
   ; "    uint8_t* input_buffer,"
@@ -704,11 +706,11 @@ let oe_gen_ecall_function structs (tf : trusted_func) =
   ; "        goto done;"
   ; ""
   ; (* Prepare in and in-out parameters *)
-    oe_gen_in_and_inout_setters fd.plist structs
+    oe_gen_in_and_inout_setters fd.plist structs ep
   ; ""
   ; (* Prepare out and in-out parameters. The in-out parameter is copied
      to output buffer. *)
-    oe_gen_out_and_inout_setters fd.plist structs
+    oe_gen_out_and_inout_setters fd.plist structs ep
   ; ""
   ; "    /* Check that in/in-out strings are null terminated. */"
     (* TODO: Fix for deep copy. *)
@@ -745,7 +747,7 @@ let oe_gen_ecall_function structs (tf : trusted_func) =
   ; "}"
   ; "" ]
 
-let gen_fill_marshal_struct (fd : func_decl) structs =
+let gen_fill_marshal_struct (fd : func_decl) structs ep =
   (* Generate assignment argument to corresponding field in args. This
      is necessary for all arguments, not just copy-as-value, because
      they are used directly by later marshalling code. *)
@@ -765,13 +767,13 @@ let gen_fill_marshal_struct (fd : func_decl) structs =
     ; (let param_count = oe_get_param_count (ptype, decl, "_args." ^ prefix) in
        flatten_map
          (gen_assignment (arg ^ gen_c_deref param_count) param_count)
-         (should_deepcopy (get_param_atype ptype) structs)) ]
+         (get_deepcopy (get_param_atype ptype) structs ep)) ]
     |> List.flatten
   in
   flatten_map (gen_assignment "" "1") fd.plist
 
 (** Generate host ECALL wrapper function. *)
-let oe_gen_host_ecall_wrapper (name : string) structs (tf : trusted_func) =
+let oe_gen_host_ecall_wrapper (name : string) structs ep (tf : trusted_func) =
   let fd = tf.tf_fdecl in
   [ oe_gen_wrapper_prototype fd true
   ; "{"
@@ -794,10 +796,10 @@ let oe_gen_host_ecall_wrapper (name : string) structs (tf : trusted_func) =
   ; ""
   ; "    /* Fill marshalling struct. */"
   ; "    memset(&_args, 0, sizeof(_args));"
-  ; "    " ^ String.concat "\n    " (gen_fill_marshal_struct fd structs)
+  ; "    " ^ String.concat "\n    " (gen_fill_marshal_struct fd structs ep)
   ; ""
   ; "    "
-    ^ String.concat "\n    " (oe_prepare_input_buffer fd "malloc" structs)
+    ^ String.concat "\n    " (oe_prepare_input_buffer fd "malloc" structs ep)
   ; ""
   ; "    /* Call enclave function. */"
   ; "    if ((_result = oe_call_enclave_function("
@@ -824,8 +826,8 @@ let oe_gen_host_ecall_wrapper (name : string) structs (tf : trusted_func) =
   ; "" ]
 
 (** Generate enclave OCALL wrapper function. *)
-let oe_gen_enclave_ocall_wrapper (name : string) structs (uf : untrusted_func)
-    =
+let oe_gen_enclave_ocall_wrapper (name : string) structs ep
+    (uf : untrusted_func) =
   let fd = uf.uf_fdecl in
   [ oe_gen_wrapper_prototype fd false
   ; "{"
@@ -853,11 +855,11 @@ let oe_gen_enclave_ocall_wrapper (name : string) structs (uf : untrusted_func)
   ; ""
   ; "    /* Fill marshalling struct. */"
   ; "    memset(&_args, 0, sizeof(_args));"
-  ; "    " ^ String.concat "\n    " (gen_fill_marshal_struct fd structs)
+  ; "    " ^ String.concat "\n    " (gen_fill_marshal_struct fd structs ep)
   ; ""
   ; "    "
     ^ String.concat "\n    "
-        (oe_prepare_input_buffer fd "oe_allocate_ocall_buffer" structs)
+        (oe_prepare_input_buffer fd "oe_allocate_ocall_buffer" structs ep)
   ; ""
   ; "    /* Call host function. */"
   ; "    if ((_result = oe_call_host_function("
@@ -887,7 +889,7 @@ let oe_gen_enclave_ocall_wrapper (name : string) structs (uf : untrusted_func)
   ; "" ]
 
 (** Generate ocall function. *)
-let oe_gen_ocall_function structs (uf : untrusted_func) =
+let oe_gen_ocall_function structs ep (uf : untrusted_func) =
   let fd = uf.uf_fdecl in
   [ sprintf "void ocall_%s(" fd.fname
   ; "    uint8_t* input_buffer,"
@@ -919,10 +921,10 @@ let oe_gen_ocall_function structs (uf : untrusted_func) =
   ; "    }"
   ; ""
   ; (* Prepare in and in-out parameters *)
-    oe_gen_in_and_inout_setters fd.plist structs
+    oe_gen_in_and_inout_setters fd.plist structs ep
   ; ""
   ; (* Prepare out and in-out parameters. The in-out parameter is copied to output buffer. *)
-    oe_gen_out_and_inout_setters fd.plist structs
+    oe_gen_out_and_inout_setters fd.plist structs ep
   ; ""
   ; (* Call the host function *)
     "    " ^ String.concat "\n    " (oe_gen_call_user_function fd)
@@ -1139,7 +1141,7 @@ let gen_t_c (ec : enclave_content) (ep : edger8r_params) =
   let ufs = ec.ufunc_decls in
   let structs = get_structs ec.comp_defs in
   let oe_gen_ecall_functions =
-    if tfs <> [] then flatten_map (oe_gen_ecall_function structs) tfs
+    if tfs <> [] then flatten_map (oe_gen_ecall_function structs ep) tfs
     else ["/* There were no ecalls. */"]
   in
   let oe_gen_ecall_table =
@@ -1158,7 +1160,7 @@ let gen_t_c (ec : enclave_content) (ep : edger8r_params) =
   in
   let oe_gen_enclave_ocall_wrappers =
     if ufs <> [] then
-      flatten_map (oe_gen_enclave_ocall_wrapper ec.enclave_name structs) ufs
+      flatten_map (oe_gen_enclave_ocall_wrapper ec.enclave_name structs ep) ufs
     else ["/* There were no ocalls. */"]
   in
   let content =
@@ -1244,11 +1246,11 @@ let gen_u_c (ec : enclave_content) (ep : edger8r_params) =
   let structs = get_structs ec.comp_defs in
   let oe_gen_host_ecall_wrappers =
     if tfs <> [] then
-      flatten_map (oe_gen_host_ecall_wrapper ec.enclave_name structs) tfs
+      flatten_map (oe_gen_host_ecall_wrapper ec.enclave_name structs ep) tfs
     else ["/* There were no ecalls. */"]
   in
   let oe_gen_ocall_functions =
-    if ufs <> [] then flatten_map (oe_gen_ocall_function structs) ufs
+    if ufs <> [] then flatten_map (oe_gen_ocall_function structs ep) ufs
     else ["/* There were no ocalls. */"]
   in
   let oe_gen_ocall_table =

--- a/tools/oeedger8r/intel/Util.ml
+++ b/tools/oeedger8r/intel/Util.ml
@@ -69,6 +69,7 @@ let usage (progname: string) =
 --trusted             Generate trusted proxy and bridge\n\
 --untrusted-dir <dir> Specify the directory for saving untrusted code\n\
 --trusted-dir   <dir> Specify the directory for saving trusted code\n\
+--experimental        Enable experimental features\n\
 --help                Print this help message\n";
   eprintf "\n\
 If neither `--untrusted' nor `--trusted' is specified, generate both.\n";
@@ -84,6 +85,7 @@ type edger8r_params = {
   gen_trusted   : bool;         (* User specified `--trusted' *)
   untrusted_dir : string;       (* Directory to save untrusted code *)
   trusted_dir   : string;       (* Directory to save trusted code *)
+  experimental  : bool;         (* Enable experimental features *)
 }
 
 (* The search paths are recored in the array below.
@@ -106,6 +108,7 @@ let rec parse_cmdline (progname: string) (cmdargs: string list) =
   let hd_only  = ref false in
   let untrusted= ref false in
   let trusted  = ref false in
+  let experi   = ref false in
   let u_dir    = ref "." in
   let t_dir    = ref "." in
   let files    = ref [] in
@@ -119,6 +122,7 @@ let rec parse_cmdline (progname: string) (cmdargs: string list) =
             | "--header-only"-> hd_only := true; local_parser ops
             | "--untrusted"  -> untrusted := true; local_parser ops
             | "--trusted"    -> trusted := true; local_parser ops
+            | "--experimental" -> experi := true; local_parser ops
             | "--untrusted-dir" ->
               (match ops with
                 []    -> usage progname
@@ -143,6 +147,7 @@ let rec parse_cmdline (progname: string) (cmdargs: string list) =
       { input_files = List.rev !files; use_prefix = !use_pref;
         header_only = !hd_only; gen_untrusted = true; gen_trusted = true;
         untrusted_dir = !u_dir; trusted_dir = !t_dir;
+        experimental = !experi;
       }
     in
       if !untrusted || !trusted (* User specified '--untrusted' or '--trusted' *)


### PR DESCRIPTION
The deep-copy **prototype** is only exposed to users of `oeedger8r` if they specify the `--experimental` flag when generating their edge routines (note that this is done in our tests).

Notable lacking support is handling of deep-copied `out` structures. However, `in` structures with `count > 1` (essentially arrays) are supported.

Next steps: a lot more tests, refactoring, and proper error handling.

Please review both the edge8r changes and the generated code in `all_u.c`, `all_t.c`, and `all_args.h` (that is, the edge routines of the oeedger8r unit tests, specifically the functions prefixed with `deepcopy_`).