### PR TITLE
Support for DCAP Libraries for Windows added to Openenclave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ prereqs/aesm/dynamic-application-loader-host-interface/
 prereqs/aesm/linux-sgx/
 prereqs/isgx/linux-sgx-driver/
 prereqs/dcap/*.deb
+prereqs/nuget/*
 prereqs/packages/.packages
 prereqs/sgx-driver/*.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ include(package_settings)
 include(add_enclave)
 
 # User configurable options
-# DCAP Libraries are supported for Windows but we still default to USE_LIBSGX OFF
+# DCAP library support on Windows is experimental and is disabled by default
 if (UNIX)
   option(USE_LIBSGX "Build oehost using SGX library requiring FLC" ON)
 elseif (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,14 +160,11 @@ include(package_settings)
 include(add_enclave)
 
 # User configurable options
+# DCAP Libraries are supported for Windows but we still default to USE_LIBSGX OFF
 if (UNIX)
   option(USE_LIBSGX "Build oehost using SGX library requiring FLC" ON)
 elseif (WIN32)
   option(USE_LIBSGX "Build oehost using SGX library requiring FLC" OFF)
-endif ()
-
-if (USE_LIBSGX AND WIN32)
-  message(FATAL_ERROR "USE_LIBSGX is not yet supported on Windows.")
 endif ()
 
 # TODO: See #756: Fix this because it is incompatible with

--- a/common/oe_host_string.h
+++ b/common/oe_host_string.h
@@ -55,6 +55,8 @@ int oe_strerror_r(int errnum, char* buf, size_t buflen)
     if (!strerror_r(errnum, buf, buflen))
         return -1;
     return 0;
+#elif defined(_WIN32)
+    return strerror_s(buf, buflen, errnum);
 #else
     return strerror_r(errnum, buf, buflen);
 #endif

--- a/docs/GettingStartedDocs/GettingStarted.Windows.md
+++ b/docs/GettingStartedDocs/GettingStarted.Windows.md
@@ -225,7 +225,7 @@ The following summary will assume that the contents were extracted to `C:\Intel 
     - The standalone `nuget.exe` [CLI tool](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) can be used to do this from the command prompt:
       ```cmd
       nuget.exe install EnclaveCommonAPI -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.1.100.49925\nupkg" -OutputDirectory C:\openenclave\prereqs\nuget
-      nuget.exe install DCAP_Components -ExclueVersion -Source "C:\Intel SGX DCAP for Windows v1.1.100.49925\nupkg" -OutputDirectory C\openenclave\prereqs\nuget
+      nuget.exe install DCAP_Components -ExcludeVersion -Source "C:\Intel SGX DCAP for Windows v1.1.100.49925\nupkg" -OutputDirectory C\openenclave\prereqs\nuget
       ```
 
 ##### [Azure DCAP client for Windows](https://github.com/Microsoft/Azure-DCAP-Client/tree/master/src/Windows) [optional]
@@ -263,7 +263,6 @@ configurations you want to build with it.
 For example, to enable it for x64-Debug, do this in your json file:
 
 ```json
-  ...
   "configurations": [
     {
       "name": "x64-Debug",
@@ -300,13 +299,13 @@ Testing
 Note that the use of Simulation Mode via the `OE_SIMULATION` flag is _not_ supported on Windows.
 See [#1753](https://github.com/microsoft/openenclave/issues/1753) for details.
 
-### Running ctests in Visual Studio 2017
+### Running tests in Visual Studio 2017
 
 1. Open the CMake project in Visual Studio from menu File > Open > CMake...
    and select top level CMakeLists.txt file which is present in openenclave folder.
 2. Select menu CMake > Tests > Run Open Enclave SDK CTests.
 
-### Running ctests on the Developer Command Prompt
+### Running tests on the Developer Command Prompt
 On the x64 Native Tools Command Prompt for VS 2017:
 
 ```cmd

--- a/enclave/core/sgx/debugmalloc.c
+++ b/enclave/core/sgx/debugmalloc.c
@@ -421,13 +421,7 @@ int oe_debug_posix_memalign(void** memptr, size_t alignment, size_t size)
     if (!memptr)
         return OE_EINVAL;
 
-    size_t d = alignment / sizeof(void*);
-    size_t r = alignment % sizeof(void*);
-
-    bool is_multiple = (d >= 1 && r == 0);
-    bool is_pow2 = (alignment != 0) && ((alignment & (alignment - 1)) == 0);
-
-    if (!is_multiple || !is_pow2)
+    if (!oe_is_ptrsize_multiple(alignment) || !oe_is_pow2(alignment))
         return OE_EINVAL;
 
     if (!(*memptr = oe_debug_memalign(alignment, size)))

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -84,6 +84,7 @@ if (OE_SGX)
     sgx/sgxload.c
     sgx/sgxmeasure.c
     sgx/sgxquote.c
+    sgx/sgxquoteprovider.c
     sgx/sgxsign.c
     sgx/sgxtypes.c
     sgx/traceh.c)
@@ -97,7 +98,6 @@ if (OE_SGX)
       sgx/linux/entersim.S
       sgx/linux/exception.c
       sgx/linux/sgxioctl.c
-      sgx/linux/sgxquoteprovider.c
       sgx/linux/xstate.c)
   else()
     list(APPEND PLATFORM_SRC
@@ -157,7 +157,7 @@ if (UNIX)
     add_library(crypto SHARED IMPORTED)
     set_target_properties(crypto PROPERTIES IMPORTED_LOCATION ${CRYPTO_LIB})
   endif ()
-  
+
   find_library(DL_LIB NAMES dl)
   if(NOT DL_LIB)
     message(FATAL_ERROR "-- Looking for dl library - not found")
@@ -183,24 +183,44 @@ target_include_directories(oehost PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # TODO: Handle Trust Zone etc.
 if (USE_LIBSGX)
-  find_library(LIBSGX_COMMON NAMES sgx_enclave_common)
-  find_library(LIBSGX_QE NAMES sgx_dcap_ql)
-  find_library(LIBSGX_URTS NAMES sgx_urts)
+  if (UNIX)
 
-  if (NOT LIBSGX_COMMON OR NOT LIBSGX_QE OR NOT LIBSGX_URTS)
-    message(FATAL_ERROR "No SGX libraries found, aborting! Set -DUSE_LIBSGX=OFF to ignore.")
+    find_library(LIBSGX_COMMON NAMES sgx_enclave_common)
+    find_library(LIBSGX_QE NAMES sgx_dcap_ql)
+    if (NOT LIBSGX_COMMON OR NOT LIBSGX_QE)
+      message(FATAL_ERROR "No SGX libraries found, aborting! Set -DUSE_LIBSGX=OFF to ignore.")
+    endif ()
+
+    add_library(sgx_enclave_common SHARED IMPORTED)
+    set_target_properties(sgx_enclave_common PROPERTIES IMPORTED_LOCATION ${LIBSGX_COMMON})
+
+    add_library(sgx_dcap_ql SHARED IMPORTED)
+    set_target_properties(sgx_dcap_ql PROPERTIES IMPORTED_LOCATION ${LIBSGX_QE})
+
+  elseif (WIN32)
+
+    find_library(LIBSGX_COMMON NAMES sgx_enclave_common
+      PATHS ${CMAKE_SOURCE_DIR}/prereqs/nuget/EnclaveCommonAPI/lib/native/x64-Release)
+    find_library(LIBSGX_QE NAMES sgx_dcap_ql
+      PATHS ${CMAKE_SOURCE_DIR}/prereqs/nuget/DCAP_Components/build/lib/native/Libraries)
+    if (NOT LIBSGX_COMMON OR NOT LIBSGX_QE)
+      message(FATAL_ERROR "No SGX libraries found, aborting! Set -DUSE_LIBSGX=OFF to ignore.")
+    endif ()
+
+    add_library(sgx_enclave_common SHARED IMPORTED)
+    set_target_properties(sgx_enclave_common PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/prereqs/nuget/EnclaveCommonAPI/Header Files"
+      IMPORTED_LOCATION $ENV{WINDIR}/System32
+      IMPORTED_IMPLIB ${LIBSGX_COMMON})
+
+    add_library(sgx_dcap_ql SHARED IMPORTED)
+    set_target_properties(sgx_dcap_ql PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/prereqs/nuget/DCAP_Components/build/Header Files"
+      IMPORTED_LOCATION $ENV{WINDIR}/System32
+      IMPORTED_IMPLIB ${LIBSGX_QE})
   endif ()
 
-  add_library(sgx_enclave_common SHARED IMPORTED)
-  set_target_properties(sgx_enclave_common PROPERTIES IMPORTED_LOCATION ${LIBSGX_COMMON})
-
-  add_library(sgx_dcap_ql SHARED IMPORTED)
-  set_target_properties(sgx_dcap_ql PROPERTIES IMPORTED_LOCATION ${LIBSGX_QE})
-
-  add_library(sgx_urts SHARED IMPORTED)
-  set_target_properties(sgx_urts PROPERTIES IMPORTED_LOCATION ${LIBSGX_URTS})
-
-  target_link_libraries(oehost PUBLIC sgx_enclave_common sgx_dcap_ql sgx_urts)
+  target_link_libraries(oehost PUBLIC sgx_enclave_common sgx_dcap_ql)
   target_compile_definitions(oehost PUBLIC OE_USE_LIBSGX)
 endif ()
 

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -185,40 +185,36 @@ target_include_directories(oehost PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # TODO: Handle Trust Zone etc.
 if (USE_LIBSGX)
+  if (WIN32)
+    set(LIBPATHS
+      ${CMAKE_SOURCE_DIR}/prereqs/nuget/EnclaveCommonAPI/lib/native/x64-Release
+      ${CMAKE_SOURCE_DIR}/prereqs/nuget/DCAP_Components/build/lib/native/Libraries)
+    set(INCPATHS
+      "${CMAKE_SOURCE_DIR}/prereqs/nuget/EnclaveCommonAPI/Header Files"
+      "${CMAKE_SOURCE_DIR}/prereqs/nuget/DCAP_Components/build/Header Files")
+    set(WINSYSLOCATION
+       $ENV{WINDIR}/System32)
+  endif ()
+
+  find_library(LIBSGX_COMMON NAMES sgx_enclave_common PATHS ${LIBPATHS})
+  find_library(LIBSGX_QE NAMES sgx_dcap_ql PATHS ${LIBPATHS})
+  if (NOT LIBSGX_COMMON OR NOT LIBSGX_QE)
+    message(FATAL_ERROR "No SGX libraries found, aborting! Set -DUSE_LIBSGX=OFF to ignore.")
+  endif ()
+  add_library(sgx_enclave_common SHARED IMPORTED)
+  add_library(sgx_dcap_ql SHARED IMPORTED)
+
   if (UNIX)
-
-    find_library(LIBSGX_COMMON NAMES sgx_enclave_common)
-    find_library(LIBSGX_QE NAMES sgx_dcap_ql)
-    if (NOT LIBSGX_COMMON OR NOT LIBSGX_QE)
-      message(FATAL_ERROR "No SGX libraries found, aborting! Set -DUSE_LIBSGX=OFF to ignore.")
-    endif ()
-
-    add_library(sgx_enclave_common SHARED IMPORTED)
     set_target_properties(sgx_enclave_common PROPERTIES IMPORTED_LOCATION ${LIBSGX_COMMON})
-
-    add_library(sgx_dcap_ql SHARED IMPORTED)
     set_target_properties(sgx_dcap_ql PROPERTIES IMPORTED_LOCATION ${LIBSGX_QE})
-
   elseif (WIN32)
-
-    find_library(LIBSGX_COMMON NAMES sgx_enclave_common
-      PATHS ${CMAKE_SOURCE_DIR}/prereqs/nuget/EnclaveCommonAPI/lib/native/x64-Release)
-    find_library(LIBSGX_QE NAMES sgx_dcap_ql
-      PATHS ${CMAKE_SOURCE_DIR}/prereqs/nuget/DCAP_Components/build/lib/native/Libraries)
-    if (NOT LIBSGX_COMMON OR NOT LIBSGX_QE)
-      message(FATAL_ERROR "No SGX libraries found, aborting! Set -DUSE_LIBSGX=OFF to ignore.")
-    endif ()
-
-    add_library(sgx_enclave_common SHARED IMPORTED)
     set_target_properties(sgx_enclave_common PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/prereqs/nuget/EnclaveCommonAPI/Header Files"
-      IMPORTED_LOCATION $ENV{WINDIR}/System32
+      INTERFACE_INCLUDE_DIRECTORIES "${INCPATHS}"
+      IMPORTED_LOCATION ${WINSYSLOCATION}
       IMPORTED_IMPLIB ${LIBSGX_COMMON})
-
-    add_library(sgx_dcap_ql SHARED IMPORTED)
     set_target_properties(sgx_dcap_ql PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/prereqs/nuget/DCAP_Components/build/Header Files"
-      IMPORTED_LOCATION $ENV{WINDIR}/System32
+      INTERFACE_INCLUDE_DIRECTORIES "${INCPATHS}"
+      IMPORTED_LOCATION ${WINSYSLOCATION}
       IMPORTED_IMPLIB ${LIBSGX_QE})
   endif ()
 

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -98,6 +98,7 @@ if (OE_SGX)
       sgx/linux/entersim.S
       sgx/linux/exception.c
       sgx/linux/sgxioctl.c
+      sgx/linux/sgxquoteproviderloader.c
       sgx/linux/xstate.c)
   else()
     list(APPEND PLATFORM_SRC
@@ -106,6 +107,7 @@ if (OE_SGX)
       sgx/windows/enter.asm
       sgx/windows/entersim.asm
       sgx/windows/exception.c
+      sgx/windows/sgxquoteproviderloader.c
       sgx/windows/xstate.c)
   endif()
 

--- a/host/sgx/linux/sgxquoteproviderloader.c
+++ b/host/sgx/linux/sgxquoteproviderloader.c
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <dlfcn.h>
+#include <openenclave/internal/trace.h>
+#include <stdlib.h>
+#include "../sgxquoteprovider.h"
+
+oe_sgx_quote_provider_t provider = {0};
+
+static void _unload_quote_provider()
+{
+    OE_TRACE_INFO("_unload_quote_provider libdcap_quoteprov.so\n");
+    if (provider.handle)
+    {
+        dlclose(provider.handle);
+        provider.handle = 0;
+    }
+}
+
+void oe_load_quote_provider()
+{
+    if (provider.handle == 0)
+    {
+        OE_TRACE_INFO("oe_load_quote_provider libdcap_quoteprov.so\n");
+        provider.handle =
+            dlopen("libdcap_quoteprov.so", RTLD_LAZY | RTLD_LOCAL);
+        if (provider.handle != 0)
+        {
+            provider.get_revocation_info =
+                dlsym(provider.handle, SGX_QL_GET_REVOCATION_INFO_NAME);
+            provider.free_revocation_info =
+                dlsym(provider.handle, SGX_QL_FREE_REVOCATION_INFO_NAME);
+
+            OE_TRACE_INFO(
+                "sgxquoteprovider: provider.get_revocation_info = 0x%lx\n",
+                (uint64_t)provider.get_revocation_info);
+            OE_TRACE_INFO(
+                "sgxquoteprovider: provider.free_revocation_info = 0x%lx\n",
+                (uint64_t)provider.free_revocation_info);
+
+            sgx_ql_set_logging_function_t set_log_fcn =
+                (sgx_ql_set_logging_function_t)dlsym(
+                    provider.handle, "sgx_ql_set_logging_function");
+            if (set_log_fcn != NULL)
+            {
+                OE_TRACE_INFO("sgxquoteprovider: Installed log function\n");
+                if (get_current_logging_level() >= OE_LOG_LEVEL_INFO)
+                {
+                    // If info tracing is enabled, install the logging function.
+                    set_log_fcn(oe_quote_provider_log);
+                }
+            }
+            else
+            {
+                OE_TRACE_ERROR("sgxquoteprovider: sgx_ql_set_logging_function "
+                               "not found\n");
+            }
+
+            provider.get_qe_identity_info =
+                dlsym(provider.handle, SGX_QL_GET_QE_IDENTITY_INFO_NAME);
+            provider.free_qe_identity_info =
+                dlsym(provider.handle, SGX_QL_FREE_QE_IDENTITY_INFO_NAME);
+
+            OE_TRACE_INFO(
+                "sgxquoteprovider: provider.get_qe_identity_info = 0x%lx\n",
+                (uint64_t)provider.get_qe_identity_info);
+            OE_TRACE_INFO(
+                "sgxquoteprovider: provider.free_qe_identity_info = 0x%lx\n",
+                (uint64_t)provider.free_qe_identity_info);
+
+            atexit(_unload_quote_provider);
+        }
+        else
+        {
+            OE_TRACE_ERROR(
+                "sgxquoteprovider: libdcap_quoteprov.so not found \n");
+        }
+    }
+}

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -317,12 +317,12 @@ static oe_result_t _sgx_free_enclave_memory(
         /* munmap memory created for either AESM or simulation enclave */
         munmap(addr, size);
 #elif defined(_WIN32)
