### PR TITLE
Enabled MBEDTLS_NET_C component

### DIFF
--- a/3rdparty/mbedtls/config.h
+++ b/3rdparty/mbedtls/config.h
@@ -2216,7 +2216,7 @@
  * This module provides networking routines.
  */
 // Open Enclave: disabled, network I/O is currently unsupported in enclaves
-//#define MBEDTLS_NET_C
+#define MBEDTLS_NET_C
 
 /**
  * \def MBEDTLS_OID_C


### PR DESCRIPTION
As part of the work for supporting attested TLS feature (https://github.com/microsoft/openenclave/issues/1325) , we need to enable this mbedtls 