### PR TITLE
Disable Intel's edger8r from looking for GCC

### DIFF
--- a/tools/oeedger8r/intel/Preprocessor.ml
+++ b/tools/oeedger8r/intel/Preprocessor.ml
@@ -51,6 +51,10 @@ let read_process (command : string) : Unix.process_status * string =
 
 (*Return None if gcc not found, caller should handle it*)
 let processor_macro ( full_path : string) : string option=
+  None
+  (* Preprocessor is disabled because:
+   * 1. It causes edger8r to print incorrect line numbers in error messages.
+   * 2. It does not work in windows.
   let gcc_path = snd (read_process "which gcc") in
   if not (String.contains gcc_path  '/' ) then
     (eprintf "warning: preprocessor is not found\n"; None)
@@ -65,4 +69,5 @@ let processor_macro ( full_path : string) : string option=
           failwithf "Preprocessor failed\n"
         else
           Some(snd output)
-      | _ -> failwithf "Preprocessor stopped by signal\n"  
+      | _ -> failwithf "Preprocessor stopped by signal\n"
+  *)


### PR DESCRIPTION
This resurrects a patch we'd previously made and was lost when we pulled
upstream edger8r code from Intel. This patch should silence the warning
on Windows that the preprocessor was not found.