-        /* VirtualFree is used for enclave addr return by CreateEnclave and 
+        /* VirtualFree is used for enclave addr return by CreateEnclave and
            simulation enclave allocated by VirtualAlloc */
         VirtualFree(addr, 0, MEM_RELEASE);
 #endif
     }
- 
+
     return OE_OK;
 }
 

--- a/host/sgx/sgxload.c
+++ b/host/sgx/sgxload.c
@@ -298,8 +298,6 @@ static oe_result_t _sgx_free_enclave_memory(
     size_t size,
     bool is_simulation)
 {
-#if defined(__linux__)
-
 #if defined(OE_USE_LIBSGX)
     if (!is_simulation)
     {
@@ -311,17 +309,20 @@ static oe_result_t _sgx_free_enclave_memory(
             return OE_PLATFORM_ERROR;
         }
     }
-    else /* FLC simulation mode needs to munmap. */
+    else /* Fallthrough to simulation mode cleanup based on OS. */
 #endif
     {
         OE_UNUSED(is_simulation);
+#if defined(__linux__)
+        /* munmap memory created for either AESM or simulation enclave */
         munmap(addr, size);
-    }
-
 #elif defined(_WIN32)
-    VirtualFree(addr, 0, MEM_RELEASE);
+        /* VirtualFree is used for enclave addr return by CreateEnclave and 
+           simulation enclave allocated by VirtualAlloc */
+        VirtualFree(addr, 0, MEM_RELEASE);
 #endif
-
+    }
+ 
     return OE_OK;
 }
 

