### PR TITLE
Add TA Dev Kits into oetools-full-*

### DIFF
--- a/.jenkins/Dockerfile.full
+++ b/.jenkins/Dockerfile.full
@@ -5,7 +5,7 @@
 # IMPORTANT- Please update the version number in the next sentence
 # when you create a new docker image.
 #
-# This Dockerfile script builds an image for tag oetools-full-18.04:0.5
+# This Dockerfile script builds an image for tag oetools-full-18.04:0.8
 
 # To use this Dockerfile, you will need to install docker-ce.
 # Instructions for installing it on Ubuntu 16.04 LTS are at:
@@ -13,10 +13,16 @@
 #
 # Once installed, build a docker image from .jenkins folder and
 # it will use this Dockerfile by default:
-#     openenclave$ sudo docker build --no-cache=true --build-arg ubuntu_version=<ubuntu_version> -t oetools-full-<ubuntu_version>:<version> -f .jenkins/Dockerfile.full .
+#     openenclave$ sudo docker build --no-cache=true --build-arg ubuntu_version=<ubuntu_version> --build-arg devkits_uri=<devkits_uri> -t oetools-full-<ubuntu_version>:<version> -f .jenkins/Dockerfile.full .
 #
 # For example, for version 1.x with Ubuntu 18.04 :
-#     openenclave$ sudo docker build --no-cache=true --build-arg ubuntu_version=18.04 -t oetools-full-18.04:1.x -f .jenkins/Dockerfile.full .
+#     openenclave$ sudo docker build \
+#         --no-cache=true \
+#         --build-arg ubuntu_version=18.04 \
+#         --build-arg devkits_uri=https://tcpsbuild.blob.core.windows.net/tcsp-build/OE-CI-devkits-dd4c992d.tar.gz \
+#         -t oetools-full-18.04:1.x \
+#         -f .jenkins/Dockerfile.full \
+#         .
 #
 # Note that DNS forwarding in a VM can interfere with Docker
 # getting updates from Ubuntu apt-get repositories as part of the
@@ -51,6 +57,7 @@ ARG GID=1000
 
 ADD scripts/ansible /ansible
 
+ARG devkits_uri
 RUN /ansible/install-ansible.sh && \
     ansible localhost --playbook-dir=/ansible -m import_role -a "name=linux/docker tasks_from=ci-setup.yml" -vvv && \
     /ansible/remove-ansible.sh && \
@@ -59,4 +66,6 @@ RUN /ansible/install-ansible.sh && \
     git config --global user.email "oeciteam@microsoft.com" && \
     git config --global user.name "OE CI Team" && \
     groupadd --gid ${GID} ${GNAME} && \
-    useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME}
+    useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME} && \
+    curl ${devkits_uri} | tar xvz --no-same-permissions --no-same-owner && \
+    echo ${devkits_uri##*/} > /devkits/TARBALL

--- a/.jenkins/build_docker_images.Jenkinsfile
+++ b/.jenkins/build_docker_images.Jenkinsfile
@@ -18,12 +18,12 @@ def buildDockerImages() {
             String buildArgs = oe.dockerBuildArgs("UID=\$(id -u)", "UNAME=\$(id -un)",
                                                   "GID=\$(id -g)", "GNAME=\$(id -gn)")
             stage("Build Ubuntu 16.04 Full Docker Image") {
-                oefull1604 = oe.dockerImage("oetools-full-16.04:${DOCKER_TAG}", ".jenkins/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=16.04")
-                puboefull1604 = oe.dockerImage("oeciteam/oetools-full-16.04:${DOCKER_TAG}", ".jenkins/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=16.04")
+                oefull1604 = oe.dockerImage("oetools-full-16.04:${DOCKER_TAG}", ".jenkins/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=16.04 --build-arg devkits_uri=${DEVKITS_URI}")
+                puboefull1604 = oe.dockerImage("oeciteam/oetools-full-16.04:${DOCKER_TAG}", ".jenkins/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=16.04 --build-arg devkits_uri=${DEVKITS_URI}")
             }
             stage("Build Ubuntu 18.04 Full Docker Image") {
-                oefull1804 = oe.dockerImage("oetools-full-18.04:${DOCKER_TAG}", ".jenkins/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=18.04")
-                puboefull1804 = oe.dockerImage("oeciteam/oetools-full-18.04:${DOCKER_TAG}", ".jenkins/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=18.04")
+                oefull1804 = oe.dockerImage("oetools-full-18.04:${DOCKER_TAG}", ".jenkins/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=18.04 --build-arg devkits_uri=${DEVKITS_URI}")
+                puboefull1804 = oe.dockerImage("oeciteam/oetools-full-18.04:${DOCKER_TAG}", ".jenkins/Dockerfile.full", "${buildArgs} --build-arg ubuntu_version=18.04 --build-arg devkits_uri=${DEVKITS_URI}")
             }
             stage("Build Ubuntu 16.04 Minimal Docker image") {
                 oeminimal1604 = oe.dockerImage("oetools-minimal-16.04:${DOCKER_TAG}", ".jenkins/Dockerfile.minimal", "${buildArgs} --build-arg ubuntu_version=16.04")


### PR DESCRIPTION
As suggested in #1820, to avoid CI failures due to possible network interruptions, this PR adds the TA Dev Kits to the `oetools-full-*` container images, which are used to build the SDK for AArch64.

#1820 has been updated to only download the TA Dev Kits if they are not already in the container, or if the TA Dev Kits in the container don't match the ones pointed to by `DEVKITS_URI` as passed to the Jenkins pipeline when CI runs.

**Note:** Successful run of image creation with these changes [here](https://oe-jenkins.eastus.cloudapp.azure.com/job/OpenEnclave-Docker-Images/23/).