### PR TITLE
Change ocall log level to VERBOSE from INFO.

### DIFF
--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -420,7 +420,7 @@ static oe_result_t _handle_ocall(
         *arg_out = 0;
 
     oe_log(
-        OE_LOG_LEVEL_INFO,
+        OE_LOG_LEVEL_VERBOSE,
         "%s 0x%x OE_OCALL: %s\n",
         enclave->path,
         enclave->addr,


### PR DESCRIPTION
This is a proposal to change the log level of the new ocall logging feature from INFO to VERBOSE. I'm proposing this change because there is important diagnostic information that can be gathered when setting the log level to INFO (for example, when diagnosing quote verification failures), and OCALL log messages add a lot of noise when they might not be important for diagnosing an issue related to core OE functionality.

Tagging @achamayou who first implemented the ocall log feature. Feel free to tag anyone else for review