--- a/host/sgx/sgxquoteprovider.c
+++ b/host/sgx/sgxquoteprovider.c
@@ -1,55 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//TODO: Separate out dynamic loading of quote provider for Windows
-#if defined(__linux__)
-#include <dlfcn.h>
-#elif defined(_WIN32)
-#include <Windows.h>
-#endif
-
 #include <openenclave/bits/safecrt.h>
 #include <openenclave/internal/hexdump.h>
 #include <openenclave/internal/raise.h>
-#include <openenclave/internal/report.h>
 #include <openenclave/internal/trace.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "../hostthread.h"
-#include "platformquoteprovider.h"
 #include "sgxquoteprovider.h"
 
 /**
- * This file manages the libdcap_quoteprov.so shared library.
- * It loads the .so during program startup and keeps it loaded till application
- * exit. Intel's quoting library repeatedly loads and unloads
- * libdcap_quoteprov.so.
- * This causes a crash in libssl.so. (See
+ * This file manages the dcap_quoteprov shared library.
+ * It loads the library during program startup and keeps it loaded until the
+ * application exits. Intel's quoting library repeatedly loads and unloads
+ * dcap_quoteprov, but this causes a crash in libssl.so. (See
  * https://rt.openssl.org/Ticket/Display.html?user=guest&pass=guest&id=2325).
- * Keeping libdcap_quoteprov.so pinned in memory solves the libssl.so crash.
+ * Keeping dcap_quoteprov pinned in memory solves the libssl.so crash.
  */
 
