### PR TITLE
Remove support for previously deprecated for V1 APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
        - Link with `-Wl,-z,noexecstack`.
        - Note that `-Wl,-z,now` is _not_ enabled by default, but app authors
          should enable it themselves after assessing its startup impact.
+- Removed support for the previously deprecated `OE_API_VERSION=1` APIs.
 
 [v0.5.0] - 2019-4-9
 -------------------

--- a/common/sgx/report.c
+++ b/common/sgx/report.c
@@ -154,7 +154,7 @@ done:
     return result;
 }
 
-oe_result_t oe_get_target_info_v1(
+static oe_result_t _oe_get_target_info_internal(
     const uint8_t* report,
     size_t report_size,
     void* target_info_buffer,
@@ -211,7 +211,8 @@ oe_result_t oe_get_target_info_v2(
     *target_info_buffer = NULL;
     *target_info_size = 0;
 
-    result = oe_get_target_info_v1(report, report_size, NULL, &temp_size);
+    result =
+        _oe_get_target_info_internal(report, report_size, NULL, &temp_size);
     if (result != OE_BUFFER_TOO_SMALL)
     {
         if (result == OE_OK)
@@ -228,7 +229,8 @@ oe_result_t oe_get_target_info_v2(
         return OE_OUT_OF_MEMORY;
     }
 
-    result = oe_get_target_info_v1(report, report_size, temp_info, &temp_size);
+    result = _oe_get_target_info_internal(
+        report, report_size, temp_info, &temp_size);
     if (result != OE_OK)
     {
         oe_free(temp_info);

--- a/enclave/core/sgx/keys.c
+++ b/enclave/core/sgx/keys.c
@@ -122,41 +122,6 @@ oe_result_t oe_get_key(
     return _get_key_imp(sgx_key_request, sgx_key);
 }
 
-oe_result_t oe_get_seal_key_v1(
-    const uint8_t* key_info,
-    size_t key_info_size,
-    uint8_t* key_buffer,
-    size_t* key_buffer_size)
-{
-    oe_result_t ret;
-
-    // Check parameters.
-    if ((key_info == NULL) || (key_info_size != sizeof(sgx_key_request_t)))
-    {
-        return OE_INVALID_PARAMETER;
-    }
-
-    if ((key_buffer == NULL) || (key_buffer_size == NULL))
-    {
-        return OE_INVALID_PARAMETER;
-    }
-
-    if (*key_buffer_size < sizeof(sgx_key_t))
-    {
-        *key_buffer_size = sizeof(sgx_key_t);
-        return OE_BUFFER_TOO_SMALL;
-    }
-
-    // Get the key based on input key info.
-    ret = oe_get_key((sgx_key_request_t*)key_info, (sgx_key_t*)key_buffer);
-    if (ret == OE_OK)
-    {
-        *key_buffer_size = sizeof(sgx_key_t);
-    }
-
-    return ret;
-}
-
 oe_result_t oe_get_seal_key_v2(
     const uint8_t* key_info,
     size_t key_info_size,
@@ -253,7 +218,7 @@ done:
     return result;
 }
 
-oe_result_t oe_get_seal_key_by_policy_v1(
+static oe_result_t _oe_get_seal_key_by_policy_internal(
     oe_seal_policy_t seal_policy,
     uint8_t* key_buffer,
     size_t* key_buffer_size,
@@ -375,7 +340,7 @@ oe_result_t oe_get_seal_key_by_policy_v2(
         }
     }
 
-    result = oe_get_seal_key_by_policy_v1(
+    result = _oe_get_seal_key_by_policy_internal(
         seal_policy, key_buffer, &key_buffer_size, key_info, &key_info_size);
     if (result != OE_OK)
     {

--- a/enclave/core/sgx/report.c
+++ b/enclave/core/sgx/report.c
@@ -261,7 +261,7 @@ done:
     return result;
 }
 
-oe_result_t oe_get_report_v1(
+static oe_result_t _oe_get_report_internal(
     uint32_t flags,
     const uint8_t* report_data,
     size_t report_data_size,
@@ -349,7 +349,7 @@ oe_result_t oe_get_report_v2(
     *report_buffer = NULL;
     *report_buffer_size = 0;
 
-    result = oe_get_report_v1(
+    result = _oe_get_report_internal(
         flags,
         report_data,
         report_data_size,
@@ -368,7 +368,7 @@ oe_result_t oe_get_report_v2(
         return OE_OUT_OF_MEMORY;
     }
 
-    result = oe_get_report_v1(
+    result = _oe_get_report_internal(
         flags,
         report_data,
         report_data_size,

--- a/host/sgx/report.c
+++ b/host/sgx/report.c
@@ -148,7 +148,7 @@ done:
     return result;
 }
 
-oe_result_t oe_get_report_v1(
+static oe_result_t _oe_get_report_internal(
     oe_enclave_t* enclave,
     uint32_t flags,
     const void* opt_params,
@@ -234,7 +234,7 @@ oe_result_t oe_get_report_v2(
     *report_buffer = NULL;
     *report_buffer_size = 0;
 
-    result = oe_get_report_v1(
+    result = _oe_get_report_internal(
         enclave,
         flags,
         opt_params,
@@ -256,7 +256,7 @@ oe_result_t oe_get_report_v2(
         return OE_OUT_OF_MEMORY;
     }
 
-    result = oe_get_report_v1(
+    result = _oe_get_report_internal(
         enclave,
         flags,
         opt_params,

--- a/include/openenclave/bits/defs.h
+++ b/include/openenclave/bits/defs.h
@@ -10,7 +10,7 @@
 
 /* OE_API_VERSION */
 #ifndef OE_API_VERSION
-#define OE_API_VERSION 1
+#define OE_API_VERSION 2
 #endif
 
 /* OE_PRINTF_FORMAT */

--- a/include/openenclave/enclave.h
+++ b/include/openenclave/enclave.h
@@ -248,50 +248,10 @@ void __oe_assert_fail(
 #endif
 
 #if (OE_API_VERSION < 2)
-#define oe_get_report oe_get_report_v1
+#error "Only OE_API_VERSION of 2 is supported"
 #else
 #define oe_get_report oe_get_report_v2
 #endif
-
-/**
- * Get a report signed by the enclave platform for use in attestation.
- *
- * This function creates a report to be used in local or remote attestation. The
- * report shall contain the data given by the **report_data** parameter.
- *
- * If the *report_buffer* is NULL or *report_size* parameter is too small,
- * this function returns OE_BUFFER_TOO_SMALL.
- *
- * @deprecated This function is deprecated. Use oe_get_report_v2() instead.
- *
- * @param flags Specifying default value (0) generates a report for local
- * attestation. Specifying OE_REPORT_FLAGS_REMOTE_ATTESTATION generates a
- * report for remote attestation.
- * @param report_data The report data that will be included in the report.
- * @param report_data_size The size of the **report_data** in bytes.
- * @param opt_params Optional additional parameters needed for the current
- * enclave type. For SGX, this can be sgx_target_info_t for local attestation.
- * @param opt_params_size The size of the **opt_params** buffer.
- * @param report_buffer The buffer to where the resulting report will be copied.
- * @param report_buffer_size The size of the **report** buffer. This is set to
- * the
- * required size of the report buffer on return.
- *
- * @retval OE_OK The report was successfully created.
- * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
- * @retval OE_BUFFER_TOO_SMALL The **report_buffer** buffer is NULL or too
- * small.
- * @retval OE_OUT_OF_MEMORY Failed to allocate memory.
- *
- */
-oe_result_t oe_get_report_v1(
-    uint32_t flags,
-    const uint8_t* report_data,
-    size_t report_data_size,
-    const void* opt_params,
-    size_t opt_params_size,
-    uint8_t* report_buffer,
-    size_t* report_buffer_size);
 
 /**
  * Get a report signed by the enclave platform for use in attestation.
@@ -333,41 +293,10 @@ oe_result_t oe_get_report_v2(
 void oe_free_report(uint8_t* report_buffer);
 
 #if (OE_API_VERSION < 2)
-#define oe_get_target_info oe_get_target_info_v1
+#error "Only OE_API_VERSION of 2 is supported"
 #else
 #define oe_get_target_info oe_get_target_info_v2
 #endif
-
-/**
- * Extracts additional platform specific data from the report and writes
- * it to *target_info_buffer*. After calling this function, the
- * *target_info_buffer* can used for the *opt_params* field in *oe_get_report*.
- *
- * For example, on SGX, the *target_info_buffer* can be used as a
- * sgx_target_info_t for local attestation.
- *
- * If the *target_info_buffer* is NULL or the *target_info_size* parameter is
- * too small, this function returns OE_BUFFER_TOO_SMALL.
- *
- * @deprecated This function is deprecated. Use oe_get_target_info_v2() instead.
- *
- * @param report The report returned by **oe_get_report**.
- * @param report_size The size of **report** in bytes.
- * @param target_info_buffer The buffer to where the platform specific data
- * will be placed.
- * @param target_info_size The size of **target_info_buffer**. This is set to
- * the required size of **target_info_buffer** on return.
- *
- * @retval OE_OK The platform specific data was successfully extracted.
- * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
- * @retval OE_BUFFER_TOO_SMALL **target_info_buffer** is NULL or too small.
- *
- */
-oe_result_t oe_get_target_info_v1(
-    const uint8_t* report,
-    size_t report_size,
-    void* target_info_buffer,
-    size_t* target_info_size);
 
 /**
  * Extracts additional platform specific data from the report and writes
@@ -446,46 +375,10 @@ oe_result_t oe_verify_report(
     oe_report_t* parsed_report);
 
 #if (OE_API_VERSION < 2)
-#define oe_get_seal_key_by_policy oe_get_seal_key_by_policy_v1
+#error "Only OE_API_VERSION of 2 is supported"
 #else
 #define oe_get_seal_key_by_policy oe_get_seal_key_by_policy_v2
 #endif
-
-/**
- * Get a symmetric encryption key derived from the specified policy and coupled
- * to the enclave platform.
- *
- * @deprecated This function is deprecated. Use oe_get_seal_key_by_policy_v2()
- instead.
- *
- * @param seal_policy The policy for the identity properties used to derive the
- * seal key.
- * @param key_buffer The buffer to write the resulting seal key to.
- * @param key_buffer_size The size of the **key_buffer** buffer. If this is too
- * small, this function sets it to the required size and returns
- * OE_BUFFER_TOO_SMALL. When this function success, the number of bytes written
- * to key_buffer is set to it.
- * @param key_info Optional buffer for the enclave-specific key information
- which
- * can be used to retrieve the same key later, on a newer security version.
- * @param key_info_size The size of the **key_info** buffer. If this is too
- small,
- * this function sets it to the required size and returns OE_BUFFER_TOO_SMALL.
- * When this function success, the number of bytes written to key_info is set to
- * it.
- *
- * @retval OE_OK The seal key was successfully requested.
- * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
- * @retval OE_BUFFER_TOO_SMALL The **key_buffer** or **key_info** buffer is too
- * small.
- * @retval OE_UNEXPECTED An unexpected error happened.
- */
-oe_result_t oe_get_seal_key_by_policy_v1(
-    oe_seal_policy_t seal_policy,
-    uint8_t* key_buffer,
-    size_t* key_buffer_size,
-    uint8_t* key_info,
-    size_t* key_info_size);
 
 /**
  * Get a symmetric encryption key derived from the specified policy and coupled
@@ -518,39 +411,10 @@ oe_result_t oe_get_seal_key_by_policy_v2(
     size_t* key_info_size);
 
 #if (OE_API_VERSION < 2)
-#define oe_get_seal_key oe_get_seal_key_v1
+#error "Only OE_API_VERSION of 2 is supported"
 #else
 #define oe_get_seal_key oe_get_seal_key_v2
 #endif
-
-/**
- * Get a symmetric encryption key from the enclave platform using existing key
- * information.
- *
- * @deprecated This function is deprecated. Use oe_get_seal_key_v2() instead.
- *
- * @param key_info The enclave-specific key information to derive the seal key
- * with.
- * @param key_info_size The size of the **key_info** buffer.
- * @param key_buffer The buffer to write the resulting seal key to. It will not
- * be changed if this function fails.
- * @param key_buffer_size The size of the **key_buffer** buffer. If this is too
- * small, this function sets it to the required size and returns
- * OE_BUFFER_TOO_SMALL. When this function success, the number of bytes written
- * to key_buffer is set to it.
- *
- * @retval OE_OK The seal key was successfully requested.
- * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
- * @retval OE_BUFFER_TOO_SMALL The **key_buffer** buffer is too small.
- * @retval OE_INVALID_CPUSVN **key_info** contains an invalid CPUSVN.
- * @retval OE_INVALID_ISVSVN **key_info** contains an invalid ISVSVN.
- * @retval OE_INVALID_KEYNAME **key_info** contains an invalid KEYNAME.
- */
-oe_result_t oe_get_seal_key_v1(
-    const uint8_t* key_info,
-    size_t key_info_size,
-    uint8_t* key_buffer,
-    size_t* key_buffer_size);
 
 /**
  * Returns a public key that is associated with the identity of the enclave

--- a/include/openenclave/host.h
+++ b/include/openenclave/host.h
@@ -122,47 +122,10 @@ oe_result_t oe_create_enclave(
 oe_result_t oe_terminate_enclave(oe_enclave_t* enclave);
 
 #if (OE_API_VERSION < 2)
-#define oe_get_report oe_get_report_v1
+#error "Only OE_API_VERSION of 2 is supported"
 #else
 #define oe_get_report oe_get_report_v2
 #endif
-
-/**
- * Get a report signed by the enclave platform for use in attestation.
- *
- * This function creates a report to be used in local or remote attestation.
- *
- * If the *report_buffer* is NULL or *report_size* parameter is too small,
- * this function returns OE_BUFFER_TOO_SMALL.
- *
- * @deprecated This function is deprecated. Use oe_get_report_v2() instead.
- *
- * @param enclave The instance of the enclave that will generate the report.
- * @param flags Specifying default value (0) generates a report for local
- * attestation. Specifying OE_REPORT_FLAGS_REMOTE_ATTESTATION generates a
- * report for remote attestation.
- * @param opt_params Optional additional parameters needed for the current
- * enclave type. For SGX, this can be sgx_target_info_t for local attestation.
- * @param opt_params_size The size of the **opt_params** buffer.
- * @param report_buffer The buffer to where the resulting report will be copied.
- * @param report_buffer_size The size of the **report** buffer. This is set to
- * the required size of the report buffer on return.
- *
- * @retval OE_OK The report was successfully created.
- * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
- * @retval OE_BUFFER_TOO_SMALL The **report_buffer** buffer is NULL or too
- * small.
- * @retval OE_OUT_OF_MEMORY Failed to allocate memory.
- *
- */
-
-oe_result_t oe_get_report_v1(
-    oe_enclave_t* enclave,
-    uint32_t flags,
-    const void* opt_params,
-    size_t opt_params_size,
-    uint8_t* report_buffer,
-    size_t* report_buffer_size);
 
 /**
  * Get a report signed by the enclave platform for use in attestation.
@@ -201,41 +164,10 @@ oe_result_t oe_get_report_v2(
 void oe_free_report(uint8_t* report_buffer);
 
 #if (OE_API_VERSION < 2)
-#define oe_get_target_info oe_get_target_info_v1
+#error "Only OE_API_VERSION of 2 is supported"
 #else
 #define oe_get_target_info oe_get_target_info_v2
 #endif
-
-/**
- * Extracts additional platform specific data from the report and writes
- * it to *target_info_buffer*. After calling this function, the
- * *target_info_buffer* can used for the *opt_params* field in *oe_get_report*.
- *
- * For example, on SGX, the *target_info_buffer* can be used as a
- * sgx_target_info_t for local attestation.
- *
- * If the *target_info_buffer* is NULL or the *target_info_size* parameter is
- * too small, this function returns OE_BUFFER_TOO_SMALL.
- *
- * @deprecated This function is deprecated. Use oe_get_target_info_v2() instead.
- *
- * @param report The report returned by **oe_get_report**.
- * @param report_size The size of **report** in bytes.
- * @param target_info_buffer The buffer to where the platform specific data
- * will be placed.
- * @param target_info_size The size of **target_info_buffer**. This is set to
- * the required size of **target_info_buffer** on return.
- *
- * @retval OE_OK The platform specific data was successfully extracted.
- * @retval OE_INVALID_PARAMETER At least one parameter is invalid.
- * @retval OE_BUFFER_TOO_SMALL **target_info_buffer** is NULL or too small.
- *
- */
-oe_result_t oe_get_target_info_v1(
-    const uint8_t* report,
-    size_t report_size,
-    void* target_info_buffer,
-    size_t* target_info_size);
 
 /**
  * Extracts additional platform specific data from the report and writes

--- a/tests/report/common/tests.cpp
+++ b/tests/report/common/tests.cpp
@@ -580,6 +580,7 @@ void test_remote_report()
                     report_ptr_size,
                     report_data,
                     report_data_size + 1) == false);
+            oe_free_report(report_buffer_ptr);
         }
     }
 #endif

--- a/tests/report/enc/enc.cpp
+++ b/tests/report/enc/enc.cpp
@@ -36,8 +36,6 @@ void test_minimum_issue_date(oe_datetime_t now)
 #ifdef OE_USE_LIBSGX
     static uint8_t* report;
     size_t report_size = 0;
-    static uint8_t report_v1[OE_MAX_REPORT_SIZE];
-    size_t report_v1_size = sizeof(report_v1);
     static uint8_t* report_v2;
     size_t report_v2_size = 0;
 
@@ -54,20 +52,6 @@ void test_minimum_issue_date(oe_datetime_t now)
 
     // Verify the report.
     OE_TEST(oe_verify_report(report, report_size, NULL) == OE_OK);
-
-    // Generate reports.
-    OE_TEST(
-        oe_get_report_v1(
-            OE_REPORT_FLAGS_REMOTE_ATTESTATION,
-            NULL,
-            0,
-            NULL,
-            0,
-            report_v1,
-            &report_v1_size) == OE_OK);
-
-    // Verify the report.
-    OE_TEST(oe_verify_report(report_v1, report_v1_size, NULL) == OE_OK);
 
     // Generate reports.
     OE_TEST(
@@ -104,10 +88,6 @@ void test_minimum_issue_date(oe_datetime_t now)
     // Verify the report.
     OE_TEST(
         oe_verify_report(report, report_size, NULL) ==
-        OE_INVALID_REVOCATION_INFO);
-
-    OE_TEST(
-        oe_verify_report(report_v1, report_v1_size, NULL) ==
         OE_INVALID_REVOCATION_INFO);
 
     OE_TEST(

--- a/tests/sealKey/enc/enc.cpp
+++ b/tests/sealKey/enc/enc.cpp
@@ -86,20 +86,11 @@ bool TestOEGetSealKey()
          seal_policy <= OE_SEAL_POLICY_PRODUCT;
          seal_policy++)
     {
-        uint8_t key_buffer[sizeof(sgx_key_t)] = {0};
         uint8_t* key_buffer_ptr = NULL;
-        size_t key_buffer_size = 0;
         size_t key_buffer_ptr_size = 0;
         oe_result_t ret;
 
         // Get the seal key should fail if the key_buffer is NULL.
-        ret = oe_get_seal_key_by_policy_v1(
-            (oe_seal_policy_t)seal_policy, NULL, NULL, NULL, NULL);
-        if (ret != OE_INVALID_PARAMETER)
-        {
-            return false;
-        }
-
         ret = oe_get_seal_key_by_policy_v2(
             (oe_seal_policy_t)seal_policy, NULL, NULL, NULL, NULL);
         if (ret != OE_INVALID_PARAMETER)
@@ -144,36 +135,8 @@ bool TestOEGetSealKey()
         {
             return false;
         }
-
-        // Get the seal key should fail if the buffer is too small.
-        ret = oe_get_seal_key_by_policy_v1(
-            (oe_seal_policy_t)seal_policy,
-            key_buffer,
-            &key_buffer_size,
-            NULL,
-            NULL);
-        if (ret != OE_BUFFER_TOO_SMALL)
-        {
-            return false;
-        }
-
-        // The correct buffer size should be returned.
-        OE_TEST(key_buffer_size == sizeof(sgx_key_t));
 
         // Get the seal key by policy and without output the key info.
-        ret = oe_get_seal_key_by_policy_v1(
-            (oe_seal_policy_t)seal_policy,
-            key_buffer,
-            &key_buffer_size,
-            NULL,
-            NULL);
-        if (ret != OE_OK)
-        {
-            return false;
-        }
-
-        OE_TEST(key_buffer_size == sizeof(sgx_key_t));
-
         ret = oe_get_seal_key_by_policy_v2(
             (oe_seal_policy_t)seal_policy,
             &key_buffer_ptr,
@@ -184,29 +147,8 @@ bool TestOEGetSealKey()
         {
             return false;
         }
-        oe_free_seal_key(key_buffer_ptr, NULL);
 
         OE_TEST(key_buffer_ptr_size == sizeof(sgx_key_t));
-
-        uint8_t second_key_buffer[sizeof(sgx_key_t)] = {0};
-        size_t second_key_buffer_size = sizeof(second_key_buffer);
-        uint8_t key_info[sizeof(sgx_key_request_t)] = {0};
-        size_t key_info_size = sizeof(key_info);
-
-        // Get the seal key by policy and output the key info.
-        ret = oe_get_seal_key_by_policy_v1(
-            (oe_seal_policy_t)seal_policy,
-            second_key_buffer,
-            &second_key_buffer_size,
-            key_info,
-            &key_info_size);
-        if (ret != OE_OK)
-        {
-            return false;
-        }
-
-        OE_TEST(second_key_buffer_size == sizeof(sgx_key_t));
-        OE_TEST(key_info_size == sizeof(sgx_key_request_t));
 
         uint8_t* second_key_buffer_ptr = NULL;
         size_t second_key_buffer_ptr_size = 0;
@@ -232,7 +174,6 @@ bool TestOEGetSealKey()
 
         second_key_buffer_ptr = NULL;
         key_info_ptr = NULL;
-        second_key_buffer_size = 0;
         key_info_ptr_size = NULL;
 
         // Get the seal key by policy and output the key info.
@@ -247,37 +188,29 @@ bool TestOEGetSealKey()
             return false;
         }
 
-        oe_free_seal_key(second_key_buffer_ptr, key_info_ptr);
+        oe_free_seal_key(second_key_buffer_ptr, NULL);
 
         OE_TEST(second_key_buffer_ptr_size == sizeof(sgx_key_t));
         OE_TEST(key_info_ptr_size == sizeof(sgx_key_request_t));
 
-        uint8_t third_key_buffer[sizeof(sgx_key_t)] = {0};
         uint8_t* third_key_ptr;
-        size_t third_key_buffer_size = sizeof(third_key_buffer);
         size_t third_key_ptr_size;
 
         // Get the seal key using saved key info.
-        ret = oe_get_seal_key_v1(
-            key_info, key_info_size, third_key_buffer, &third_key_buffer_size);
-        if (ret != OE_OK)
-        {
-            return false;
-        }
         ret = oe_get_seal_key_v2(
-            key_info, key_info_size, &third_key_ptr, &third_key_ptr_size);
+            key_info_ptr,
+            key_info_ptr_size,
+            &third_key_ptr,
+            &third_key_ptr_size);
         if (ret != OE_OK)
         {
             return false;
         }
 
-        OE_TEST(third_key_buffer_size == sizeof(sgx_key_t));
         OE_TEST(third_key_ptr_size == sizeof(sgx_key_t));
 
         // The seal keys should match.
-        if ((memcmp(key_buffer, second_key_buffer, sizeof(sgx_key_t)) != 0) ||
-            (memcmp(key_buffer, third_key_ptr, sizeof(sgx_key_t)) != 0) ||
-            (memcmp(key_buffer, third_key_buffer, sizeof(sgx_key_t)) != 0))
+        if ((memcmp(key_buffer_ptr, third_key_ptr, sizeof(sgx_key_t)) != 0))
         {
             return false;
         }
@@ -286,17 +219,14 @@ bool TestOEGetSealKey()
 
         // Modify the isv_svn of key request to invalid and verify the function
         // can't get seal key.
-        sgx_key_request_t* key_request = (sgx_key_request_t*)key_info;
+        sgx_key_request_t* key_request = (sgx_key_request_t*)key_info_ptr;
         uint16_t cur_isv_svn = key_request->isv_svn;
         key_request->isv_svn = 0XFFFF;
-        ret = oe_get_seal_key_v1(
-            key_info, key_info_size, third_key_buffer, &third_key_buffer_size);
-        if (ret != OE_INVALID_ISVSVN)
-        {
-            return false;
-        }
         ret = oe_get_seal_key_v2(
-            key_info, key_info_size, &third_key_ptr, &third_key_ptr_size);
+            key_info_ptr,
+            key_info_ptr_size,
+            &third_key_ptr,
+            &third_key_ptr_size);
         if (ret != OE_INVALID_ISVSVN)
         {
             return false;
@@ -309,18 +239,18 @@ bool TestOEGetSealKey()
             key_request->cpu_svn,
             0XFF,
             OE_FIELD_SIZE(sgx_key_request_t, cpu_svn));
-        ret = oe_get_seal_key_v1(
-            key_info, key_info_size, third_key_buffer, &third_key_buffer_size);
-        if (ret != OE_INVALID_CPUSVN)
-        {
-            return false;
-        }
         ret = oe_get_seal_key_v2(
-            key_info, key_info_size, &third_key_ptr, &third_key_ptr_size);
+            key_info_ptr,
+            key_info_ptr_size,
+            &third_key_ptr,
+            &third_key_ptr_size);
         if (ret != OE_INVALID_CPUSVN)
         {
             return false;
         }
+
+        oe_free_seal_key(key_buffer_ptr, NULL);
+        oe_free_seal_key(NULL, key_info_ptr);
     }
 
     return true;

--- a/tests/sealKey/enc/enc.cpp
+++ b/tests/sealKey/enc/enc.cpp
@@ -212,6 +212,7 @@ bool TestOEGetSealKey()
         // The seal keys should match.
         if ((memcmp(key_buffer_ptr, third_key_ptr, sizeof(sgx_key_t)) != 0))
         {
+            oe_free_seal_key(third_key_ptr, NULL);
             return false;
         }
 
@@ -229,6 +230,10 @@ bool TestOEGetSealKey()
             &third_key_ptr_size);
         if (ret != OE_INVALID_ISVSVN)
         {
+            if (ret == OE_OK)
+            {
+                oe_free_seal_key(third_key_ptr, NULL);
+            }
             return false;
         }
 
@@ -246,6 +251,10 @@ bool TestOEGetSealKey()
             &third_key_ptr_size);
         if (ret != OE_INVALID_CPUSVN)
         {
+            if (ret == OE_OK)
+            {
+                oe_free_seal_key(third_key_ptr, NULL);
+            }
             return false;
         }
 


### PR DESCRIPTION
Default to OE_API_VERSION=2 and remove all code referring to OE_API_VERSION=1, throwing an error if built with that option.
Fixes #1829
