### PR TITLE
More VS work for Linux

### DIFF
--- a/new_platforms/vsextension/ItemTemplates/oehost/host.vstemplate
+++ b/new_platforms/vsextension/ItemTemplates/oehost/host.vstemplate
@@ -17,7 +17,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="openenclave" version="0.2.0-CI-20190521-020719" />
+      <package id="openenclave" version="0.2.0-CI-20190607-222616" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
@@ -93,24 +93,39 @@
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(NoInherit)</IncludePath>
     <LibraryPath>$(NoInherit)</LibraryPath>
+    <RemoteCCompileToolExe>clang-7</RemoteCCompileToolExe>
+    <RemoteCppCompileToolExe>clang-7</RemoteCppCompileToolExe>
+    <RemoteLdToolExe>clang-7</RemoteLdToolExe>
+    <RemoteLdCommmandTimeout />
     <TargetExt />
     <TargetName>$(ProjectName)</TargetName>
+    <RemoteTargetPath>$(RemoteOutDir)/$(TargetName)</RemoteTargetPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='SGX-Simulation-Debug|x86'">
     <GenerateManifest>false</GenerateManifest>
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(NoInherit)</IncludePath>
     <LibraryPath>$(NoInherit)</LibraryPath>
+    <RemoteCCompileToolExe>clang-7</RemoteCCompileToolExe>
+    <RemoteCppCompileToolExe>clang-7</RemoteCppCompileToolExe>
+    <RemoteLdToolExe>clang-7</RemoteLdToolExe>
+    <RemoteLdCommmandTimeout />
     <TargetExt />
     <TargetName>$(ProjectName)</TargetName>
+    <RemoteTargetPath>$(RemoteOutDir)/$(TargetName)</RemoteTargetPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <GenerateManifest>false</GenerateManifest>
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(NoInherit)</IncludePath>
     <LibraryPath>$(NoInherit)</LibraryPath>
+    <RemoteCCompileToolExe>clang-7</RemoteCCompileToolExe>
+    <RemoteCppCompileToolExe>clang-7</RemoteCppCompileToolExe>
+    <RemoteLdToolExe>clang-7</RemoteLdToolExe>
+    <RemoteLdCommmandTimeout />
     <TargetExt />
     <TargetName>$(ProjectName)</TargetName>
+    <RemoteTargetPath>$(RemoteOutDir)/$(TargetName)</RemoteTargetPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <GenerateManifest>false</GenerateManifest>
@@ -121,9 +136,9 @@
     <RemoteCppCompileToolExe>clang-7</RemoteCppCompileToolExe>
     <RemoteLdToolExe>clang-7</RemoteLdToolExe>
     <RemoteLdCommmandTimeout />
-    <RemoteTargetPath>$(RemoteOutDir)/$(TargetName)</RemoteTargetPath>
     <TargetExt />
     <TargetName>$(ProjectName)</TargetName>
+    <RemoteTargetPath>$(RemoteOutDir)/$(TargetName)</RemoteTargetPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='SGX-Simulation-Debug|x64'">
     <GenerateManifest>false</GenerateManifest>
@@ -133,8 +148,10 @@
     <RemoteCCompileToolExe>clang-7</RemoteCCompileToolExe>
     <RemoteCppCompileToolExe>clang-7</RemoteCppCompileToolExe>
     <RemoteLdToolExe>clang-7</RemoteLdToolExe>
+    <RemoteLdCommmandTimeout />
     <TargetExt />
     <TargetName>$(ProjectName)</TargetName>
+    <RemoteTargetPath>$(RemoteOutDir)/$(TargetName)</RemoteTargetPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <GenerateManifest>false</GenerateManifest>
@@ -144,8 +161,10 @@
     <RemoteCCompileToolExe>clang-7</RemoteCCompileToolExe>
     <RemoteCppCompileToolExe>clang-7</RemoteCppCompileToolExe>
     <RemoteLdToolExe>clang-7</RemoteLdToolExe>