-static void* _lib_handle = 0;
-static sgx_ql_get_revocation_info_t _get_revocation_info = 0;
-static sgx_ql_free_revocation_info_t _free_revocation_info = 0;
-static sgx_get_qe_identity_info_t _get_qe_identity_info = 0;
-static sgx_free_qe_identity_info_t _free_qe_identity_info = 0;
+extern oe_sgx_quote_provider_t provider;
 
-static void _unload_quote_provider()
-{
-#if defined(__linux__)
-    OE_TRACE_INFO("_unload_quote_provider libdcap_quoteprov.so\n");
-    if (_lib_handle)
-    {
-        dlclose(_lib_handle);
-        _lib_handle = 0;
-    }
-#endif
-}
-
-static void _quote_provider_log(sgx_ql_log_level_t level, const char* message)
+void oe_quote_provider_log(sgx_ql_log_level_t level, const char* message)
 {
     const char* level_string = level == 0 ? "ERROR" : "INFO";
     char formatted[1024];
@@ -58,80 +32,16 @@ static void _quote_provider_log(sgx_ql_log_level_t level, const char* message)
 
     formatted[sizeof(formatted) - 1] = 0;
 
-    OE_TRACE_INFO("libdcap_quoteprov.so: %s", formatted);
-}
-
-static void _load_quote_provider()
-{
-#if defined(__linux__)
-    if (_lib_handle == 0)
-    {
-        OE_TRACE_INFO("_load_quote_provider libdcap_quoteprov.so\n");
-        _lib_handle = dlopen("libdcap_quoteprov.so", RTLD_LAZY | RTLD_LOCAL);
-        if (_lib_handle != 0)
-        {
-            _get_revocation_info =
-                dlsym(_lib_handle, "sgx_ql_get_revocation_info");
-            _free_revocation_info =
-                dlsym(_lib_handle, "sgx_ql_free_revocation_info");
-
-            OE_TRACE_INFO(
-                "sgxquoteprovider: _get_revocation_info = 0x%lx\n",
-                (uint64_t)_get_revocation_info);
-            OE_TRACE_INFO(
-                "sgxquoteprovider: _free_revocation_info = 0x%lx\n",
-                (uint64_t)_free_revocation_info);
-
-            sgx_ql_set_logging_function_t set_log_fcn =
-                (sgx_ql_set_logging_function_t)dlsym(
-                    _lib_handle, "sgx_ql_set_logging_function");
-            if (set_log_fcn != NULL)
-            {
-                OE_UNUSED(_quote_provider_log);
-
-                OE_TRACE_INFO("sgxquoteprovider: Installed log function\n");
-                if (get_current_logging_level() >= OE_LOG_LEVEL_INFO)
-                {
-                    // If info tracing is enabled, install the logging function.
-                    set_log_fcn(_quote_provider_log);
-                }
-            }
-            else
-            {
-                OE_TRACE_ERROR("sgxquoteprovider: sgx_ql_set_logging_function "
-                               "not found\n");
-            }
-
-            _get_qe_identity_info =
-                dlsym(_lib_handle, "sgx_get_qe_identity_info");
-            _free_qe_identity_info =
-                dlsym(_lib_handle, "sgx_free_qe_identity_info");
-
-            OE_TRACE_INFO(
-                "sgxquoteprovider: _get_qe_identity_info = 0x%lx\n",
-                (uint64_t)_get_qe_identity_info);
-            OE_TRACE_INFO(
-                "sgxquoteprovider: _free_qe_identity_info = 0x%lx\n",
-                (uint64_t)_free_qe_identity_info);
-
-            atexit(_unload_quote_provider);
-        }
-        else
-        {
-            OE_TRACE_ERROR(
-                "sgxquoteprovider: libdcap_quoteprov.so not found \n");
-        }
-    }
-#endif
+    OE_TRACE_INFO("dcap_quoteprov: %s", formatted);
 }
 
 oe_result_t oe_initialize_quote_provider()
 {
     oe_result_t result = OE_OK;
     static oe_once_type once = OE_H_ONCE_INITIALIZER;
-    oe_once(&once, _load_quote_provider);
+    oe_once(&once, oe_load_quote_provider);
 
-    if (!_lib_handle)
+    if (!provider.handle)
         OE_RAISE_MSG(
             OE_QUOTE_PROVIDER_LOAD_ERROR,
             "oe_initialize_quote_provider failed",
@@ -152,7 +62,7 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
 
     OE_CHECK(oe_initialize_quote_provider());
 
-    if (!_get_revocation_info || !_free_revocation_info)
+    if (!provider.get_revocation_info || !provider.free_revocation_info)
         OE_RAISE(OE_QUOTE_PROVIDER_LOAD_ERROR);
 
     params.version = SGX_QL_REVOCATION_INFO_VERSION_1;
@@ -172,7 +82,7 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
         }
     }
 
