### PR TITLE
Handle `count * size`

### DIFF
--- a/tests/oeedger8r/edl/deepcopy.edl
+++ b/tests/oeedger8r/edl/deepcopy.edl
@@ -68,6 +68,14 @@ enclave {
     // should take place.
     public void deepcopy_countsizeparam([in, count=1] CountSizeParamStruct* s);
 
+    // Deep copy of one `CountSizeParamStruct` with an embedded array
+    // should take place, tests with `size * 1`.
+    public void deepcopy_countsizeparam_size([in, count=1] CountSizeParamStruct* s);
+
+    // Deep copy of one `CountSizeParamStruct` with an embedded array
+    // should take place, tests with `count * 1`.
+    public void deepcopy_countsizeparam_count([in, count=1] CountSizeParamStruct* s);
+
     // Deep copy of two `CountParamStruct`s each with an embedded
     // array and different counts should take place.
     public void deepcopy_countparamarray([in, count=2] CountParamStruct* s);

--- a/tests/oeedger8r/enc/testdeepcopy.cpp
+++ b/tests/oeedger8r/enc/testdeepcopy.cpp
@@ -81,6 +81,30 @@ void deepcopy_countsizeparam(CountSizeParamStruct* s)
     OE_TEST(oe_is_within_enclave(s->ptr, s->count * s->size));
 }
 
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of `s->count * s->size` bytes of `data` in enclave memory, not just
+// `s->count` copies.
+void deepcopy_countsizeparam_size(CountSizeParamStruct* s)
+{
+    OE_TEST(s->count == 1);
+    OE_TEST(s->size == (4 * sizeof(uint64_t)));
+    for (size_t i = 0; i < 4; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, (4 * sizeof(uint64_t))));
+}
+
+// Assert that the struct is deep-copied such that `s->ptr` has a copy
+// of `s->count * s->size` bytes of `data` in enclave memory, not just
+// `s->size` bytes.
+void deepcopy_countsizeparam_count(CountSizeParamStruct* s)
+{
+    OE_TEST(s->count == 4);
+    OE_TEST(s->size == sizeof(uint64_t));
+    for (size_t i = 0; i < 4; ++i)
+        OE_TEST(s->ptr[i] == data[i]);
+    OE_TEST(oe_is_within_enclave(s->ptr, (4 * sizeof(uint64_t))));
+}
+
 // Assert that the struct array is deep-copied such that each
 // element's `ptr` has a copy of its `count` elements of `data` in
 // enclave memory.

--- a/tests/oeedger8r/host/testdeepcopy.cpp
+++ b/tests/oeedger8r/host/testdeepcopy.cpp
@@ -61,6 +61,20 @@ void test_deepcopy_edl_ecalls(oe_enclave_t* enclave)
     }
 
     {
+        auto s = init_structs<CountSizeParamStruct>();
+        s[0].count = 1;
+        s[0].size = 4 * sizeof(uint64_t);
+        OE_TEST(deepcopy_countsizeparam_size(enclave, &s[0]) == OE_OK);
+    }
+
+    {
+        auto s = init_structs<CountSizeParamStruct>();
+        s[0].count = 4;
+        s[0].size = sizeof(uint64_t);
+        OE_TEST(deepcopy_countsizeparam_count(enclave, &s[0]) == OE_OK);
+    }
+
+    {
         auto s = init_structs<CountParamStruct>();
         OE_TEST(deepcopy_countparamarray(enclave, s.data()) == OE_OK);
     }


### PR DESCRIPTION
This fixes the deep-copy code to properly handle when both `count` and `size` attributes are specified, plus loosely associated cleanups.