### PR TITLE
OCall logging bugfixes

### DIFF
--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -367,22 +367,22 @@ done:
 
 static const char* oe_ocall_str(oe_func_t ocall)
 {
-    static const char* func_names[] = {"OE_OCALL_CALL_HOST_FUNCTION",
-                                       "OE_OCALL_GET_QE_TARGET_INFO",
-                                       "OE_OCALL_GET_QUOTE",
-                                       "OE_OCALL_GET_REVOCATION_INFO",
-                                       "OE_OCALL_GET_QE_ID_INFO",
-                                       "OE_OCALL_THREAD_WAKE",
-                                       "OE_OCALL_THREAD_WAIT",
-                                       "OE_OCALL_THREAD_WAKE_WAIT",
-                                       "OE_OCALL_MALLOC",
-                                       "OE_OCALL_REALLOC",
-                                       "OE_OCALL_FREE",
-                                       "OE_OCALL_WRITE",
-                                       "OE_OCALL_SLEEP",
-                                       "OE_OCALL_GET_TIME",
-                                       "OE_OCALL_BACKTRACE_SYMBOLS",
-                                       "OE_OCALL_LOG"};
+    static const char* func_names[] = {"CALL_HOST_FUNCTION",
+                                       "GET_QE_TARGET_INFO",
+                                       "GET_QUOTE",
+                                       "GET_REVOCATION_INFO",
+                                       "GET_QE_ID_INFO",
+                                       "THREAD_WAKE",
+                                       "THREAD_WAIT",
+                                       "THREAD_WAKE_WAIT",
+                                       "MALLOC",
+                                       "REALLOC",
+                                       "FREE",
+                                       "WRITE",
+                                       "SLEEP",
+                                       "GET_TIME",
+                                       "BACKTRACE_SYMBOLS",
+                                       "LOG"};
 
     OE_STATIC_ASSERT(OE_OCALL_BASE + OE_COUNTOF(func_names) == OE_OCALL_MAX);
 

--- a/host/sgx/calls.c
+++ b/host/sgx/calls.c
@@ -381,11 +381,10 @@ static const char* oe_ocall_str(oe_func_t ocall)
                                        "OE_OCALL_WRITE",
                                        "OE_OCALL_SLEEP",
                                        "OE_OCALL_GET_TIME",
-                                       "OE_OCALL_BACKTRACE_SYMBOLS"
+                                       "OE_OCALL_BACKTRACE_SYMBOLS",
                                        "OE_OCALL_LOG"};
 
-    OE_STATIC_ASSERT(
-        OE_OCALL_BASE + OE_COUNTOF(func_names) == OE_OCALL_MAX - 1);
+    OE_STATIC_ASSERT(OE_OCALL_BASE + OE_COUNTOF(func_names) == OE_OCALL_MAX);
 
     if (ocall >= OE_OCALL_BASE &&
         ocall < (OE_OCALL_BASE + OE_COUNTOF(func_names)))
@@ -421,9 +420,10 @@ static oe_result_t _handle_ocall(
 
     oe_log(
         OE_LOG_LEVEL_VERBOSE,
-        "%s 0x%x OE_OCALL: %s\n",
+        "%s 0x%x %s: %s\n",
         enclave->path,
         enclave->addr,
+        func == OE_OCALL_CALL_HOST_FUNCTION ? "EDL_OCALL" : "OE_OCALL",
         oe_ocall_str(func));
 
     switch ((oe_func_t)func)


### PR DESCRIPTION
@letmaik spotted a couple of mistakes that found their way into the OCall logging PR:

- A missing comma (!) in the array of names, coupled with a mistaken assertion
- OE_OCALL_CALL_HOST_FUNCTION was labeled as OE_OCALL, when it should have been EDL_OCALL