-    r = _get_revocation_info(&params, &revocation_info);
+    r = provider.get_revocation_info(&params, &revocation_info);
 
     if (r != SGX_PLAT_ERROR_OK || revocation_info == NULL)
     {
@@ -317,7 +227,7 @@ oe_result_t oe_get_revocation_info(oe_get_revocation_info_args_t* args)
     result = OE_OK;
 done:
     if (revocation_info != NULL)
-        _free_revocation_info(revocation_info);
+        provider.free_revocation_info(revocation_info);
 
     return result;
 }
@@ -343,7 +253,7 @@ oe_result_t oe_get_qe_identity_info(oe_get_qe_identity_info_args_t* args)
 
     OE_CHECK(oe_initialize_quote_provider());
 
-    if (!_get_qe_identity_info || !_free_qe_identity_info)
+    if (!provider.get_qe_identity_info || !provider.free_qe_identity_info)
     {
         OE_TRACE_WARNING(
             "Warning: QE Identity was not supported by quote provider\n");
@@ -352,7 +262,7 @@ oe_result_t oe_get_qe_identity_info(oe_get_qe_identity_info_args_t* args)
     }
 
     // fetch qe identity information
-    r = _get_qe_identity_info(&identity);
+    r = provider.get_qe_identity_info(&identity);
     if (r != SGX_PLAT_ERROR_OK || identity == NULL)
     {
         OE_RAISE(OE_QUOTE_PROVIDER_CALL_ERROR);
@@ -414,7 +324,7 @@ oe_result_t oe_get_qe_identity_info(oe_get_qe_identity_info_args_t* args)
 done:
     if (identity != NULL)
     {
-        _free_qe_identity_info(identity);
+        provider.free_qe_identity_info(identity);
     }
     return result;
 }

