### PR TITLE
Make openssl available to the command line with ansible windows.yml

### DIFF
--- a/scripts/ansible/roles/windows/openenclave/vars/windows.yml
+++ b/scripts/ansible/roles/windows/openenclave/vars/windows.yml
@@ -33,6 +33,7 @@ packages_env_path:
   - 'C:\Program Files\OCaml\bin'
   - 'C:\Program Files\LLVM\bin'
   - 'C:\Program Files\Git\bin'
+  - 'C:\Program Files\Git\mingw64\bin'
   - 'C:\Program Files\shellcheck'
   - 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build'
 


### PR DESCRIPTION
openssl is needed for certificate generation by a few tests (big-malloc, debug-mode, props, etc) and the build will fail on Windows ACC VMs systems configured by ansible/oe-engine. 
For Windows, we are using the openssl from Git and manually add this to the system PATH. 
This PR adds C:\Program Files\Git\mingw64\bin to the system PATH in ansible windows.yml