+    <RemoteLdCommmandTimeout />
     <TargetExt />
     <TargetName>$(ProjectName)</TargetName>
+    <RemoteTargetPath>$(RemoteOutDir)/$(TargetName)</RemoteTargetPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <ClCompile>
@@ -253,12 +272,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\openenclave.0.2.0-CI-20190521-020719\build\native\openenclave.targets" Condition="Exists('..\packages\openenclave.0.2.0-CI-20190521-020719\build\native\openenclave.targets')" />
+    <Import Project="..\packages\openenclave.0.2.0-CI-20190607-222616\build\native\openenclave.targets" Condition="Exists('..\packages\openenclave.0.2.0-CI-20190607-222616\build\native\openenclave.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\openenclave.0.2.0-CI-20190521-020719\build\native\openenclave.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\openenclave.0.2.0-CI-20190521-020719\build\native\openenclave.targets'))" />
+    <Error Condition="!Exists('..\packages\openenclave.0.2.0-CI-20190607-222616\build\native\openenclave.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\openenclave.0.2.0-CI-20190607-222616\build\native\openenclave.targets'))" />
   </Target>
 </Project>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
@@ -31,7 +31,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="openenclave" version="0.2.0-CI-20190521-020719" />
+      <package id="openenclave" version="0.2.0-CI-20190607-222616" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/packages.config
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="openenclave" version="0.2.0-CI-20190521-020719" targetFramework="native" />
+  <package id="openenclave" version="0.2.0-CI-20190607-222616" targetFramework="native" />
 </packages>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
@@ -35,7 +35,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="openenclave" version="0.2.0-CI-20190521-020719" />
+      <package id="openenclave" version="0.2.0-CI-20190607-222616" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/sub.mk
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/sub.mk
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-OE_SDK_PATH=../../packages/openenclave.0.2.0-CI-20190521-020719
+OE_SDK_PATH=../../packages/openenclave.0.2.0-CI-20190607-222616
 OE_SDK_INC_PATH=$(OE_SDK_PATH)/build/native/include
 OEEDGER8R=$(OE_SDK_PATH)/tools/oeedger8r
 

--- a/new_platforms/vsextension/ProjectWizard/ImportEnclaveCommand.cs
+++ b/new_platforms/vsextension/ProjectWizard/ImportEnclaveCommand.cs
@@ -345,7 +345,7 @@ namespace OpenEnclaveSDK
                     // Add nuget package to project.
                     // See https://stackoverflow.com/questions/41803738/how-to-programmatically-install-a-nuget-package/41895490#41895490
                     // and more particularly https://docs.microsoft.com/en-us/nuget/visual-studio-extensibility/nuget-api-in-visual-studio
