### PR TITLE
Fix ocaml warnings

### DIFF
--- a/tools/oeedger8r/Emitter.ml
+++ b/tools/oeedger8r/Emitter.ml
@@ -568,7 +568,7 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
     in
     let with_errno = List.exists (fun uf -> uf.uf_propagate_errno) ufs in
     let guard_macro =
-      "EDGER8R_" ^ String.uppercase ec.enclave_name ^ "_ARGS_H"
+      "EDGER8R_" ^ String.uppercase_ascii ec.enclave_name ^ "_ARGS_H"
     in
     let content =
       [ "#ifndef " ^ guard_macro
@@ -1124,7 +1124,7 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
           ufs
       else ["/* There were no ocalls. */"]
     in
-    let guard = "EDGER8R_" ^ String.uppercase ec.file_shortnm ^ "_T_H" in
+    let guard = "EDGER8R_" ^ String.uppercase_ascii ec.file_shortnm ^ "_T_H" in
     let content =
       [ "#ifndef " ^ guard
       ; "#define " ^ guard
@@ -1214,7 +1214,7 @@ let gen_enclave_code (ec : enclave_content) (ep : edger8r_params) =
         List.map (fun f -> oe_gen_prototype f.uf_fdecl ^ ";") ufs
       else ["/* There were no ocalls. */"]
     in
-    let guard = "EDGER8R_" ^ String.uppercase ec.file_shortnm ^ "_U_H" in
+    let guard = "EDGER8R_" ^ String.uppercase_ascii ec.file_shortnm ^ "_U_H" in
     let content =
       [ "#ifndef " ^ guard
       ; "#define " ^ guard

--- a/tools/oeedger8r/intel/CodeGen.ml
+++ b/tools/oeedger8r/intel/CodeGen.ml
@@ -636,7 +636,7 @@ let gen_ufunc_proto (uf: Ast.untrusted_func) =
   let cconv_str = "SGX_" ^ Ast.get_call_conv_str uf.Ast.uf_fattr.Ast.fa_convention in
   let func_name = uf.Ast.uf_fdecl.Ast.fname in
   let plist_str = get_plist_str uf.Ast.uf_fdecl in
-  let func_guard = sprintf "%s_DEFINED__" (String.uppercase func_name) in 
+  let func_guard = sprintf "%s_DEFINED__" (String.uppercase_ascii func_name) in
     sprintf "#ifndef %s\n#define %s\n%s%s SGX_UBRIDGE(%s, %s, (%s));\n#endif"
             func_guard func_guard dllimport ret_tystr cconv_str func_name plist_str
 
@@ -665,7 +665,7 @@ let ms_writer out_chan ec =
 (* Generate untrusted header for enclave *)
 let gen_untrusted_header (ec: enclave_content) =
   let header_fname = get_uheader_name ec.file_shortnm in
-  let guard_macro = sprintf "%s_U_H__" (String.uppercase ec.enclave_name) in
+  let guard_macro = sprintf "%s_U_H__" (String.uppercase_ascii ec.enclave_name) in
   let preemble_code =
     let include_list = gen_include_list (ec.include_list @ !untrusted_headers) in
       gen_uheader_preemble guard_macro include_list
@@ -698,7 +698,7 @@ let gen_theader_preemble (guard: string) (inclist: string) =
 (* Generate trusted header for enclave *)
 let gen_trusted_header (ec: enclave_content) =
   let header_fname = get_theader_name ec.file_shortnm in
-  let guard_macro = sprintf "%s_T_H__" (String.uppercase ec.enclave_name) in
+  let guard_macro = sprintf "%s_T_H__" (String.uppercase_ascii ec.enclave_name) in
   let guard_code =
     let include_list = gen_include_list (ec.include_list @ !trusted_headers) in
       gen_theader_preemble guard_macro include_list in

--- a/tools/oeedger8r/intel/Util.ml
+++ b/tools/oeedger8r/intel/Util.ml
@@ -117,7 +117,7 @@ let rec parse_cmdline (progname: string) (cmdargs: string list) =
     match args with
         [] -> ()
       | op :: ops ->
-          match String.lowercase op with
+          match String.lowercase_ascii op with
               "--use-prefix" -> use_pref := true; local_parser ops
             | "--header-only"-> hd_only := true; local_parser ops
             | "--untrusted"  -> untrusted := true; local_parser ops


### PR DESCRIPTION
Newer version of OCAML complains:
File "/home/azureuser/openenclave/tools/oeedger8r/intel/Util.ml", line 120, characters 16-32:
Warning 3: deprecated: String.lowercase
Use String.lowercase_ascii instead.
File "/home/azureuser/openenclave/tools/oeedger8r/intel/CodeGen.ml", line 639, characters 43-59:
Warning 3: deprecated: String.uppercase
Use String.uppercase_ascii instead.
File "/home/azureuser/openenclave/tools/oeedger8r/intel/CodeGen.ml", line 668, characters 40-56:
Warning 3: deprecated: String.uppercase
Use String.uppercase_ascii instead.
File "/home/azureuser/openenclave/tools/oeedger8r/intel/CodeGen.ml", line 701, characters 40-56:
Warning 3: deprecated: String.uppercase
Use String.uppercase_ascii instead.
File "/home/azureuser/openenclave/tools/oeedger8r/Emitter.ml", line 571, characters 19-35:
Warning 3: deprecated: String.uppercase
Use String.uppercase_ascii instead.
File "/home/azureuser/openenclave/tools/oeedger8r/Emitter.ml", line 1127, characters 29-45:
Warning 3: deprecated: String.uppercase
Use String.uppercase_ascii instead.
File "/home/azureuser/openenclave/tools/oeedger8r/Emitter.ml", line 1217, characters 29-45:
Warning 3: deprecated: String.uppercase
Use String.uppercase_ascii instead.

FWIW: https://oe-jenkins.eastus.cloudapp.azure.com/blue/organizations/jenkins/OpenEnclave-sandbox/detail/OpenEnclave-sandbox/1401/pipeline/55#step-922-log-100

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>