--- a/host/sgx/sgxquoteprovider.h
+++ b/host/sgx/sgxquoteprovider.h
@@ -9,10 +9,28 @@
 #include <openenclave/internal/report.h>
 #include "../../common/sgx/qeidentity.h"
 #include "../../common/sgx/revocation.h"
+#include "platformquoteprovider.h"
 
 OE_EXTERNC_BEGIN
 
 oe_result_t oe_initialize_quote_provider(void);
+void oe_load_quote_provider(void);
+void oe_quote_provider_log(sgx_ql_log_level_t level, const char* message);
+
+typedef struct _oe_sgx_quote_provider
+{
+    void* handle;
+    sgx_ql_get_revocation_info_t get_revocation_info;
+    sgx_ql_free_revocation_info_t free_revocation_info;
+    sgx_get_qe_identity_info_t get_qe_identity_info;
+    sgx_free_qe_identity_info_t free_qe_identity_info;
+} oe_sgx_quote_provider_t;
+
+#define SGX_QL_GET_REVOCATION_INFO_NAME "sgx_ql_get_revocation_info"
+#define SGX_QL_FREE_REVOCATION_INFO_NAME "sgx_ql_free_revocation_info"
+#define SGX_QL_GET_QE_IDENTITY_INFO_NAME "sgx_ql_get_qe_identity_info"
+#define SGX_QL_FREE_QE_IDENTITY_INFO_NAME "sgx_ql_free_qe_identity_info"
+#define SGX_QL_SET_LOGGING_FUNCTION_NAME "sgx_ql_set_logging_function"
 
 OE_EXTERNC_END
 