-                    var packageVersions = new Dictionary<string, string>() { { "openenclave", "0.2.0-CI-20190521-020719" } };
+                    var packageVersions = new Dictionary<string, string>() { { "openenclave", "0.2.0-CI-20190607-222616" } };
                     var componentModel = (IComponentModel)(await this.ServiceProvider.GetServiceAsync(typeof(SComponentModel)));
                     var packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
                     packageInstaller.InstallPackagesFromVSExtensionRepository(
@@ -408,7 +408,7 @@ namespace OpenEnclaveSDK
                         else
                         {
                             // Add a post-build event to copy the enclave binary to the existing OutDir.
-                            string cmd = "cp $(RemoteRootDir)/" + baseName + "/bin/$(Platform)/$(Configuration)/" + baseName + ".signed $(RemoteOutDir)";
+                            string cmd = "cp $(RemoteRootDir)/" + baseName + "/bin/$(Platform)/$(Configuration)/" + baseName + ".signed $(RemoteOutDir)" + baseName;
                             var clRule = config.Rules.Item("ConfigurationBuildEvents") as IVCRulePropertyStorage;
                             clRule.SetPropertyValue("RemotePostBuildCommand", cmd);
                             clRule.SetPropertyValue("RemotePostBuildMessage", "Copying enclave binary");
@@ -441,7 +441,12 @@ namespace OpenEnclaveSDK
                             if (gdbRule != null)
                             {
                                 // Configure GDB debugger settings.
-                                gdbRule.SetPropertyValue("PreLaunchCommand", "export PYTHONPATH=/opt/openenclave/lib/openenclave/debugger/gdb-sgx-plugin;export LD_PRELOAD=/opt/openenclave/lib/openenclave/debugger/liboe_ptrace.so");
+                                string gdbEnvironmentSettings = "export PYTHONPATH=/opt/openenclave/lib/openenclave/debugger/gdb-sgx-plugin;export LD_PRELOAD=/opt/openenclave/lib/openenclave/debugger/liboe_ptrace.so";
+                                if (name.Contains("Simulation"))
+                                {
+                                    gdbEnvironmentSettings += ";export OE_SIMULATION=1";
+                                }
+                                gdbRule.SetPropertyValue("PreLaunchCommand", gdbEnvironmentSettings);
                                 gdbRule.SetPropertyValue("AdditionalDebuggerCommands", "directory /opt/openenclave/lib/openenclave/debugger/gdb-sgx-plugin;source /opt/openenclave/lib/openenclave/debugger/gdb-sgx-plugin/gdb_sgx_plugin.py;set environment LD_PRELOAD;add-auto-load-safe-path /usr/lib");
                             }
                         }

--- a/new_platforms/vsextension/ProjectWizard/VS Extension.csproj
+++ b/new_platforms/vsextension/ProjectWizard/VS Extension.csproj
@@ -155,7 +155,7 @@
       <ResourceName>Menus.ctmenu</ResourceName>
       <SubType>Designer</SubType>
     </VSCTCompile>
-    <Content Include="Packages\openenclave.0.2.0-CI-20190521-020719.nupkg">
+    <Content Include="Packages\openenclave.0.2.0-CI-20190607-222616.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <None Include="source.extension.vsixmanifest">

--- a/new_platforms/vsextension/ProjectWizard/WizardImplementation.cs
+++ b/new_platforms/vsextension/ProjectWizard/WizardImplementation.cs
@@ -123,7 +123,7 @@ namespace OpenEnclaveSDK
                 // User picked a specific board for which we have binaries in the nuget package.
                 string solutionDirectory;
                 replacementsDictionary.TryGetValue("$solutiondirectory$", out solutionDirectory);
-                oeFolder = Path.Combine(solutionDirectory, "packages\\openenclave.0.2.0-CI-20190521-020719\\lib\\native\\gcc6\\optee\\v3.3.0\\" + board);
+                oeFolder = Path.Combine(solutionDirectory, "packages\\openenclave.0.2.0-CI-20190607-222616\\lib\\native\\gcc6\\optee\\v3.3.0\\" + board);
             }
             else
             {

--- a/new_platforms/vsextension/ProjectWizard/source.extension.vsixmanifest
+++ b/new_platforms/vsextension/ProjectWizard/source.extension.vsixmanifest
@@ -16,7 +16,7 @@
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveWindowsProject.zip" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveLinuxProject.zip" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
-        <Asset Type="openenclave.0.2.0-CI-20190521-020719.nupkg" d:Source="File" Path="Packages\openenclave.0.2.0-CI-20190521-020719.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="openenclave.0.2.0-CI-20190607-222616.nupkg" d:Source="File" Path="Packages\openenclave.0.2.0-CI-20190607-222616.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="ItemTemplates\Built\OEHostItem.zip" />
     </Assets>


### PR DESCRIPTION
Update nuget package
Add OE_SIMULATION=1 for Simulation configs
Fix binary name of enclave in Simulation config
Fixed bug where wrong TargetName was used since it was defined after
being used by RemoteTargetPath
Remove .signed suffix when copying enclave since OE doesn't expect it

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>