### PR TITLE
Include ARM32 GCC and python-crypto in ARM setup.

### DIFF
--- a/scripts/ansible/roles/linux/openenclave/vars/ubuntu.yml
+++ b/scripts/ansible/roles/linux/openenclave/vars/ubuntu.yml
@@ -53,8 +53,11 @@ apt_packages:
   - "libncurses5-dev"
 
 apt_arm_packages:
+  - "gcc-arm-linux-gnueabi"
+  - "gcc-arm-linux-gnueabihf"
   - "gcc-aarch64-linux-gnu"
   - "g++-aarch64-linux-gnu"
+  - "python-crypto"
   - "libc6-dev:arm64"
   - "libssl-dev:arm64"
 


### PR DESCRIPTION
This PR adds additional tooling to the required packages list to build for ARM:

- 32-bit ARM compilers (soft-float and hard-float);
- Python cryptography module (for TA signatures).

I had originally added these changes to #1820, but to be able to pass CI, these tools must be in the `oetools-full-*` containers, so I've separated them into a new PR.