--- a/host/sgx/windows/sgxquoteproviderloader.c
+++ b/host/sgx/windows/sgxquoteproviderloader.c
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <Windows.h>
+#include <openenclave/internal/trace.h>
+#include <stdlib.h>
+#include "../sgxquoteprovider.h"
+
+#ifdef OE_USE_LIBSGX
+
+oe_sgx_quote_provider_t provider = {0};
+
+static void _unload_quote_provider()
+{
+    OE_TRACE_INFO("_unload_quote_provider dcap_quoteprov.dll\n");
+    if (provider.handle)
+    {
+        FreeLibrary((HMODULE)provider.handle);
+        provider.handle = 0;
+    }
+}
+
+void oe_load_quote_provider()
+{
+    if (provider.handle == 0)
+    {
+        OE_TRACE_INFO("oe_load_quote_provider dcap_quoteprov.dll\n");
+        HMODULE _handle = LoadLibraryEx("dcap_quoteprov.dll", NULL, 0);
+        if (_handle != 0)
+        {
+            provider.get_revocation_info =
+                (sgx_ql_get_revocation_info_t)GetProcAddress(
+                    _handle, SGX_QL_GET_REVOCATION_INFO_NAME);
+            provider.free_revocation_info =
+                (sgx_ql_free_revocation_info_t)GetProcAddress(
+                    _handle, SGX_QL_FREE_REVOCATION_INFO_NAME);
+
+            OE_TRACE_INFO(
+                "sgxquoteprovider: provider.get_revocation_info = 0x%lx\n",
+                (uint64_t)provider.get_revocation_info);
+            OE_TRACE_INFO(
+                "sgxquoteprovider: provider.free_revocation_info = 0x%lx\n",
+                (uint64_t)provider.free_revocation_info);
+
+            sgx_ql_set_logging_function_t set_log_fcn =
+                (sgx_ql_set_logging_function_t)GetProcAddress(
+                    _handle, SGX_QL_SET_LOGGING_FUNCTION_NAME);
+            if (set_log_fcn != NULL)
+            {
+                OE_TRACE_INFO("sgxquoteprovider: Installed log function\n");
+                if (get_current_logging_level() >= OE_LOG_LEVEL_INFO)
+                {
+                    // If info tracing is enabled, install the logging function.
+                    set_log_fcn(oe_quote_provider_log);
+                }
+            }
+            else
+            {
+                OE_TRACE_ERROR("sgxquoteprovider: sgx_ql_set_logging_function "
+                               "not found\n");
+            }
+
+            provider.get_qe_identity_info =
+                (sgx_get_qe_identity_info_t)GetProcAddress(
+                    _handle, SGX_QL_GET_QE_IDENTITY_INFO_NAME);
+            provider.free_qe_identity_info =
+                (sgx_free_qe_identity_info_t)GetProcAddress(
+                    _handle, SGX_QL_FREE_QE_IDENTITY_INFO_NAME);
+
+            OE_TRACE_INFO(
+                "sgxquoteprovider: provider.get_qe_identity_info = 0x%lx\n",
+                (uint64_t)provider.get_qe_identity_info);
+            OE_TRACE_INFO(
+                "sgxquoteprovider: provider.free_qe_identity_info = 0x%lx\n",
+                (uint64_t)provider.free_qe_identity_info);
+
+            atexit(_unload_quote_provider);
+            provider.handle = _handle;
+        }
+        else
+        {
+            DWORD error = GetLastError();
+            OE_TRACE_ERROR(
+                "sgxquoteprovider: LoadLibraryEx on dcap_quoteprov.dll error "
+                "= %#x\n",
+                error);
+        }
+    }
+}
+
+#endif

--- a/include/openenclave/internal/utils.h
+++ b/include/openenclave/internal/utils.h
@@ -34,6 +34,18 @@ OE_INLINE uint64_t oe_round_u64_to_pow2(uint64_t n)
     return x + 1;
 }
 
+OE_INLINE bool oe_is_pow2(size_t n)
+{
+    return (n != 0) && ((n & (n - 1)) == 0);
+}
+
+OE_INLINE bool oe_is_ptrsize_multiple(size_t n)
+{
+    size_t d = n / sizeof(void*);
+    size_t r = n % sizeof(void*);
+    return (d >= 1 && r == 0);
+}
+
 OE_INLINE unsigned int oe_checksum(const void* data, size_t size)
 {
     const unsigned char* p = (const unsigned char*)data;


### PR DESCRIPTION
DCAP dependencies and libraries are added to the Open Enclave flows for Windows (addresses some bullets in #1043 ).
Default build for Windows is still OE_LIBSGX=OFF i.e. the AESM/non-FLC flows.
Installing and/or building Intel SGX DCAP and Azure DCAP client libraries/packages for Windows is documented in the Getting Started on Windows Guide.
