### PR TITLE
Added tls_between_enclaves sample

### DIFF
--- a/samples/tls_between_enclaves/CMakeLists.txt
+++ b/samples/tls_between_enclaves/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+cmake_minimum_required(VERSION 3.11)
+
+project("TLS connection between two enclaves sample" LANGUAGES C CXX)
+
+find_package(OpenEnclave CONFIG REQUIRED)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_subdirectory(server)
+add_subdirectory(client)
+
+# generate key-pair for both client and server
+#add_custom_command(OUTPUT client_private.pem client_public.pem server_private.pem server_public.pem
+#  COMMAND openssl genrsa -out ${CMAKE_BINARY_DIR}/client/enc/client_private.pem -3 3072
+#  COMMAND openssl rsa -in ${CMAKE_BINARY_DIR}/client/enc/client_private.pem -pubout -out ${CMAKE_BINARY_DIR}/client/enc/client_public.pem
+#  COMMAND openssl genrsa -out ${CMAKE_BINARY_DIR}/server/enc/server_private.pem -3 3072
+#  COMMAND openssl rsa -in ${CMAKE_BINARY_DIR}/server/enc/server_private.pem -pubout -out ${CMAKE_BINARY_DIR}/server/enc/server_public.pem)
+
+# Generate public key header files
+#add_custom_command(OUTPUT tls_client_enc_pubkey.h tls_server_enc_pubkey.h
+#  DEPENDS ${CMAKE_SOURCE_DIR}/scripts/gen_pubkey_header.sh
+#  COMMAND ${CMAKE_SOURCE_DIR}/scripts/gen_pubkey_header.sh ${CMAKE_SOURCE_DIR}/common/tls_client_enc_pubkey.h ${CMAKE_BINARY_DIR}/client/enc/client_public.pem
+#  COMMAND ${CMAKE_SOURCE_DIR}/scripts/gen_pubkey_header.sh ${CMAKE_SOURCE_DIR}/common/tls_server_enc_pubkey.h ${CMAKE_BINARY_DIR}/server/enc/server_public.pem)
+
+#add_custom_target(build_common DEPENDS client_private.pem  tls_client_enc_pubkey.h)
+
+if ((NOT DEFINED ENV{OE_SIMULATION}) OR (NOT $ENV{OE_SIMULATION}))
+  add_custom_target(run
+    DEPENDS tls_server tls_client
+    COMMAND ${CMAKE_BINARY_DIR}/server/host/tls_server_host ${CMAKE_BINARY_DIR}/server/enc/tls_server_enc.signed -port:12341 &
+    COMMAND sleep 2
+    COMMAND ${CMAKE_BINARY_DIR}/client/host/tls_client_host ${CMAKE_BINARY_DIR}/client/enc/tls_client_enc.signed -server:localhost -port:12341)
+endif ()

--- a/samples/tls_between_enclaves/Makefile
+++ b/samples/tls_between_enclaves/Makefile
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+.PHONY: all build clean run
+
+all: build
+
+build:
+	$(MAKE) -C server
+	$(MAKE) -C client
+clean:
+	$(MAKE) -C server clean
+	$(MAKE) -C client clean
+
+run:
+	./server/host/tls_server_host ./server/enc/tls_server_enc.signed -port:12341 &
+	sleep 2
+	./client/host/tls_client_host ./client/enc/tls_client_enclave.signed -server:localhost -port:12341

--- a/samples/tls_between_enclaves/client/CMakeLists.txt
+++ b/samples/tls_between_enclaves/client/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+cmake_minimum_required(VERSION 3.11)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_subdirectory(enc)
+add_subdirectory(host)
+
+add_custom_target(tls_client DEPENDS tls_client_host tls_client_enc tls_client_sign_enc)

--- a/samples/tls_between_enclaves/client/Makefile
+++ b/samples/tls_between_enclaves/client/Makefile
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+all: build
+
+#genkey:
+#	$(MAKE) -C enc genkey
+
+build:
+	$(MAKE) -C enc
+	$(MAKE) -C host
+
+clean:
+	$(MAKE) -C enc clean
+	$(MAKE) -C host clean
+
+run:
+	host/tls_client_host ./enc/tls_client_enclave.signed -server:localhost -port:12341

--- a/samples/tls_between_enclaves/client/enc/CMakeLists.txt
+++ b/samples/tls_between_enclaves/client/enc/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Use the edger8r to generate C bindings from the EDL file.
+add_custom_command(OUTPUT tls_client_t.h tls_client_t.c tls_client_args.h
+  DEPENDS ${CMAKE_SOURCE_DIR}/client/tls_client.edl
+  COMMAND openenclave::oeedger8r --trusted ${CMAKE_SOURCE_DIR}/client/tls_client.edl)
+
+# Sign enclave
+add_custom_command(OUTPUT tls_client_enc.signed
+  DEPENDS tls_client_enc enc.conf
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:tls_client_enc> -c ${CMAKE_SOURCE_DIR}/client/enc/enc.conf -k ${CMAKE_SOURCE_DIR}/client/enc/client_signing_private.pem)
+
+add_executable(tls_client_enc ecalls.cpp crypto.cpp client.cpp identity_verifier.cpp cert_verifier.cpp ../../common/utility.cpp ${CMAKE_CURRENT_BINARY_DIR}/tls_client_t.c)
+target_compile_definitions(tls_client_enc PUBLIC OE_API_VERSION=2)
+
+target_include_directories(tls_client_enc PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR} # Needed for #include "../shared.h"
+  ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(tls_client_enc
+		openenclave::oeenclave
+		openenclave::oelibcxx
+                openenclave::mbedtls
+		openenclave::mbedcrypto
+		openenclave::oehostsock
+		openenclave::oehostresolver
+                openenclave::oecore
+	        openenclave::oelibc
+	        openenclave::oeposix)
+
+add_custom_target(tls_client_sign_enc ALL DEPENDS tls_client_enc.signed)

--- a/samples/tls_between_enclaves/client/enc/Makefile
+++ b/samples/tls_between_enclaves/client/enc/Makefile
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Detect C and C++ compiler options
+# if not gcc and g++, default to clang-7
+C_COMPILER=$(notdir $(CC))
+ifeq ($(C_COMPILER), gcc)
+        CXX_COMPILER=$(notdir $(CXX))
+        USE_GCC = true
+endif
+
+ifeq ($(USE_GCC),)
+        CC = clang-7
+        CXX = clang++-7
+        C_COMPILER=clang
+        CXX_COMPILER=clang++
+endif
+
+CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
+CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)
+LDFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --libs)
+
+all:
+#	$(MAKE) genkey
+#	$(MAKE) -C ../../server/enc genkey
+	$(MAKE) build
+	$(MAKE) sign
+
+#private.pem:
+#	openssl genrsa -out $@ -3 3072
+
+#public.pem: private.pem
+#	openssl rsa -in $< -out $@ -pubout
+
+# The enclaves in the sample will check if the other enclave is signed
+# with the expected key. Since this sample builds both enclaves, we can
+# inject the expected public keys at build time.
+#
+# If the other public key isn't known, then we would have to load the
+# public key from the host. We can't simply load the raw public key since
+# a malicious host might change it. So, we would need to load a certicate
+# that contains the expected public key that is signed by a trusted CA.
+#genkey: public.pem
+#	chmod u+x ../../scripts/gen_pubkey_header.sh
+#	../../scripts/gen_pubkey_header.sh ../../common/tls_client_enc_pubkey.h $<
+
+build:
+	@ echo "Compilers used: $(CC), $(CXX)"
+	oeedger8r ../tls_client.edl --trusted --trusted-dir .
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp client.cpp identity_verifier.cpp ../../common/utility.cpp crypto.cpp cert_verifier.cpp
+	$(CC) -c $(CFLAGS) $(CINCLUDES) ./tls_client_t.c
+	$(CXX) -o tls_client_enclave ecalls.o crypto.o client.o identity_verifier.o tls_client_t.o utility.o cert_verifier.o $(LDFLAGS) -lmbedtls -lmbedcrypto -loehostsock -loehostresolver -loecore -loelibc -loeposix
+
+sign:
+	oesign sign -e tls_client_enclave -c  enc.conf -k client_signing_private.pem
+
+clean:
+	rm -f ./*.o tls_client_enclave tls_client_enclave.signed enclave1.signed.so tls_client_t.* tls_client_args.h

--- a/samples/tls_between_enclaves/client/enc/cert_verifier.cpp
+++ b/samples/tls_between_enclaves/client/enc/cert_verifier.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <errno.h>
+#include <mbedtls/certs.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/debug.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/error.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/platform.h>
+#include <mbedtls/ssl.h>
+#include <openenclave/enclave.h>
+#include <string.h>
+#include "../../common/tls_client_tls_cert_private_key.h"
+#include "../../common/tls_client_tls_cert_public_key.h"
+#include "../../common/tls_server_tls_cert_public_key.h"
+#include "../../common/utility.h"
+
+oe_result_t enclave_identity_verifier_callback(
+    oe_identity_t* identity,
+    void* arg);
+
+oe_result_t get_tls_cert_keys(
+    uint8_t** public_key,
+    size_t* public_key_size,
+    uint8_t** private_key,
+    size_t* private_key_size)
+{
+    *public_key = (uint8_t*)CLIENT_ENCLAVE_TLS_CERT_PUBLIC_KEY;
+    *public_key_size = strlen(CLIENT_ENCLAVE_TLS_CERT_PUBLIC_KEY) + 1;
+    *private_key = (uint8_t*)CLIENT_ENCLAVE_TLS_CERT_PRIVATE_KEY;
+    *private_key_size = strlen(CLIENT_ENCLAVE_TLS_CERT_PRIVATE_KEY) + 1;
+
+    return OE_OK;
+}
+
+// If set, the verify callback is called for each certificate in the chain.
+// The verification callback is supposed to return 0 on success. Otherwise, the
+// verification failed.
+int cert_verify_callback(
+    void* data,
+    mbedtls_x509_crt* crt,
+    int depth,
+    uint32_t* flags)
+{
+    oe_result_t result = OE_FAILURE;
+    int ret = 1;
+    unsigned char* cert_buf = NULL;
+    size_t cert_size = 0;
+
+    (void)data;
+
+    printf(" cert_verify_callback with depth = %d\n", depth);
+
+    cert_buf = crt->raw.p;
+    cert_size = crt->raw.len;
+
+    printf("crt->version = %d cert_size = %zu\n", crt->version, cert_size);
+    if (cert_size <= 0)
+        goto exit;
+
+    // The following two checked
+    if (!is_certificate_public_key_trusted(
+            crt,
+            (char*)SERVER_ENCLAVE_TLS_CERT_PUBLIC_KEY,
+            strlen(SERVER_ENCLAVE_TLS_CERT_PUBLIC_KEY)))
+    {
+        printf("Unexpected certificate received\n");
+        printf("Expected: [%s]\n", (char*)SERVER_ENCLAVE_TLS_CERT_PUBLIC_KEY);
+        goto exit;
+    }
+
+    result = oe_verify_attestation_certificate(
+        cert_buf, cert_size, enclave_identity_verifier_callback, NULL);
+    if (result != OE_OK)
+    {
+        printf(
+            "oe_verify_attestation_certificate failed with result = %s\n",
+            oe_result_str(result));
+        goto exit;
+    }
+    ret = 0;
+    *flags = 0;
+exit:
+    return ret;
+}

--- a/samples/tls_between_enclaves/client/enc/client.cpp
+++ b/samples/tls_between_enclaves/client/enc/client.cpp
@@ -1,0 +1,322 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <errno.h>
+#include <mbedtls/certs.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/debug.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/error.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/platform.h>
+#include <mbedtls/ssl.h>
+#include <openenclave/enclave.h>
+#include <string.h>
+#include "../../common/utility.h"
+
+#define DEBUG_LEVEL 1
+#define MAX_ERROR_BUFF_SIZE 256
+char error_buf[MAX_ERROR_BUFF_SIZE];
+unsigned char buf[1024];
+extern "C"
+{
+    int setup_tls_client_and_run(char* server_name, char* server_port);
+};
+
+static void your_debug(
+    void* ctx,
+    int level,
+    const char* file,
+    int line,
+    const char* str)
+{
+    ((void)level);
+
+    mbedtls_fprintf((FILE*)ctx, "%s:%04d: %s", file, line, str);
+    fflush((FILE*)ctx);
+}
+
+int configure_client_ssl(
+    mbedtls_ssl_context* ssl,
+    mbedtls_ssl_config* conf,
+    mbedtls_ctr_drbg_context* ctr_drbg,
+    mbedtls_x509_crt* client_cert,
+    mbedtls_pk_context* private_key)
+{
+    int ret = 1;
+    oe_result_t result = OE_FAILURE;
+
+    printf("Generating the certificate\n");
+    result = generate_tls_certificate(client_cert, private_key);
+    if (result != OE_OK)
+    {
+        printf("failed with %s\n", oe_result_str(result));
+        ret = 1;
+        goto exit;
+    }
+
+    printf("Setting up the SSL/TLS structure...\n");
+
+    if ((ret = mbedtls_ssl_config_defaults(
+             conf,
+             MBEDTLS_SSL_IS_CLIENT,
+             MBEDTLS_SSL_TRANSPORT_STREAM,
+             MBEDTLS_SSL_PRESET_DEFAULT)) != 0)
+    {
+        printf("failed! mbedtls_ssl_config_defaults returned %d\n", ret);
+        goto exit;
+    }
+
+    printf("mbedtls_ssl_config_defaults returned successfully\n");
+
+    // set up random engine
+    mbedtls_ssl_conf_rng(conf, mbedtls_ctr_drbg_random, ctr_drbg);
+    mbedtls_ssl_conf_dbg(conf, your_debug, stdout);
+
+    // Set the certificate verification mode to MBEDTLS_SSL_VERIFY_OPTIONAL
+    mbedtls_ssl_conf_authmode(conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+    mbedtls_ssl_conf_verify(conf, cert_verify_callback, NULL);
+
+    if ((ret = mbedtls_ssl_conf_own_cert(conf, client_cert, private_key)) != 0)
+    {
+        printf("failed\n  ! mbedtls_ssl_conf_own_cert returned %d\n", ret);
+        goto exit;
+    }
+
+    if ((ret = mbedtls_ssl_setup(ssl, conf)) != 0)
+    {
+        printf("failed! mbedtls_ssl_setup returned %d\n", ret);
+        goto exit;
+    }
+
+    ret = 0;
+
+exit:
+    fflush(stdout);
+    return ret;
+}
+
+int handle_communication_until_done(mbedtls_ssl_context* ssl)
+{
+    int len = 0;
+    int ret = 0;
+    int exit_code = MBEDTLS_EXIT_FAILURE;
+
+    // Write client payload to the server
+    printf("Write to server-->:");
+    len = sprintf((char*)buf, PAYLOAD_FROM_CLIENT);
+    while ((ret = mbedtls_ssl_write(ssl, buf, len)) <= 0)
+    {
+        if (ret != MBEDTLS_ERR_SSL_WANT_READ &&
+            ret != MBEDTLS_ERR_SSL_WANT_WRITE)
+        {
+            printf("Failed! mbedtls_ssl_write returned %d\n", ret);
+            goto done;
+        }
+    }
+
+    len = ret;
+    printf("%d bytes written:\n[%s]\n", len, (char*)buf);
+
+    printf("Read the response from server:\n");
+    printf("<-- Read from server:\n");
+    do
+    {
+        len = sizeof(buf) - 1;
+        memset(buf, 0, sizeof(buf));
+        ret = mbedtls_ssl_read(ssl, buf, len);
+        if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
+            ret == MBEDTLS_ERR_SSL_WANT_WRITE)
+            continue;
+
+        if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
+            break;
+
+        if (ret < 0)
+        {
+            printf("Failed! mbedtls_ssl_read returned %d\n\n", ret);
+            break;
+        }
+
+        if (ret == 0)
+        {
+            printf("\n\nEOF\n\n");
+            break;
+        }
+        len = ret;
+        printf(" %d bytes received from server:\n[%s]\n", len, (char*)buf);
+        if ((len != SERVER_PAYLOAD_SIZE) ||
+            (memcmp(PAYLOAD_FROM_SERVER, buf, len) != 0))
+        {
+            printf(
+                "ERROR: expected reading %d bytes but only got %d bytes\n",
+                (int)SERVER_PAYLOAD_SIZE,
+                len);
+            exit_code = MBEDTLS_EXIT_FAILURE;
+            goto done;
+        }
+        else
+        {
+            printf("Client done reading server data\n");
+            break;
+        }
+        printf("Verified: the contents of server payload were expected\n\n");
+    } while (1);
+
+    ret = 0;
+done:
+    return ret;
+}
+
+int setup_tls_client_and_run(char* server_name, char* server_port)
+{
+    int ret = 1;
+    uint32_t flags;
+    const char* pers = "ssl_client";
+    oe_result_t result = OE_FAILURE;
+    int exit_code = MBEDTLS_EXIT_FAILURE;
+
+    mbedtls_net_context server_fd;
+    mbedtls_entropy_context entropy;
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_config conf;
+    mbedtls_x509_crt client_cert;
+    mbedtls_pk_context pkey;
+
+    // Explicitly enabling host resolver and socket features
+    if ((result = oe_load_module_host_resolver()) != OE_OK)
+    {
+        printf(
+            "oe_load_module_host_resolver failed with %s\n",
+            oe_result_str(result));
+        goto exit;
+    }
+    if ((result = oe_load_module_host_socket_interface()) != OE_OK)
+    {
+        printf(
+            "oe_load_module_host_socket_interface failed with %s\n",
+            oe_result_str(result));
+        goto exit;
+    }
+
+    // Initialize mbedtls objects
+    mbedtls_debug_set_threshold(DEBUG_LEVEL);
+    mbedtls_net_init(&server_fd);
+    mbedtls_ssl_init(&ssl);
+    mbedtls_ssl_config_init(&conf);
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    mbedtls_x509_crt_init(&client_cert);
+    mbedtls_pk_init(&pkey);
+
+    printf("\nSeeding the random number generator...\n");
+    mbedtls_entropy_init(&entropy);
+    if ((ret = mbedtls_ctr_drbg_seed(
+             &ctr_drbg,
+             mbedtls_entropy_func,
+             &entropy,
+             (const unsigned char*)pers,
+             strlen(pers))) != 0)
+    {
+        printf("Failed\n  ! mbedtls_ctr_drbg_seed returned %d\n", ret);
+        goto exit;
+    }
+
+    printf("mbedtls_ctr_drbg_seed done\n");
+
+    //
+    // Start the connection
+    //
+    printf("Connecting to tcp: %s/%s...\n", server_name, server_port);
+
+    if ((ret = mbedtls_net_connect(
+             &server_fd, server_name, server_port, MBEDTLS_NET_PROTO_TCP)) != 0)
+    {
+        printf(
+            "Failed\n  ! mbedtls_net_connect returned %d errno=%d\n",
+            ret,
+            errno);
+        exit_code = ret;
+        goto exit;
+    }
+
+    printf("Connected to server @%s.%s\n", server_name, server_port);
+
+    //
+    // Configure client SSL settings
+    //
+    ret = configure_client_ssl(&ssl, &conf, &ctr_drbg, &client_cert, &pkey);
+    if (ret != 0)
+    {
+        printf("Failed! mbedtls_net_connect returned %d\n", ret);
+        goto exit;
+    }
+
+    if ((ret = mbedtls_ssl_set_hostname(&ssl, server_name)) != 0)
+    {
+        printf("Failed! mbedtls_ssl_set_hostname returned %d\n", ret);
+        goto exit;
+    }
+
+    mbedtls_ssl_set_bio(
+        &ssl, &server_fd, mbedtls_net_send, mbedtls_net_recv, NULL);
+
+    //
+    // Handshake
+    //
+    printf("Performing the SSL/TLS handshake...\n");
+    while ((ret = mbedtls_ssl_handshake(&ssl)) != 0)
+    {
+        if (ret != MBEDTLS_ERR_SSL_WANT_READ &&
+            ret != MBEDTLS_ERR_SSL_WANT_WRITE)
+        {
+            printf(
+                "Failed\n  ! mbedtls_ssl_handshake returned -0x%x\n\n", -ret);
+            goto exit;
+        }
+    }
+
+    printf("mbedtls_ssl_handshake ok\n");
+
+    //
+    // Start simple communication with the TLS server
+    //
+
+    ret = handle_communication_until_done(&ssl);
+    if (ret != 0)
+    {
+        printf("client communication error %d\n", ret);
+        goto exit;
+    }
+
+    mbedtls_ssl_close_notify(&ssl);
+    exit_code = MBEDTLS_EXIT_SUCCESS;
+exit:
+    if (exit_code != MBEDTLS_EXIT_SUCCESS)
+    {
+        mbedtls_strerror(ret, error_buf, MAX_ERROR_BUFF_SIZE);
+        printf("Last error was: %d - %s\n", ret, error_buf);
+    }
+
+    mbedtls_net_free(&server_fd);
+
+    // free mbedtls objects
+    mbedtls_x509_crt_free(&client_cert);
+    mbedtls_pk_free(&pkey);
+    mbedtls_ssl_free(&ssl);
+    mbedtls_ssl_config_free(&conf);
+    mbedtls_ctr_drbg_free(&ctr_drbg);
+    mbedtls_entropy_free(&entropy);
+
+    if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
+        ret = 0;
+
+    fflush(stdout);
+    return (exit_code);
+}

--- a/samples/tls_between_enclaves/client/enc/crypto.cpp
+++ b/samples/tls_between_enclaves/client/enc/crypto.cpp
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "crypto.h"
+#include <mbedtls/pk.h>
+#include <mbedtls/rsa.h>
+#include <openenclave/enclave.h>
+#include <stdlib.h>
+#include <string.h>
+
+Crypto::Crypto()
+{
+    m_initialized = init_mbedtls();
+}
+
+Crypto::~Crypto()
+{
+    cleanup_mbedtls();
+}
+
+/**
+ * init_mbedtls initializes the crypto module.
+ * mbedtls initialization. Please refer to mbedtls documentation for detailed
+ * information about the functions used.
+ */
+bool Crypto::init_mbedtls(void)
+{
+    bool ret = false;
+    int res = -1;
+
+    mbedtls_ctr_drbg_init(&m_ctr_drbg_contex);
+    mbedtls_entropy_init(&m_entropy_context);
+    mbedtls_pk_init(&m_pk_context);
+
+    // Initialize entropy.
+    res = mbedtls_ctr_drbg_seed(
+        &m_ctr_drbg_contex, mbedtls_entropy_func, &m_entropy_context, NULL, 0);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_ctr_drbg_seed failed.");
+        goto exit;
+    }
+
+    // Initialize RSA context.
+    res = mbedtls_pk_setup(
+        &m_pk_context, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA));
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_setup failed (%d).", res);
+        goto exit;
+    }
+
+    // Generate an ephemeral 2048-bit RSA key pair with
+    // exponent 65537 for the enclave.
+    res = mbedtls_rsa_gen_key(
+        mbedtls_pk_rsa(m_pk_context),
+        mbedtls_ctr_drbg_random,
+        &m_ctr_drbg_contex,
+        2048,
+        65537);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_rsa_gen_key failed (%d)\n", res);
+        goto exit;
+    }
+
+    // Write out the public key in PEM format for exchange with other enclaves.
+    res = mbedtls_pk_write_pubkey_pem(
+        &m_pk_context, m_public_key, sizeof(m_public_key));
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_write_pubkey_pem failed (%d)\n", res);
+        goto exit;
+    }
+    ret = true;
+    TRACE_ENCLAVE("mbedtls initialized.");
+exit:
+    return ret;
+}
+
+/**
+ * mbedtls cleanup during shutdown.
+ */
+void Crypto::cleanup_mbedtls(void)
+{
+    mbedtls_pk_free(&m_pk_context);
+    mbedtls_entropy_free(&m_entropy_context);
+    mbedtls_ctr_drbg_free(&m_ctr_drbg_contex);
+
+    TRACE_ENCLAVE("mbedtls cleaned up.");
+}
+
+/**
+ * Get the public key for this enclave.
+ */
+void Crypto::retrieve_public_key(uint8_t pem_public_key[512])
+{
+    memcpy(pem_public_key, m_public_key, sizeof(m_public_key));
+}
+
+// Compute the sha256 hash of given data.
+int Crypto::Sha256(const uint8_t* data, size_t data_size, uint8_t sha256[32])
+{
+    int ret = 0;
+    mbedtls_sha256_context ctx;
+
+    mbedtls_sha256_init(&ctx);
+
+    ret = mbedtls_sha256_starts_ret(&ctx, 0);
+    if (ret)
+        goto exit;
+
+    ret = mbedtls_sha256_update_ret(&ctx, data, data_size);
+    if (ret)
+        goto exit;
+
+    ret = mbedtls_sha256_finish_ret(&ctx, sha256);
+    if (ret)
+        goto exit;
+
+exit:
+    mbedtls_sha256_free(&ctx);
+    return ret;
+}
+
+/**
+ * Encrypt encrypts the given data using the given public key.
+ * Used to encrypt data using the public key of another enclave.
+ */
+bool Crypto::Encrypt(
+    const uint8_t* pem_public_key,
+    const uint8_t* data,
+    size_t data_size,
+    uint8_t* encrypted_data,
+    size_t* encrypted_data_size)
+{
+    bool result = false;
+    mbedtls_pk_context key;
+    size_t key_size = 0;
+    int res = -1;
+    mbedtls_rsa_context* rsa_context;
+
+    mbedtls_pk_init(&key);
+
+    if (!m_initialized)
+        goto exit;
+
+    // Read the given public key.
+    key_size = strlen((const char*)pem_public_key) + 1; // Include ending '\0'.
+    res = mbedtls_pk_parse_public_key(&key, pem_public_key, key_size);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_parse_public_key failed.");
+        goto exit;
+    }
+
+    rsa_context = mbedtls_pk_rsa(key);
+    rsa_context->padding = MBEDTLS_RSA_PKCS_V21;
+    rsa_context->hash_id = MBEDTLS_MD_SHA256;
+
+    if (rsa_context->padding == MBEDTLS_RSA_PKCS_V21)
+    {
+        TRACE_ENCLAVE("Padding used: MBEDTLS_RSA_PKCS_V21 for OAEP or PSS");
+    }
+
+    if (rsa_context->padding == MBEDTLS_RSA_PKCS_V15)
+    {
+        TRACE_ENCLAVE("New MBEDTLS_RSA_PKCS_V15  for 1.5 padding");
+    }
+
+    // Encrypt the data.
+    res = mbedtls_rsa_pkcs1_encrypt(
+        rsa_context,
+        mbedtls_ctr_drbg_random,
+        &m_ctr_drbg_contex,
+        MBEDTLS_RSA_PUBLIC,
+        data_size,
+        data,
+        encrypted_data);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_rsa_pkcs1_encrypt failed with %d\n", res);
+        goto exit;
+    }
+
+    *encrypted_data_size = mbedtls_pk_rsa(key)->len;
+    result = true;
+exit:
+    mbedtls_pk_free(&key);
+    return result;
+}
+
+/**
+ * decrypt the given data using current enclave's private key.
+ * Used to receive encrypted data from another enclave.
+ */
+bool Crypto::decrypt(
+    const uint8_t* encrypted_data,
+    size_t encrypted_data_size,
+    uint8_t* data,
+    size_t* data_size)
+{
+    bool ret = false;
+    size_t output_size = 0;
+    int res = 0;
+    mbedtls_rsa_context* rsa_context;
+
+    if (!m_initialized)
+        goto exit;
+
+    mbedtls_pk_rsa(m_pk_context)->len = encrypted_data_size;
+    rsa_context = mbedtls_pk_rsa(m_pk_context);
+    rsa_context->padding = MBEDTLS_RSA_PKCS_V21;
+    rsa_context->hash_id = MBEDTLS_MD_SHA256;
+
+    output_size = *data_size;
+    res = mbedtls_rsa_pkcs1_decrypt(
+        rsa_context,
+        mbedtls_ctr_drbg_random,
+        &m_ctr_drbg_contex,
+        MBEDTLS_RSA_PRIVATE,
+        &output_size,
+        encrypted_data,
+        data,
+        output_size);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_rsa_pkcs1_decrypt failed with %d\n", res);
+        goto exit;
+    }
+    *data_size = output_size;
+    ret = true;
+
+exit:
+    return ret;
+}
+
+bool Crypto::get_rsa_modulus_from_pem(
+    const char* pem_data,
+    size_t pem_size,
+    uint8_t** modulus,
+    size_t* modulus_size)
+{
+    mbedtls_pk_context ctx;
+    mbedtls_pk_type_t pk_type;
+    mbedtls_rsa_context* rsa_ctx = NULL;
+    uint8_t* modulus_local = NULL;
+    size_t modulus_local_size = 0;
+    int res = 0;
+    bool ret = false;
+
+    if (!m_initialized || !modulus || !modulus_size)
+        goto exit_preinit;
+
+    mbedtls_pk_init(&ctx);
+    res = mbedtls_pk_parse_public_key(
+        &ctx, (const unsigned char*)pem_data, pem_size);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_parse_public_key failed with %d\n", res);
+        goto exit;
+    }
+
+    pk_type = mbedtls_pk_get_type(&ctx);
+    if (pk_type != MBEDTLS_PK_RSA)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_get_type had incorrect type: %d\n", res);
+        goto exit;
+    }
+
+    rsa_ctx = mbedtls_pk_rsa(ctx);
+    modulus_local_size = mbedtls_rsa_get_len(rsa_ctx);
+    modulus_local = (uint8_t*)malloc(modulus_local_size);
+    if (modulus_local == NULL)
+    {
+        TRACE_ENCLAVE(
+            "malloc for modulus failed with size %zu:\n", modulus_local_size);
+        goto exit;
+    }
+
+    res = mbedtls_rsa_export_raw(
+        rsa_ctx,
+        modulus_local,
+        modulus_local_size,
+        NULL,
+        0,
+        NULL,
+        0,
+        NULL,
+        0,
+        NULL,
+        0);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_rsa_export failed with %d\n", res);
+        goto exit;
+    }
+
+    *modulus = modulus_local;
+    *modulus_size = modulus_local_size;
+    modulus_local = NULL;
+    ret = true;
+
+exit:
+    if (modulus_local != NULL)
+        free(modulus_local);
+
+    mbedtls_pk_free(&ctx);
+
+exit_preinit:
+    return ret;
+}

--- a/samples/tls_between_enclaves/client/enc/crypto.h
+++ b/samples/tls_between_enclaves/client/enc/crypto.h
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef OE_SAMPLES_ATTESTATION_ENC_CRYPTO_H
+#define OE_SAMPLES_ATTESTATION_ENC_CRYPTO_H
+
+#include <openenclave/enclave.h>
+// Includes for mbedtls shipped with oe.
+// Also add the following libraries to your linker command line:
+// -loeenclave -lmbedcrypto -lmbedtls -lmbedx509
+#include <mbedtls/config.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/rsa.h>
+#include <mbedtls/sha256.h>
+#include "log.h"
+
+#define PUBLIC_KEY_SIZE 512
+
+class Crypto
+{
+  private:
+    mbedtls_ctr_drbg_context m_ctr_drbg_contex;
+    mbedtls_entropy_context m_entropy_context;
+    mbedtls_pk_context m_pk_context;
+    uint8_t m_public_key[512];
+    bool m_initialized;
+
+    // Public key of another enclave.
+    uint8_t m_other_enclave_pubkey[PUBLIC_KEY_SIZE];
+
+  public:
+    Crypto();
+    ~Crypto();
+
+    /**
+     * Get this enclave's own public key
+     */
+    void retrieve_public_key(uint8_t pem_public_key[512]);
+
+    /**
+     * Encrypt encrypts the given data using the given public key.
+     * Used to encrypt data using the public key of another enclave.
+     */
+    bool Encrypt(
+        const uint8_t* pem_public_key,
+        const uint8_t* data,
+        size_t size,
+        uint8_t* encrypted_data,
+        size_t* encrypted_data_size);
+
+    /**
+     * decrypt decrypts the given data using current enclave's private key.
+     * Used to receive encrypted data from another enclave.
+     */
+    bool decrypt(
+        const uint8_t* encrypted_data,
+        size_t encrypted_data_size,
+        uint8_t* data,
+        size_t* data_size);
+
+    /**
+     * get_rsa_modulus_from_pem returns the RSA modulus in big endian format
+     * from the public key PEM data. This is needed to verify the MRSIGNER
+     * of the other enclave, which ensures that the other enclave has been
+     * signed by the right key. MRSIGNER is the SHA256 hash of the modulus
+     * in little endian.
+     */
+    bool get_rsa_modulus_from_pem(
+        const char* pem_data,
+        size_t pem_size,
+        uint8_t** modulus,
+        size_t* modulus_size);
+
+    // Public key of another enclave.
+    uint8_t* get_the_other_enclave_public_key()
+    {
+        return m_other_enclave_pubkey;
+    }
+
+    /**
+     * Compute the sha256 hash of given data.
+     */
+    int Sha256(const uint8_t* data, size_t data_size, uint8_t sha256[32]);
+
+  private:
+    /**
+     * Crypto demonstrates use of mbedtls within the enclave to generate keys
+     * and perform encryption. In this sample, each enclave instance generates
+     * an ephemeral 2048-bit RSA key pair and shares the public key with the
+     * other instance. The other enclave instance then replies with data
+     * encrypted to the provided public key.
+     */
+
+    /** init_mbedtls initializes the crypto module.
+     */
+    bool init_mbedtls(void);
+
+    void cleanup_mbedtls(void);
+};
+
+#endif // OE_SAMPLES_ATTESTATION_ENC_CRYPTO_H

--- a/samples/tls_between_enclaves/client/enc/ecalls.cpp
+++ b/samples/tls_between_enclaves/client/enc/ecalls.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <string.h>
+#include "../../common/tls_client_enc_signing_pubkey.h"
+#include "tls_client_t.h"
+
+#define ENCLAVE_SECRET_DATA_SIZE 16
+
+typedef struct _enclave_config_data
+{
+    uint8_t* enclave_secret_data;
+    const char* other_enclave_pubkey_pem;
+    size_t other_enclave_pubkey_pem_size;
+} enclave_config_data_t;
+
+// For this purpose of this example: demonstrating how to do remote attestation
+// g_enclave_secret_data is hardcoded as part of the enclave. In this sample,
+// the secret data is hard coded as part of the enclave binary. In a real world
+// enclave implementation, secrets are never hard coded in the enclave binary
+// since the enclave binary itself is not encrypted. Instead, secrets are
+// acquired via provisioning from a service (such as a cloud server) after
+// successful attestation.
+// This g_enclave_secret_data holds the secret data specific to the holding
+// enclave, it's only visible inside this secured enclave. Arbitrary enclave
+// specific secret data exchanged by the enclaves. In this sample, the first
+// enclave sends its g_enclave_secret_data (encrypted) to the second enclave.
+// The second enclave decrypts the received data and adds it to its own
+// g_enclave_secret_data, and sends it back to the other enclave.
+uint8_t g_enclave_secret_data[ENCLAVE_SECRET_DATA_SIZE] =
+    {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
+enclave_config_data_t config_data = {g_enclave_secret_data,
+                                     OTHER_ENCLAVE_SIGNING_PUBLIC_KEY,
+                                     sizeof(OTHER_ENCLAVE_SIGNING_PUBLIC_KEY)};
+int ecall_launch_tls_client(char* server_name, char* server_port)
+{
+    return setup_tls_client_and_run(server_name, server_port);
+}

--- a/samples/tls_between_enclaves/client/enc/enc.conf
+++ b/samples/tls_between_enclaves/client/enc/enc.conf
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Enclave settings:
+Debug=1
+NumHeapPages=1024
+NumStackPages=1024
+NumTCS=2
+ProductID=1
+SecurityVersion=1

--- a/samples/tls_between_enclaves/client/enc/identity_verifier.cpp
+++ b/samples/tls_between_enclaves/client/enc/identity_verifier.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <stdlib.h>
+#include <string>
+
+#include "../../common/tls_server_enc_signing_pubkey.h"
+#include "../../common/utility.h"
+
+oe_result_t enclave_identity_verifier_callback(
+    oe_identity_t* identity,
+    void* arg)
+{
+    oe_result_t result = OE_VERIFY_FAILED;
+    bool bret = false;
+
+    printf("Client:enclave_identity_verifier_callback is called with enclave "
+           "identity information:\n");
+
+    // enclave's security version
+    printf("identity->security_version = %d\n", identity->security_version);
+
+    // the unique ID for the enclave, for SGX enclaves, this is the MRENCLAVE
+    // value
+    printf("identity->unique_id(MRENCLAVE) :\n");
+    for (int i = 0; i < OE_UNIQUE_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->unique_id[i]);
+
+    // The signer ID for the enclave, for SGX enclaves, this is the MRSIGNER
+    // value
+    printf("\nidentity->signer_id(MRSIGNER) :\n");
+    for (int i = 0; i < OE_SIGNER_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->signer_id[i]);
+
+    if (!verify_mrsigner(
+            (char*)OTHER_ENCLAVE_SIGNING_PUBLIC_KEY,
+            sizeof(OTHER_ENCLAVE_SIGNING_PUBLIC_KEY),
+            identity->signer_id,
+            sizeof(identity->signer_id)))
+    {
+        printf("failed:mrsigner not equal!\n");
+        goto exit;
+    }
+    printf("mrsigner id validation passed.\n");
+
+    // The Product ID for the enclave, for SGX enclaves, this is the ISVPRODID
+    // value
+    printf("\nidentity->product_id :\n");
+    for (int i = 0; i < OE_PRODUCT_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->product_id[i]);
+
+    result = OE_OK;
+exit:
+    return result;
+}

--- a/samples/tls_between_enclaves/client/enc/log.h
+++ b/samples/tls_between_enclaves/client/enc/log.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef OE_SAMPLES_ATTESTATION_ENC_LOG_H
+#define OE_SAMPLES_ATTESTATION_ENC_LOG_H
+
+#include <stdio.h>
+
+#define TRACE_ENCLAVE(fmt, ...) \
+                                \
+    printf("Enclave: ***%s(%d): " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#endif // OE_SAMPLES_ATTESTATION_ENC_LOG_H

--- a/samples/tls_between_enclaves/client/enc/verifier_client.cpp
+++ b/samples/tls_between_enclaves/client/enc/verifier_client.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <stdlib.h>
+#include <string>
+
+#include "../../common/tls_server_enc_pubkey.h"
+#include "../../common/utility.h"
+
+oe_result_t enclave_identity_verifier_callback(
+    oe_identity_t* identity,
+    void* arg)
+{
+    oe_result_t result = OE_VERIFY_FAILED;
+    bool bret = false;
+
+    printf("Client:enclave_identity_verifier_callback is called with enclave "
+           "identity information:\n");
+
+    // enclave's security version
+    printf("identity->security_version = %d\n", identity->security_version);
+
+    // the unique ID for the enclave, for SGX enclaves, this is the MRENCLAVE
+    // value
+    printf("identity->unique_id(MRENCLAVE) :\n");
+    for (int i = 0; i < OE_UNIQUE_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->unique_id[i]);
+
+    // The signer ID for the enclave, for SGX enclaves, this is the MRSIGNER
+    // value
+    printf("\nidentity->signer_id(MRSIGNER) :\n");
+    for (int i = 0; i < OE_SIGNER_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->signer_id[i]);
+
+    if (!verify_mrsigner(
+            (char*)OTHER_ENCLAVE_PUBLIC_KEY,
+            sizeof(OTHER_ENCLAVE_PUBLIC_KEY),
+            identity->signer_id,
+            sizeof(identity->signer_id)))
+    {
+        printf("failed:mrsigner not equal!\n");
+        goto exit;
+    }
+    printf("mrsigner id validation passed.\n");
+
+    // The Product ID for the enclave, for SGX enclaves, this is the ISVPRODID
+    // value
+    printf("\nidentity->product_id :\n");
+    for (int i = 0; i < OE_PRODUCT_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->product_id[i]);
+
+    result = OE_OK;
+exit:
+    return result;
+}

--- a/samples/tls_between_enclaves/client/host/CMakeLists.txt
+++ b/samples/tls_between_enclaves/client/host/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+add_custom_command(OUTPUT tls_client_u.h tls_client_u.c tls_client_args.h
+  DEPENDS ${CMAKE_SOURCE_DIR}/client/tls_client.edl
+  COMMAND openenclave::oeedger8r --untrusted ${CMAKE_SOURCE_DIR}/client/tls_client.edl)
+
+add_executable(tls_client_host host.cpp ${CMAKE_CURRENT_BINARY_DIR}/tls_client_u.c)
+
+target_include_directories(tls_client_host PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR} # Needed for #include "../shared.h"
+  ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(tls_client_host openenclave::oehostapp)

--- a/samples/tls_between_enclaves/client/host/Makefile
+++ b/samples/tls_between_enclaves/client/host/Makefile
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Detect C and C++ compiler options
+# if not gcc and g++, default to clang-7
+C_COMPILER=$(notdir $(CC))
+ifeq ($(C_COMPILER), gcc)
+        CXX_COMPILER=$(notdir $(CXX))
+        USE_GCC = true
+endif
+
+ifeq ($(USE_GCC),)
+        CC = clang-7
+        CXX = clang++-7
+        C_COMPILER=clang
+        CXX_COMPILER=clang++
+endif
+
+CFLAGS=$(shell pkg-config oehost-$(C_COMPILER) --cflags)
+CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)
+LDFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --libs)
+
+all: build
+
+build:
+	@ echo "Compilers used: $(CC), $(CXX)"
+	oeedger8r ../tls_client.edl --untrusted
+	$(CC) -c $(CFLAGS) $(CINCLUDES) tls_client_u.c
+	$(CXX) -c $(CXXFLAGS) $(INCLUDES) host.cpp
+	$(CXX) -o tls_client_host host.o tls_client_u.o $(LDFLAGS)
+
+clean:
+	rm -f tls_client_host *.o tls_client_u.* tls_client_args.h

--- a/samples/tls_between_enclaves/client/host/host.cpp
+++ b/samples/tls_between_enclaves/client/host/host.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <stdio.h>
+#include "tls_client_u.h"
+
+#define TLS_SERVER_NAME "localhost"
+#define TLS_SERVER_PORT "12340"
+
+oe_enclave_t* create_enclave(const char* enclave_path)
+{
+    oe_enclave_t* enclave = NULL;
+
+    printf("Host: Enclave library %s\n", enclave_path);
+    oe_result_t result = oe_create_tls_client_enclave(
+        enclave_path,
+        OE_ENCLAVE_TYPE_SGX,
+        OE_ENCLAVE_FLAG_DEBUG,
+        NULL,
+        0,
+        &enclave);
+
+    if (result != OE_OK)
+    {
+        printf(
+            "Host: oe_create_remoteattestation_enclave failed. %s",
+            oe_result_str(result));
+    }
+    else
+    {
+        printf("Host: Enclave successfully created.\n");
+    }
+    return enclave;
+}
+
+void terminate_enclave(oe_enclave_t* enclave)
+{
+    oe_terminate_enclave(enclave);
+    printf("Host: Enclave successfully terminated.\n");
+}
+
+int main(int argc, const char* argv[])
+{
+    oe_enclave_t* enclave = NULL;
+    uint8_t* encrypted_msg = NULL;
+    size_t encrypted_msg_size = 0;
+    oe_result_t result = OE_OK;
+    int ret = 1;
+    uint8_t* pem_key = NULL;
+    size_t pem_key_size = 0;
+    uint8_t* remote_report = NULL;
+    size_t remote_report_size = 0;
+    char* server_name = NULL;
+    char* server_port = NULL;
+
+    /* Check argument count */
+    if (argc != 4)
+    {
+    print_usage:
+        printf(
+            "Usage: %s TLS_SERVER_ENCLAVE_PATH -server:<name> -port:<port>\n",
+            argv[0]);
+        return 1;
+    }
+    // read server name  parameter
+    {
+        const char* option = "-server:";
+        int param_len = 0;
+        param_len = strlen(option);
+        if (strncmp(argv[2], option, param_len) == 0)
+        {
+            server_name = (char*)(argv[2] + param_len);
+        }
+        else
+        {
+            fprintf(stderr, "Unknown option %s\n", argv[2]);
+            goto print_usage;
+        }
+    }
+    printf("server name = [%s]\n", server_name);
+
+    // read port parameter
+    {
+        const char* option = "-port:";
+        int param_len = 0;
+        param_len = strlen(option);
+        if (strncmp(argv[3], option, param_len) == 0)
+        {
+            server_port = (char*)(argv[3] + param_len);
+        }
+        else
+        {
+            fprintf(stderr, "Unknown option %s\n", argv[2]);
+            goto print_usage;
+        }
+    }
+    printf("server port = [%s]\n", server_port);
+
+    printf("Host: Creating two enclaves\n");
+    enclave = create_enclave(argv[1]);
+    if (enclave == NULL)
+    {
+        goto exit;
+    }
+
+    printf("Host: launch TLS client to initiate TLS connection\n");
+    ret = setup_tls_client_and_run(enclave, &ret, server_name, server_port);
+    if (ret != 0)
+    {
+        printf("Host: launch_tls_client failed\n");
+        goto exit;
+    }
+    ret = 0;
+exit:
+
+    if (enclave)
+        terminate_enclave(enclave);
+
+    printf("Host:  %s \n", (ret == 0) ? "succeeded" : "failed");
+    return ret;
+}

--- a/samples/tls_between_enclaves/client/tls_client.edl
+++ b/samples/tls_between_enclaves/client/tls_client.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+    trusted {
+
+        public int setup_tls_client_and_run([in, string] char* server_name, [in, string] char* server_port);
+    };
+};

--- a/samples/tls_between_enclaves/common/tls_client_enc_pubkey.h
+++ b/samples/tls_between_enclaves/common/tls_client_enc_pubkey.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef SAMPLES_REMOTE_ATTESTATION_PUBKEY_H
+#define SAMPLES_REMOTE_ATTESTATION_PUBKEY_H
+
+static const char OTHER_ENCLAVE_PUBLIC_KEY[] =
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MIIBoDANBgkqhkiG9w0BAQEFAAOCAY0AMIIBiAKCAYEApnWkkVfAlvvrD2GP4fuW\n"
+    "FU25WgTSwCPpXs/mZj8/Utz2rFZnsD2z05eZb/kuTt7UQsRYkFWupxPiw5qe8JrU\n"
+    "UnnBIzxutySWgu/PAo/k7MY1hFDF3BfpZ+70yDKqLQkuhMsXByfKVZHpoC3A+i7e\n"
+    "EXLe0gLo+pNkRkcDsOavlHuwSS9e7/nTF+f6MoqLeXALv7HWAeUiDH66BqQ2GEt0\n"
+    "lohc+PGdObGthjbqkPO1eJqCJxIoffCJLQxPAQOmVHO6ztWkaCrik+Z2rlnjtUK7\n"
+    "8mtTod0zSxaPUGKIViG8w9cuWNeG/Gbi1IZE4H+r653G7P4u1XDgIVA+i7ArrsS0\n"
+    "dYL/clfNHmMongf7mMR+awK3o0sAYN3X8AJlEDwKxpP2eFmuqCt0P+8U1NfX29hM\n"
+    "TeBWr42ozuYORngDkHLwjblly2sTEtoyZ4OPP8OjSuVTmCqbf7Tb9QVZj5zMAypV\n"
+    "I8Sc6exG8p1mnJ907q/lVBs8xBP0JOLR8oibHjrA9tOFAgED\n"
+    "-----END PUBLIC KEY-----\n";
+
+#endif /* SAMPLES_REMOTE_ATTESTATION_PUBKEY_H */

--- a/samples/tls_between_enclaves/common/tls_client_enc_signing_pubkey.h
+++ b/samples/tls_between_enclaves/common/tls_client_enc_signing_pubkey.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef SAMPLES_TLS_BETWEEN_ENCLAVES_SIGNING_PUBKEY_H
+#define SAMPLES_TLS_BETWEEN_ENCLAVES_SIGNING_PUBKEY_H
+
+static const char OTHER_ENCLAVE_SIGNING_PUBLIC_KEY[] =
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MIIBoDANBgkqhkiG9w0BAQEFAAOCAY0AMIIBiAKCAYEApnWkkVfAlvvrD2GP4fuW\n"
+    "FU25WgTSwCPpXs/mZj8/Utz2rFZnsD2z05eZb/kuTt7UQsRYkFWupxPiw5qe8JrU\n"
+    "UnnBIzxutySWgu/PAo/k7MY1hFDF3BfpZ+70yDKqLQkuhMsXByfKVZHpoC3A+i7e\n"
+    "EXLe0gLo+pNkRkcDsOavlHuwSS9e7/nTF+f6MoqLeXALv7HWAeUiDH66BqQ2GEt0\n"
+    "lohc+PGdObGthjbqkPO1eJqCJxIoffCJLQxPAQOmVHO6ztWkaCrik+Z2rlnjtUK7\n"
+    "8mtTod0zSxaPUGKIViG8w9cuWNeG/Gbi1IZE4H+r653G7P4u1XDgIVA+i7ArrsS0\n"
+    "dYL/clfNHmMongf7mMR+awK3o0sAYN3X8AJlEDwKxpP2eFmuqCt0P+8U1NfX29hM\n"
+    "TeBWr42ozuYORngDkHLwjblly2sTEtoyZ4OPP8OjSuVTmCqbf7Tb9QVZj5zMAypV\n"
+    "I8Sc6exG8p1mnJ907q/lVBs8xBP0JOLR8oibHjrA9tOFAgED\n"
+    "-----END PUBLIC KEY-----\n";
+
+#endif /* SAMPLES_TLS_BETWEEN_ENCLAVES_SIGNING_PUBKEY_H */

--- a/samples/tls_between_enclaves/common/tls_client_tls_cert_private_key.h
+++ b/samples/tls_between_enclaves/common/tls_client_tls_cert_private_key.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef SAMPLES_TLS_BETWEEN_ENCLAVES_CLIENT_TLS_CERT_KEY_H
+#define SAMPLES_TLS_BETWEEN_ENCLAVES_CLIENT_TLS_CERT_KEY_H
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// Note: an enclave is not supposed to embed any secrets in an enclave
+// image itself, such as the TLS private key below.
+// In this sample, we focus on showing how to use oe_verify_attestation_cert
+// and oe_generate_attestation_cert APIs to establish an attested TLS channel
+// . In the real production app, you want to have a clean enclave without
+// and secret to start with and once an enclave is running, provision
+// secrets into it after the enclave passese attestation challenges from
+// the secret owner.
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+const char CLIENT_ENCLAVE_TLS_CERT_PRIVATE_KEY[] =
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIG4wIBAAKCAYEAt+UODLMJ8s0CnTTK44Po6c5IS8pn97PAU4/SENMSjGDr/+OB\n"
+    "Ryb4ssMLjQm8UQ/zSs9ubwHyxtSylmrsTrzpjkRt63Pnv+rEu/N8U8Iz103jGy07\n"
+    "6V4OB+LkfJsYaMrCo+yTz22+GAFB3baHkLWwVSqDSTanmwym5kPFqlBzglw/Aq63\n"
+    "+PI2W0HJHTjFgNFDY0TcZz05th4LbYroRTSSlURaL3DRiF2pLK8RIetVjqLIieK1\n"
+    "sd7YjZc8MoRYZzyJrk0K0rPUONWrqIPJ2JH4m2mejh0tkPpMwdNcsqpH9LPZPSkE\n"
+    "+7l49Xe0fvnwfp8PHCM4dzUTZRHImnhqLYg6bNXpYoTG3oeQdT6cPCGHib0YmSgX\n"
+    "DtqCKNL50nURczfwc8pPKGMfpys91DiJ66lctNwvRL453U6VbZsZwajnUpbkGMno\n"
+    "h4veknyzGQhMAn0w4dVfJqNSX2FC5P18Fa6JQEOih8+zxGp2YWGQ2sHqEuYUm88v\n"
+    "wmjJ+ZiXQh1VhNgRAgEDAoIBgHqYtAh3W/czVxN4h0JX8Jve2t0xmqUigDe1NrXi\n"
+    "DF2V8qqXq4TEpcyCB7Nb0uC1TNyKSZ9WodnjIbmcnYnTRl7YSUeimn/x2H1M/Y0s\n"
+    "Io+JQhIeJ/DpXq/smFMSEEXcgcKdt9+efrqrgT55r7XOdY4cV4Ykb7yzGe7X2Rw1\n"
+    "olboKgHJz/tMJDzWhhN7LlXg15eDPZoo0SQUB55cmtjNtw4tkXT14QWTxh3KC2vy\n"
+    "OQnB2waXI8vp5bO6KCGtkETTBVKxfMT8l0ch1WYblBbO6AiDeRGCIB0hEIh5pBXk\n"
+    "OdPjuQ7LP9G0Thi7zlYNsqCxF2i2PE8BVVjuc8q3aAEp6RDIcPp5RAs0w5kyuvTn\n"
+    "XVj5zA1xDSlH6ePrEfnG1l3p1GftwPp5HUOxBSXjdUWStablcxKECQC2tkOrnkrg\n"
+    "PakpKXyXLUE64tQDd4VirlHIMVkX3N/SYkucJJbvC1J5G79UAZmfWC2IdQiHhbL6\n"
+    "IWa7mUgcryvTP1QCod35FSZlSwKBwQDhaacRfkhDO0ggAaFtPMUd9KB0TTCdHVcM\n"
+    "oOJSjnytfSoEegLDZ8ZO6eXrwFdv08EnMI4YqP0u6Qs2JZpLkMf7c4Ej26bUw8is\n"
+    "MsWGEc5hZjCicH1wGf8O1N3KyeoI1L2xWIotB4v7oVtbuV3PTURnC1IW1dSySYkr\n"
+    "qgAL5QywBL67zS052+Z8wR/8ACim82m3Xym9/cbwEC0HpWATWMwy2UFpMKBZyavp\n"
+    "5ZyrDBhz3D9BTh7hFfyk8EzQBtLy4LUCgcEA0NkombqpCuejb1jKSR7XcK/If4zM\n"
+    "yCtc6HwEP0V0iWEZon4ifcM9gXQZEiUNHcGq1+FP6AoWMMMPtD+z4DiU2DW+xvM5\n"
+    "+PSiYz++RrStIuA14o4F4NSkRB2BEQDl3YR0Jo0jg6XnxgBav6n8NAAH03iwkiJX\n"
+    "qfL63G+sRXN+JNRnIhn3a9ej17Zf1PQd4N19JNJqGOn3/ebe+vGLBqATbmxeuDAP\n"
+    "JlQa6rCroz6fhPBvblYKH5XuVqRXpSDi2F9tAoHBAJZGb2D+2td82sABFkjTLhP4\n"
+    "avgzdb4Tj13AluG0Ux5TcVhRVyzv2YnxQ/KAOkqNK291tBBwqMnwsiQZEYe12qei\n"
+    "VhfnxI3X2x13LllhNEDuyxb1qPVmqgnjPocxRrCN08uQXB4FB/0WPOfQ6TTeLZoH\n"
+    "jA85OHbbsMfGqrKYsyADKdKIyNE9RFMraqgAGxn3m8+Uxn6pL0q1c1puQAzl3Xc7\n"
+    "gPDLFZExHUaZExyyuvfoKiuJaetj/cNK3eAEjKHrIwKBwQCLO3BmfHCx78JKOzGG\n"
+    "FI+gdTBVCIiFcj3wUq1/g6MGQLvBqWxT135WTWYMGLNpK8c6ljVFXA7LLLUi1SKV\n"
+    "ew3leSnZ93v7TcGXf9QvIx4XQCPsXq6V4xgtaQC2AJk+WE1vCMJXw+/ZVZHVG/14\n"
+    "AAU3pcsMFuUb91HoSnLY96lt4u9sEU+dOm06eZU4or6V6P4YjEa7RqVT7z9R9lyv\n"
+    "FWJJnZR6yrTEOBHxyx0XfxUDSvT0OVwVDp7kbY/Da0HllPMCgcEAtmt30mUUhFCD\n"
+    "5KHn+UmWg8oMuXj42Njunf06vgMJ0tdC3RINNcztnXiWwpS3iDKBkBg+F4JYXvLx\n"
+    "SVme25uaLDXyW5TeyTfbkUrH9OHyXOSpLr5R4NUwiLScaafVWolx9tHtakPISy2s\n"
+    "NHg4fmiG7CzlObnn94OADGpvm99UdAsR/TpO7M55nGQe126HSNThPSJeTouGEt8Z\n"
+    "FepjSWhg+pKijCIRIpOpX1qeHAxDt64CLBj7V8tcI3gzbivNpeX6\n"
+    "-----END RSA PRIVATE KEY-----\n";
+
+#endif /* SAMPLES_TLS_BETWEEN_ENCLAVES_CLIENT_TLS_CERT_KEYS_H */

--- a/samples/tls_between_enclaves/common/tls_client_tls_cert_public_key.h
+++ b/samples/tls_between_enclaves/common/tls_client_tls_cert_public_key.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef SAMPLES_TLS_BETWEEN_ENCLAVES_CLIENT_TLS_CERT_PUBLIC_KEY_H
+#define SAMPLES_TLS_BETWEEN_ENCLAVES_CLIENT_TLS_CERT_PUBLIC_KEY_H
+
+const char CLIENT_ENCLAVE_TLS_CERT_PUBLIC_KEY[] =
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MIIBoDANBgkqhkiG9w0BAQEFAAOCAY0AMIIBiAKCAYEAt+UODLMJ8s0CnTTK44Po\n"
+    "6c5IS8pn97PAU4/SENMSjGDr/+OBRyb4ssMLjQm8UQ/zSs9ubwHyxtSylmrsTrzp\n"
+    "jkRt63Pnv+rEu/N8U8Iz103jGy076V4OB+LkfJsYaMrCo+yTz22+GAFB3baHkLWw\n"
+    "VSqDSTanmwym5kPFqlBzglw/Aq63+PI2W0HJHTjFgNFDY0TcZz05th4LbYroRTSS\n"
+    "lURaL3DRiF2pLK8RIetVjqLIieK1sd7YjZc8MoRYZzyJrk0K0rPUONWrqIPJ2JH4\n"
+    "m2mejh0tkPpMwdNcsqpH9LPZPSkE+7l49Xe0fvnwfp8PHCM4dzUTZRHImnhqLYg6\n"
+    "bNXpYoTG3oeQdT6cPCGHib0YmSgXDtqCKNL50nURczfwc8pPKGMfpys91DiJ66lc\n"
+    "tNwvRL453U6VbZsZwajnUpbkGMnoh4veknyzGQhMAn0w4dVfJqNSX2FC5P18Fa6J\n"
+    "QEOih8+zxGp2YWGQ2sHqEuYUm88vwmjJ+ZiXQh1VhNgRAgED\n"
+    "-----END PUBLIC KEY-----\n";
+
+#endif /* SAMPLES_TLS_BETWEEN_ENCLAVES_CLIENT_TLS_CERT_PUBLIC_KEY_H */

--- a/samples/tls_between_enclaves/common/tls_server_enc_pubkey.h
+++ b/samples/tls_between_enclaves/common/tls_server_enc_pubkey.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef SAMPLES_REMOTE_ATTESTATION_PUBKEY_H
+#define SAMPLES_REMOTE_ATTESTATION_PUBKEY_H
+
+static const char OTHER_ENCLAVE_PUBLIC_KEY[] =
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MIIBoDANBgkqhkiG9w0BAQEFAAOCAY0AMIIBiAKCAYEAu90S+340qQStWTrhzXTf\n"
+    "5gmYTyf7SVNJkXpoCmxMToKUmlD6aOAkKGWaOy8w+A+DW3DlA6XJLit9HEclJcVR\n"
+    "Bszo5Q9tQYpq2DFeSlpDgzHqBGYYN/oDPCEkenBOO8e+dPxLpxwlLWPy08nmf79/\n"
+    "mzduWp88sF3ofi6QyR5S/Aw7LQ1KsZtKB3/4X0tgHzKOCx5DlYtsKTUx1dNl5G4n\n"
+    "e+7LtUwYt0W73m6e+BoOO1dXmMmXEHeg84GldfsPK320qqda5hCziyZMK+WfRo+d\n"
+    "nm1+qLGOOgL2bCtSaU2JA7TmK5lQk6hKACkQT8UDADCUJC585I9fTV66pb3VOmdB\n"
+    "PgmB+5EEvAuWxBGFgHsF91D2NYFeIUGXUUBW58aneilp+BTn4PwTRUzUb7P9o+KF\n"
+    "/BWULGeroFZkpf+aytr+Ac4+8c7z7BlpTdfMEKXzh/3FCbfUHw0sUF2ZJ/dRqrA4\n"
+    "oUolPifJeQIoY3zdH1/ZoPiysoPR5iA2cnqFXLo7nv3/AgED\n"
+    "-----END PUBLIC KEY-----\n";
+
+#endif /* SAMPLES_REMOTE_ATTESTATION_PUBKEY_H */

--- a/samples/tls_between_enclaves/common/tls_server_enc_signing_pubkey.h
+++ b/samples/tls_between_enclaves/common/tls_server_enc_signing_pubkey.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef SAMPLES_TLS_BETWEEN_ENCLAVES_SIGNING_PUBKEY_H
+#define SAMPLES_TLS_BETWEEN_ENCLAVES_SIGNING_PUBKEY_H
+
+static const char OTHER_ENCLAVE_SIGNING_PUBLIC_KEY[] =
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MIIBoDANBgkqhkiG9w0BAQEFAAOCAY0AMIIBiAKCAYEAu90S+340qQStWTrhzXTf\n"
+    "5gmYTyf7SVNJkXpoCmxMToKUmlD6aOAkKGWaOy8w+A+DW3DlA6XJLit9HEclJcVR\n"
+    "Bszo5Q9tQYpq2DFeSlpDgzHqBGYYN/oDPCEkenBOO8e+dPxLpxwlLWPy08nmf79/\n"
+    "mzduWp88sF3ofi6QyR5S/Aw7LQ1KsZtKB3/4X0tgHzKOCx5DlYtsKTUx1dNl5G4n\n"
+    "e+7LtUwYt0W73m6e+BoOO1dXmMmXEHeg84GldfsPK320qqda5hCziyZMK+WfRo+d\n"
+    "nm1+qLGOOgL2bCtSaU2JA7TmK5lQk6hKACkQT8UDADCUJC585I9fTV66pb3VOmdB\n"
+    "PgmB+5EEvAuWxBGFgHsF91D2NYFeIUGXUUBW58aneilp+BTn4PwTRUzUb7P9o+KF\n"
+    "/BWULGeroFZkpf+aytr+Ac4+8c7z7BlpTdfMEKXzh/3FCbfUHw0sUF2ZJ/dRqrA4\n"
+    "oUolPifJeQIoY3zdH1/ZoPiysoPR5iA2cnqFXLo7nv3/AgED\n"
+    "-----END PUBLIC KEY-----\n";
+
+#endif /* SAMPLES_TLS_BETWEEN_ENCLAVES_SIGNING_PUBKEY_H */

--- a/samples/tls_between_enclaves/common/tls_server_tls_cert_private_key.h
+++ b/samples/tls_between_enclaves/common/tls_server_tls_cert_private_key.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef SAMPLES_TLS_BETWEEN_ENCLAVES_SERVER_TLS_CERT_PRIVATE_KEY_H
+#define SAMPLES_TLS_BETWEEN_ENCLAVES_SERVER_TLS_CERT_PRIVATE_KEY_H
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// Note: an enclave is not supposed to embed any secrets in an enclave
+// image itself, such as the TLS private key below.
+// In this sample, we focus on showing how to use oe_verify_attestation_cert
+// and oe_generate_attestation_cert APIs to establish an attested TLS channel
+// . In the real production app, you want to have a clean enclave without
+// and secret to start with and once an enclave is running, provision
+// secrets into it after the enclave passese attestation challenges from
+// the secret owner.
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+const char SERVER_ENCLAVE_TLS_CERT_PRIVATE_KEY[] =
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIG4wIBAAKCAYEA1tgZ1JjU9iu8V05tXS5dzOuGQscVwAC/3lNQZfduKtKBA8vY\n"
+    "VwJh+aPBJTMh7QwVGjuhhAm6vzsetVIWYQ113V5RChqLFHJgLwiltY5AzRMjr/CN\n"
+    "RHxutgyMHMSSobwyJbaVIR5blnWKBXrh7cCoUb9V+G0ro8WUPDpkwIGtgx65auSg\n"
+    "sTqni6Ab+wgmHwq0Fed7UR6q/R2gsL3LE0m3GP8MAr8o/8adx6X9fuHfMT0FZnpG\n"
+    "iLbGCS9Cbtng9NNLAr4/+fDRjdID9fGv7hxilMaWjvQoS6HHyfuX309rULL78YjW\n"
+    "ULTglhiyCQUUJ+Po4MDXq0PzibmtqttrfLG4oAs7Ue65TE/+zNEOeQCAUpS6eZYG\n"
+    "8Yyoq5HPwhcT23F194u5fc/z2Yh7y/k+benJvr6ogy+8NnMhgda954cIhAL5cCtd\n"
+    "l1Yn+UIoHUqAYOMcqnEWECAE+0FM+j0mXVlRLduwsuBi3WH3rLwZxSi3lqaGKkK9\n"
+    "qCiPToTtFKpRal9LAgEDAoIBgQCPOrvjEI35cn2PiZ4+HukzR67XL2PVVdU+4jWZ\n"
+    "T57HNwCtMpA6AZambStuIhaeCA4RfRZYBnx/fL8jjA7rXk6TlDYGvFy4TEAfWxkj\n"
+    "tCszYhfKoF4tqEnOswgTLbcWfXbDzw4WFD0O+QauUevz1cWL1OP683JtLmLS0ZiA\n"
+    "VnOsvyZHQxXLfG+yar1SBW6/XHgOmlI2FHH+E8B109y3hnoQqggB1MX/2b6FGVOp\n"
+    "6+og01ju/C8Fzy6wyixJ5pX4jNtzypLszq1hKzb+EVszeP9miDFzokkpIeuLWrAH\n"
+    "ETkMJ10MafZl0q80tNgMjpbUQXJVc+QqYBOfChsQw/9b1Ht+dL7oUAUpOKC+lo9Z\n"
+    "hjKBE8WboGmHP//uR3jKpeZmKCdT+TPNJ8PsUTLswtH3dS/QoiLrJAzHmi2JeQ3I\n"
+    "EwsCO1ElEbOqDqqzB6iuC6Ecdw+aDO0INYmrBJUAAr12raTLFXJKb2QWb5+83geh\n"
+    "nkT+4P2yeZlKDMEQ3WmJV4SDKAsCgcEA7Fph86oRuMe3ojqbEbkqB8xkLUL5VDCZ\n"
+    "ew8YuXcZ7X1IclfBKOK7WE81Z0WDh3AEOQjUQEqPL0avYHxjLXG25FCdQL9u624B\n"
+    "HKr92gUpYCBa/F8O8s0lpdFupt/HbHjMqBvy40ksoAHJRWofTFJ3wn0G9uMOkNiL\n"
+    "diRRrFJCj7pWKAwkUQNnoQDdpwNfwsWrqjuYSTRbJkWckD4JSvL13C9/Bvah0rIx\n"
+    "3BYYKgBAvV0JyMeE8oVmWvmG5rhiM/7zAoHBAOi0AaMQu8NJedadDA8tuXMt6DQ9\n"
+    "wTm+TP3kdxs+e9D6p+ySI48WHm66OI7prmIRuSeKLStpRuvj1bE5CUWBSH4Lf7S3\n"
+    "QqMNDJJEOZiyCzDWtxPGWbPfgyBVK+s+ctW8blF5+ObLIVcM5iNq5C5nikNObSuW\n"
+    "mnozUb18148YNXDvqZCEq8c8wEu1zXE1rvNq2ZkiGjqbW1R00On7AOBh5CEMBjxC\n"
+    "qukIVjVY9ii7D1r3/9XE0saQB1o/R9/uqHGkSQKBwQCdkZaicWEl2npsJxIL0Mav\n"
+    "3ZgeLKY4IGZSChB7pLvzqNr25StwlyeQNM5E2QJaSq17Wzgq3F902cpAUuzI9nnt\n"
+    "ixOAf59Hnqtocf6RWMZAFZH9lLSh3hkZNknElS+dpd3FZ/dCMMhqq9uDnBTdjE/W\n"
+    "/gSkl18LOwekGDZy4YG1JuQassLgrO/Aqz5vV5Usg8fG0mWGIudu2RMK1AYx906S\n"
+    "ylSvTxaMdsvoDrrGqtXTk1vbL633A5mR+69EeuwiqfcCgcEAmyKrwgsn14ZROb4I\n"
+    "Ch57oh6azX6A0SmIqUL6Eimn4KcanbbCX2QUSdF7CfEe7AvQxQbIx5uEnUKOdiYG\n"
+    "LlYwVAeqeHosbLNdttgmZcwHdeR6DS7md+pXauNynNRMjn2e4Pv7RIdrj13uwkdC\n"
+    "yZpcLN7zcmRm/CI2flM6X2V49fUbta3H2iiAMnkzoM50okc7u2wRfGeSOE3gm/yr\n"
+    "QEFCwLKu0tccm1rkI5CkGydfkfqqjoM3LwqvkX+FP/RwS8LbAoHAVzeMDQkXnrzA\n"
+    "quhdVbw4ijht1NqGYmEJ7XqkqTFdc9Of0Jibq17Pl7Nf6b3ikXnOxWm37gongH2k\n"
+    "O2KQ5eC/6n2jlHMBbbQe525l75TpZo2QA/F7z+chAhieNsCn7oU+EsG1B5Bk71CN\n"
+    "JyfEZlALP/peVwkNjO5rhFOhZ4zHYQ9CkYQdxo8fNvJYST83LmXAf97dFFVeThMl\n"
+    "TUg4G/PCbRg/gjBaZoIH+Efh1vvBJtFjj/Si46Qns4mFAkq3fvQF\n"
+    "-----END RSA PRIVATE KEY-----\n";
+
+#endif /* SAMPLES_TLS_BETWEEN_ENCLAVES_SERVER_TLS_CERT_PRIVATE_KEY_H */

--- a/samples/tls_between_enclaves/common/tls_server_tls_cert_public_key.h
+++ b/samples/tls_between_enclaves/common/tls_server_tls_cert_public_key.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef SAMPLES_TLS_BETWEEN_ENCLAVES_SERVER_TLS_CERT_PUBLIC_KEY_H
+#define SAMPLES_TLS_BETWEEN_ENCLAVES_SERVER_TLS_CERT_PUBLIC_KEY_H
+
+const char SERVER_ENCLAVE_TLS_CERT_PUBLIC_KEY[] =
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MIIBoDANBgkqhkiG9w0BAQEFAAOCAY0AMIIBiAKCAYEA1tgZ1JjU9iu8V05tXS5d\n"
+    "zOuGQscVwAC/3lNQZfduKtKBA8vYVwJh+aPBJTMh7QwVGjuhhAm6vzsetVIWYQ11\n"
+    "3V5RChqLFHJgLwiltY5AzRMjr/CNRHxutgyMHMSSobwyJbaVIR5blnWKBXrh7cCo\n"
+    "Ub9V+G0ro8WUPDpkwIGtgx65auSgsTqni6Ab+wgmHwq0Fed7UR6q/R2gsL3LE0m3\n"
+    "GP8MAr8o/8adx6X9fuHfMT0FZnpGiLbGCS9Cbtng9NNLAr4/+fDRjdID9fGv7hxi\n"
+    "lMaWjvQoS6HHyfuX309rULL78YjWULTglhiyCQUUJ+Po4MDXq0PzibmtqttrfLG4\n"
+    "oAs7Ue65TE/+zNEOeQCAUpS6eZYG8Yyoq5HPwhcT23F194u5fc/z2Yh7y/k+benJ\n"
+    "vr6ogy+8NnMhgda954cIhAL5cCtdl1Yn+UIoHUqAYOMcqnEWECAE+0FM+j0mXVlR\n"
+    "LduwsuBi3WH3rLwZxSi3lqaGKkK9qCiPToTtFKpRal9LAgED\n"
+    "-----END PUBLIC KEY-----\n";
+
+#endif /* SAMPLES_TLS_BETWEEN_ENCLAVES_SERVER_TLS_CERT_PUBLIC_KEY_H */

--- a/samples/tls_between_enclaves/common/utility.cpp
+++ b/samples/tls_between_enclaves/common/utility.cpp
@@ -1,0 +1,255 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// clang-format off
+#include <openenclave/enclave.h>
+#include <stdio.h>
+#include <string.h>
+#include "utility.h"
+// clang-format on
+
+#define MAX_PUBLIC_KEY_BUFF_SIZE 2048
+
+extern oe_result_t get_tls_cert_keys(
+    uint8_t** public_key,
+    size_t* public_key_size,
+    uint8_t** private_key,
+    size_t* private_key_size);
+
+// check whether the crt is from a trust party
+bool is_certificate_public_key_trusted(
+    mbedtls_x509_crt* crt,
+    char* trusted_pub_key,
+    int trusted_pub_key_size)
+{
+    bool ret = false;
+    unsigned char* pub_key = NULL;
+
+    pub_key = (unsigned char*)malloc(MAX_PUBLIC_KEY_BUFF_SIZE);
+    if (pub_key == NULL)
+        goto done;
+
+    ret = mbedtls_pk_write_pubkey_pem(
+        &crt->pk, (unsigned char*)pub_key, MAX_PUBLIC_KEY_BUFF_SIZE);
+    if (ret != 0)
+    {
+        printf("mbedtls_pk_write_pubkey_pem failed with ret = %d\n", ret);
+        goto done;
+    }
+    printf(
+        "pub_key size = %zu pub_key = [%s] \n",
+        strlen((const char*)pub_key),
+        pub_key);
+
+    if (strncmp(trusted_pub_key, (const char*)pub_key, trusted_pub_key_size) !=
+        0)
+        goto done;
+
+    printf("The public key in received certificate is trusted\n");
+    ret = true;
+
+done:
+
+    free(pub_key);
+    return ret;
+}
+
+// Compute the sha256 hash of given data.
+static int sha256(const uint8_t* data, size_t data_size, uint8_t sha256[32])
+{
+    int ret = 0;
+    mbedtls_sha256_context ctx;
+
+    mbedtls_sha256_init(&ctx);
+
+    ret = mbedtls_sha256_starts_ret(&ctx, 0);
+    if (ret)
+        goto exit;
+
+    ret = mbedtls_sha256_update_ret(&ctx, data, data_size);
+    if (ret)
+        goto exit;
+
+    ret = mbedtls_sha256_finish_ret(&ctx, sha256);
+    if (ret)
+        goto exit;
+
+exit:
+    mbedtls_sha256_free(&ctx);
+    return ret;
+}
+
+// Consider to move this function into a shared directory
+oe_result_t generate_tls_certificate(
+    mbedtls_x509_crt* cert,
+    mbedtls_pk_context* private_key)
+{
+    oe_result_t result = OE_FAILURE;
+    uint8_t* host_cert_buf = NULL;
+    uint8_t* output_cert = NULL;
+    size_t output_cert_size = 0;
+    uint8_t* private_key_buf = NULL;
+    size_t private_key_buf_size = 0;
+    uint8_t* public_key_buf = NULL;
+    size_t public_key_buf_size = 0;
+    int ret = 0;
+
+    result = get_tls_cert_keys(
+        &public_key_buf,
+        &public_key_buf_size,
+        &private_key_buf,
+        &private_key_buf_size);
+
+    if (result != OE_OK)
+    {
+        printf(" failed with %s\n", oe_result_str(result));
+        goto exit;
+    }
+
+    printf("public key used:\n[%s]\n", public_key_buf);
+
+    // both ec key such ASYMMETRIC_KEY_EC_SECP256P1 or RSA key work
+    result = oe_generate_attestation_certificate(
+        (const unsigned char*)"CN=Open Enclave SDK,O=OESDK TLS,C=US",
+        private_key_buf,
+        private_key_buf_size,
+        public_key_buf,
+        public_key_buf_size,
+        &output_cert,
+        &output_cert_size);
+    if (result != OE_OK)
+    {
+        printf(" failed with %s\n", oe_result_str(result));
+        goto exit;
+    }
+
+    // create mbedtls_x509_crt from output_cert
+    ret = mbedtls_x509_crt_parse_der(cert, output_cert, output_cert_size);
+    if (ret != 0)
+    {
+        printf(" failed with ret = %d\n", ret);
+        result = OE_FAILURE;
+        goto exit;
+    }
+
+    // create mbedtls_pk_context from private key data
+    ret = mbedtls_pk_parse_key(
+        private_key,
+        (const unsigned char*)private_key_buf,
+        private_key_buf_size,
+        NULL,
+        0);
+    if (ret != 0)
+    {
+        printf(" failed with ret = %d\n", ret);
+        result = OE_FAILURE;
+        goto exit;
+    }
+
+exit:
+    oe_free_attestation_certificate(output_cert);
+    return result;
+}
+
+bool verify_mrsigner(
+    char* siging_public_key_buf,
+    size_t siging_public_key_buf_size,
+    uint8_t* signer_id_buf,
+    size_t signer_id_buf_size)
+{
+    mbedtls_pk_context ctx;
+    mbedtls_pk_type_t pk_type;
+    mbedtls_rsa_context* rsa_ctx = NULL;
+    uint8_t* modulus = NULL;
+    size_t modulus_size = 0;
+    int res = 0;
+    bool ret = false;
+    unsigned char* signer = NULL;
+
+    signer = (unsigned char*)malloc(signer_id_buf_size);
+    if (signer == NULL)
+    {
+        printf("Out of memory\n");
+        goto exit;
+    }
+
+    printf("Verify connecting client's identity\n");
+    printf("public key buffer size[%lu]\n", sizeof(siging_public_key_buf));
+    printf("public key\n[%s]\n", siging_public_key_buf);
+
+    mbedtls_pk_init(&ctx);
+    res = mbedtls_pk_parse_public_key(
+        &ctx,
+        (const unsigned char*)siging_public_key_buf,
+        siging_public_key_buf_size);
+    if (res != 0)
+    {
+        printf("mbedtls_pk_parse_public_key failed with %d\n", res);
+        goto exit;
+    }
+
+    pk_type = mbedtls_pk_get_type(&ctx);
+    if (pk_type != MBEDTLS_PK_RSA)
+    {
+        printf("mbedtls_pk_get_type had incorrect type: %d\n", res);
+        goto exit;
+    }
+    printf("This public sigining key is a rsa key \n");
+
+    rsa_ctx = mbedtls_pk_rsa(ctx);
+    modulus_size = mbedtls_rsa_get_len(rsa_ctx);
+    printf("modulus_size = [%zu]\n", modulus_size);
+    modulus = (uint8_t*)malloc(modulus_size);
+    if (modulus == NULL)
+    {
+        printf("malloc for modulus failed with size %zu:\n", modulus_size);
+        goto exit;
+    }
+
+    res = mbedtls_rsa_export_raw(
+        rsa_ctx, modulus, modulus_size, NULL, 0, NULL, 0, NULL, 0, NULL, 0);
+    if (res != 0)
+    {
+        printf("mbedtls_rsa_export failed with %d\n", res);
+        goto exit;
+    }
+
+    // Reverse the modulus and compute sha256 on it.
+    for (size_t i = 0; i < modulus_size / 2; i++)
+    {
+        uint8_t tmp = modulus[i];
+        modulus[i] = modulus[modulus_size - 1 - i];
+        modulus[modulus_size - 1 - i] = tmp;
+    }
+
+    // Calculate the MRSIGNER value which is the SHA256 hash of the
+    // little endian representation of the public key modulus. This value
+    // is populated by the signer_id sub-field of a parsed oe_report_t's
+    // identity field.
+    if (sha256(modulus, modulus_size, signer) != 0)
+    {
+        printf("sha256 failed\n");
+        goto exit;
+    }
+
+    if (memcmp(signer, signer_id_buf, signer_id_buf_size) != 0)
+    {
+        printf("mrsigner is not equal!\n");
+        for (int i = 0; i < signer_id_buf_size; i++)
+        {
+            printf(
+                "0x%x - 0x%x\n", (uint8_t)signer[i], (uint8_t)signer_id_buf[i]);
+        }
+        goto exit;
+    }
+    ret = true;
+exit:
+    if (signer)
+        free(signer);
+
+    if (modulus != NULL)
+        free(modulus);
+
+    mbedtls_pk_free(&ctx);
+    return ret;
+}

--- a/samples/tls_between_enclaves/common/utility.h
+++ b/samples/tls_between_enclaves/common/utility.h
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <mbedtls/pk.h>
+#include <mbedtls/rsa.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/x509_crt.h>
+
+oe_result_t generate_tls_certificate(
+    mbedtls_x509_crt* cert,
+    mbedtls_pk_context* private_key);
+
+bool verify_mrsigner(
+    char* siging_public_key_buf,
+    size_t siging_public_key_buf_size,
+    uint8_t* signer_id_buf,
+    size_t signer_id_buf_size);
+
+int cert_verify_callback(
+    void* data,
+    mbedtls_x509_crt* crt,
+    int depth,
+    uint32_t* flags);
+
+bool is_certificate_public_key_trusted(
+    mbedtls_x509_crt* crt,
+    char* trusted_pub_key,
+    int trusted_pub_key_size);
+
+#define ADD_TEST_CHECKING
+#define PAYLOAD_FROM_CLIENT "GET / HTTP/1.0\r\n\r\n"
+
+#define PAYLOAD_FROM_SERVER                              \
+    "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\n" \
+    "<h2>mbed TLS Test Server</h2>\r\n"                  \
+    "<p>Successful connection : </p>\r\n"                \
+    "A message from TLS server inside enclave\r\n"
+
+#define CLIENT_PAYLOAD_SIZE strlen(PAYLOAD_FROM_CLIENT)
+#define SERVER_PAYLOAD_SIZE strlen(PAYLOAD_FROM_SERVER)

--- a/samples/tls_between_enclaves/server/CMakeLists.txt
+++ b/samples/tls_between_enclaves/server/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+cmake_minimum_required(VERSION 3.11)
+
+#find_package(OpenEnclave CONFIG REQUIRED)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_subdirectory(enc)
+add_subdirectory(host)
+
+add_custom_target(tls_server DEPENDS tls_server_host tls_server_enc tls_server_sign_enc)
+
+#if ((NOT DEFINED ENV{OE_SIMULATION}) OR (NOT $ENV{OE_SIMULATION}))
+#  add_custom_target(run
+#    DEPENDS tls_server_host sign
+#    #   COMMAND file-encryptor_host ${CMAKE_CURRENT_SOURCE_DIR}/testfile ${CMAKE_BINARY_DIR}/enclave/enclave.signed)
+#    COMMAND ${CMAKE_BINARY_DIR}/host/tls_server_host ${CMAKE_BINARY_DIR}/enc/tls_server_enc.signed -port:12341)
+#endif ()

--- a/samples/tls_between_enclaves/server/Makefile
+++ b/samples/tls_between_enclaves/server/Makefile
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+all: build
+
+#genkey:
+#	$(MAKE) -C enc genkey
+
+build:
+	$(MAKE) -C enc
+	$(MAKE) -C host
+
+clean:
+	$(MAKE) -C enc clean
+	$(MAKE) -C host clean
+
+run:
+	host/tls_server_host ./enc/tls_server_enc.signed -port:12341

--- a/samples/tls_between_enclaves/server/enc/CMakeLists.txt
+++ b/samples/tls_between_enclaves/server/enc/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Use the edger8r to generate C bindings from the EDL file.
+add_custom_command(OUTPUT tls_server_t.h tls_server_t.c tls_server_args.h
+  DEPENDS ${CMAKE_SOURCE_DIR}/server/tls_server.edl
+  COMMAND openenclave::oeedger8r --trusted ${CMAKE_SOURCE_DIR}/server/tls_server.edl)
+
+# Sign enclave
+add_custom_command(OUTPUT tls_server_enc.signed
+  DEPENDS tls_server_enc enc.conf
+  COMMAND openenclave::oesign sign -e $<TARGET_FILE:tls_server_enc> -c ${CMAKE_SOURCE_DIR}/server/enc/enc.conf -k ${CMAKE_SOURCE_DIR}/server/enc/server_signing_private.pem)
+
+add_executable(tls_server_enc ecalls.cpp crypto.cpp server.cpp identity_verifier.cpp cert_verifier.cpp ../../common/utility.cpp ${CMAKE_CURRENT_BINARY_DIR}/tls_server_t.c)
+target_compile_definitions(tls_server_enc PUBLIC OE_API_VERSION=2)
+
+target_include_directories(tls_server_enc PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR} # Needed for #include "../shared.h"
+  ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(tls_server_enc
+		openenclave::oeenclave
+		openenclave::oelibcxx
+                openenclave::mbedtls
+		openenclave::mbedcrypto
+		openenclave::oehostsock
+		openenclave::oehostresolver
+                openenclave::oecore
+	        openenclave::oelibc
+	        openenclave::oeposix)
+
+add_custom_target(tls_server_sign_enc ALL DEPENDS tls_server_enc.signed)

--- a/samples/tls_between_enclaves/server/enc/Makefile
+++ b/samples/tls_between_enclaves/server/enc/Makefile
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Detect C and C++ compiler options
+# if not gcc and g++, default to clang-7
+C_COMPILER=$(notdir $(CC))
+ifeq ($(C_COMPILER), gcc)
+        CXX_COMPILER=$(notdir $(CXX))
+        USE_GCC = true
+endif
+
+ifeq ($(USE_GCC),)
+        CC = clang-7
+        CXX = clang++-7
+        C_COMPILER=clang
+        CXX_COMPILER=clang++
+endif
+
+CFLAGS=$(shell pkg-config oeenclave-$(C_COMPILER) --cflags)
+CXXFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --cflags)
+LDFLAGS=$(shell pkg-config oeenclave-$(CXX_COMPILER) --libs)
+
+all:
+#	$(MAKE) genkey
+#	$(MAKE) -C ../../client/enc genkey
+	$(MAKE) build
+	$(MAKE) sign
+
+#private.pem:
+#	openssl genrsa -out $@ -3 3072
+
+#public.pem: private.pem
+#	openssl rsa -in $< -out $@ -pubout
+
+# The enclaves in the sample will check if the other enclave is signed
+# with the expected key. Since this sample builds both enclaves, we can
+# inject the expected public keys at build time.
+#
+# If the other public key isn't known, then we would have to load the
+# public key from the host. We can't simply load the raw public key since
+# a malicious host might change it. So, we would need to load a certicate
+# that contains the expected public key that is signed by a trusted CA.
+#genkey: public.pem
+#	chmod u+x ../../scripts/gen_pubkey_header.sh
+#	../../scripts/gen_pubkey_header.sh ../../common/tls_server_enc_pubkey.h $<
+
+# command to generate ca certificate
+# openssl req -new -x509 -key server_ca_cert_private.pem -out server_root_cert.pem -days 3650 -subj "/CN=Open Enclave SDK Server,/O=OESDK TLS,/C=US"
+
+build:
+	@ echo "Compilers used: $(CC), $(CXX)"
+	oeedger8r ../tls_server.edl --trusted --trusted-dir .
+	$(CXX) -g -c $(CXXFLAGS) $(INCLUDES) -std=c++11 ecalls.cpp server.cpp identity_verifier.cpp crypto.cpp ../../common/utility.cpp cert_verifier.cpp
+	$(CC) -c $(CFLAGS) $(CINCLUDES) tls_server_t.c
+	$(CXX) -o tls_server_enc ecalls.o server.o identity_verifier.o crypto.o utility.o tls_server_t.o cert_verifier.o $(LDFLAGS) -lmbedtls -lmbedcrypto -loehostsock -loehostresolver -loecore -loelibc -loeposix
+
+sign:
+	oesign sign -e tls_server_enc -c enc.conf -k server_signing_private.pem
+
+clean:
+	rm -f *.o tls_server_enc tls_server_enc.signed tls_server_enc.signed.so tls_server_t.* tls_server_args.h

--- a/samples/tls_between_enclaves/server/enc/cert_verifier.cpp
+++ b/samples/tls_between_enclaves/server/enc/cert_verifier.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <mbedtls/certs.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/debug.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/error.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/platform.h>
+#include <mbedtls/rsa.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/ssl_cache.h>
+#include <mbedtls/x509.h>
+#include <openenclave/enclave.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include "../../common/utility.h"
+
+#include "../../common/tls_client_tls_cert_public_key.h"
+#include "../../common/tls_server_tls_cert_private_key.h"
+#include "../../common/tls_server_tls_cert_public_key.h"
+
+oe_result_t enclave_identity_verifier_callback(
+    oe_identity_t* identity,
+    void* arg);
+
+oe_result_t get_tls_cert_keys(
+    uint8_t** public_key,
+    size_t* public_key_size,
+    uint8_t** private_key,
+    size_t* private_key_size)
+{
+    *public_key = (uint8_t*)SERVER_ENCLAVE_TLS_CERT_PUBLIC_KEY;
+    *public_key_size = strlen(SERVER_ENCLAVE_TLS_CERT_PUBLIC_KEY) + 1;
+    *private_key = (uint8_t*)SERVER_ENCLAVE_TLS_CERT_PRIVATE_KEY;
+    *private_key_size = strlen(SERVER_ENCLAVE_TLS_CERT_PRIVATE_KEY) + 1;
+
+    return OE_OK;
+}
+
+// If set, the verify callback is called for each certificate in the chain.
+// The verification callback is supposed to return 0 on success. Otherwise, the
+// verification failed.
+int cert_verify_callback(
+    void* data,
+    mbedtls_x509_crt* crt,
+    int depth,
+    uint32_t* flags)
+{
+    oe_result_t result = OE_FAILURE;
+    int ret = 1;
+    unsigned char* cert_buf = NULL;
+    size_t cert_size = 0;
+
+    (void)data;
+
+    printf(" cert_verify_callback with depth = %d\n", depth);
+
+    cert_buf = crt->raw.p;
+    cert_size = crt->raw.len;
+
+    printf("crt->version = %d cert_size = %zu\n", crt->version, cert_size);
+    if (cert_size <= 0)
+        goto exit;
+
+    if (!is_certificate_public_key_trusted(
+            crt,
+            (char*)CLIENT_ENCLAVE_TLS_CERT_PUBLIC_KEY,
+            strlen(CLIENT_ENCLAVE_TLS_CERT_PUBLIC_KEY)))
+    {
+        printf("Unexpected certificate received\n");
+        printf("Expected: [%s]\n", (char*)CLIENT_ENCLAVE_TLS_CERT_PUBLIC_KEY);
+        goto exit;
+    }
+
+    result = oe_verify_attestation_certificate(
+        cert_buf, cert_size, enclave_identity_verifier_callback, NULL);
+    if (result != OE_OK)
+    {
+        printf(
+            "oe_verify_attestation_certificate failed with result = %s\n",
+            oe_result_str(result));
+        goto exit;
+    }
+    ret = 0;
+    *flags = 0;
+exit:
+    return ret;
+}

--- a/samples/tls_between_enclaves/server/enc/crypto.cpp
+++ b/samples/tls_between_enclaves/server/enc/crypto.cpp
@@ -1,0 +1,313 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "crypto.h"
+#include <mbedtls/pk.h>
+#include <mbedtls/rsa.h>
+#include <openenclave/enclave.h>
+#include <stdlib.h>
+#include <string.h>
+
+Crypto::Crypto()
+{
+    m_initialized = init_mbedtls();
+    // mbedtls_net_init(NULL);
+}
+
+Crypto::~Crypto()
+{
+    cleanup_mbedtls();
+}
+
+/**
+ * init_mbedtls initializes the crypto module.
+ * mbedtls initialization. Please refer to mbedtls documentation for detailed
+ * information about the functions used.
+ */
+bool Crypto::init_mbedtls(void)
+{
+    bool ret = false;
+    int res = -1;
+
+    mbedtls_ctr_drbg_init(&m_ctr_drbg_contex);
+    mbedtls_entropy_init(&m_entropy_context);
+    mbedtls_pk_init(&m_pk_context);
+
+    // Initialize entropy.
+    res = mbedtls_ctr_drbg_seed(
+        &m_ctr_drbg_contex, mbedtls_entropy_func, &m_entropy_context, NULL, 0);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_ctr_drbg_seed failed.");
+        goto exit;
+    }
+
+    // Initialize RSA context.
+    res = mbedtls_pk_setup(
+        &m_pk_context, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA));
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_setup failed (%d).", res);
+        goto exit;
+    }
+
+    // Generate an ephemeral 2048-bit RSA key pair with
+    // exponent 65537 for the enclave.
+    res = mbedtls_rsa_gen_key(
+        mbedtls_pk_rsa(m_pk_context),
+        mbedtls_ctr_drbg_random,
+        &m_ctr_drbg_contex,
+        2048,
+        65537);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_rsa_gen_key failed (%d)\n", res);
+        goto exit;
+    }
+
+    // Write out the public key in PEM format for exchange with other enclaves.
+    res = mbedtls_pk_write_pubkey_pem(
+        &m_pk_context, m_public_key, sizeof(m_public_key));
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_write_pubkey_pem failed (%d)\n", res);
+        goto exit;
+    }
+    ret = true;
+    TRACE_ENCLAVE("mbedtls initialized.");
+exit:
+    return ret;
+}
+
+/**
+ * mbedtls cleanup during shutdown.
+ */
+void Crypto::cleanup_mbedtls(void)
+{
+    mbedtls_pk_free(&m_pk_context);
+    mbedtls_entropy_free(&m_entropy_context);
+    mbedtls_ctr_drbg_free(&m_ctr_drbg_contex);
+
+    TRACE_ENCLAVE("mbedtls cleaned up.");
+}
+
+/**
+ * Get the public key for this enclave.
+ */
+void Crypto::retrieve_public_key(uint8_t pem_public_key[512])
+{
+    memcpy(pem_public_key, m_public_key, sizeof(m_public_key));
+}
+
+// Compute the sha256 hash of given data.
+int Crypto::Sha256(const uint8_t* data, size_t data_size, uint8_t sha256[32])
+{
+    int ret = 0;
+    mbedtls_sha256_context ctx;
+
+    mbedtls_sha256_init(&ctx);
+
+    ret = mbedtls_sha256_starts_ret(&ctx, 0);
+    if (ret)
+        goto exit;
+
+    ret = mbedtls_sha256_update_ret(&ctx, data, data_size);
+    if (ret)
+        goto exit;
+
+    ret = mbedtls_sha256_finish_ret(&ctx, sha256);
+    if (ret)
+        goto exit;
+
+exit:
+    mbedtls_sha256_free(&ctx);
+    return ret;
+}
+
+/**
+ * Encrypt encrypts the given data using the given public key.
+ * Used to encrypt data using the public key of another enclave.
+ */
+bool Crypto::Encrypt(
+    const uint8_t* pem_public_key,
+    const uint8_t* data,
+    size_t data_size,
+    uint8_t* encrypted_data,
+    size_t* encrypted_data_size)
+{
+    bool result = false;
+    mbedtls_pk_context key;
+    size_t key_size = 0;
+    int res = -1;
+    mbedtls_rsa_context* rsa_context;
+
+    mbedtls_pk_init(&key);
+
+    if (!m_initialized)
+        goto exit;
+
+    // Read the given public key.
+    key_size = strlen((const char*)pem_public_key) + 1; // Include ending '\0'.
+    res = mbedtls_pk_parse_public_key(&key, pem_public_key, key_size);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_parse_public_key failed.");
+        goto exit;
+    }
+
+    rsa_context = mbedtls_pk_rsa(key);
+    rsa_context->padding = MBEDTLS_RSA_PKCS_V21;
+    rsa_context->hash_id = MBEDTLS_MD_SHA256;
+
+    if (rsa_context->padding == MBEDTLS_RSA_PKCS_V21)
+    {
+        TRACE_ENCLAVE("Padding used: MBEDTLS_RSA_PKCS_V21 for OAEP or PSS");
+    }
+
+    if (rsa_context->padding == MBEDTLS_RSA_PKCS_V15)
+    {
+        TRACE_ENCLAVE("New MBEDTLS_RSA_PKCS_V15  for 1.5 padding");
+    }
+
+    // Encrypt the data.
+    res = mbedtls_rsa_pkcs1_encrypt(
+        rsa_context,
+        mbedtls_ctr_drbg_random,
+        &m_ctr_drbg_contex,
+        MBEDTLS_RSA_PUBLIC,
+        data_size,
+        data,
+        encrypted_data);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_rsa_pkcs1_encrypt failed with %d\n", res);
+        goto exit;
+    }
+
+    *encrypted_data_size = mbedtls_pk_rsa(key)->len;
+    result = true;
+exit:
+    mbedtls_pk_free(&key);
+    return result;
+}
+
+/**
+ * decrypt the given data using current enclave's private key.
+ * Used to receive encrypted data from another enclave.
+ */
+bool Crypto::decrypt(
+    const uint8_t* encrypted_data,
+    size_t encrypted_data_size,
+    uint8_t* data,
+    size_t* data_size)
+{
+    bool ret = false;
+    size_t output_size = 0;
+    int res = 0;
+    mbedtls_rsa_context* rsa_context;
+
+    if (!m_initialized)
+        goto exit;
+
+    mbedtls_pk_rsa(m_pk_context)->len = encrypted_data_size;
+    rsa_context = mbedtls_pk_rsa(m_pk_context);
+    rsa_context->padding = MBEDTLS_RSA_PKCS_V21;
+    rsa_context->hash_id = MBEDTLS_MD_SHA256;
+
+    output_size = *data_size;
+    res = mbedtls_rsa_pkcs1_decrypt(
+        rsa_context,
+        mbedtls_ctr_drbg_random,
+        &m_ctr_drbg_contex,
+        MBEDTLS_RSA_PRIVATE,
+        &output_size,
+        encrypted_data,
+        data,
+        output_size);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_rsa_pkcs1_decrypt failed with %d\n", res);
+        goto exit;
+    }
+    *data_size = output_size;
+    ret = true;
+
+exit:
+    return ret;
+}
+
+bool Crypto::get_rsa_modulus_from_pem(
+    const char* pem_data,
+    size_t pem_size,
+    uint8_t** modulus,
+    size_t* modulus_size)
+{
+    mbedtls_pk_context ctx;
+    mbedtls_pk_type_t pk_type;
+    mbedtls_rsa_context* rsa_ctx = NULL;
+    uint8_t* modulus_local = NULL;
+    size_t modulus_local_size = 0;
+    int res = 0;
+    bool ret = false;
+
+    if (!m_initialized || !modulus || !modulus_size)
+        goto exit_preinit;
+
+    mbedtls_pk_init(&ctx);
+    res = mbedtls_pk_parse_public_key(
+        &ctx, (const unsigned char*)pem_data, pem_size);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_parse_public_key failed with %d\n", res);
+        goto exit;
+    }
+
+    pk_type = mbedtls_pk_get_type(&ctx);
+    if (pk_type != MBEDTLS_PK_RSA)
+    {
+        TRACE_ENCLAVE("mbedtls_pk_get_type had incorrect type: %d\n", res);
+        goto exit;
+    }
+
+    rsa_ctx = mbedtls_pk_rsa(ctx);
+    modulus_local_size = mbedtls_rsa_get_len(rsa_ctx);
+    modulus_local = (uint8_t*)malloc(modulus_local_size);
+    if (modulus_local == NULL)
+    {
+        TRACE_ENCLAVE(
+            "malloc for modulus failed with size %zu:\n", modulus_local_size);
+        goto exit;
+    }
+
+    res = mbedtls_rsa_export_raw(
+        rsa_ctx,
+        modulus_local,
+        modulus_local_size,
+        NULL,
+        0,
+        NULL,
+        0,
+        NULL,
+        0,
+        NULL,
+        0);
+    if (res != 0)
+    {
+        TRACE_ENCLAVE("mbedtls_rsa_export failed with %d\n", res);
+        goto exit;
+    }
+
+    *modulus = modulus_local;
+    *modulus_size = modulus_local_size;
+    modulus_local = NULL;
+    ret = true;
+
+exit:
+    if (modulus_local != NULL)
+        free(modulus_local);
+
+    mbedtls_pk_free(&ctx);
+
+exit_preinit:
+    return ret;
+}

--- a/samples/tls_between_enclaves/server/enc/crypto.h
+++ b/samples/tls_between_enclaves/server/enc/crypto.h
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef OE_SAMPLES_ATTESTATION_ENC_CRYPTO_H
+#define OE_SAMPLES_ATTESTATION_ENC_CRYPTO_H
+
+#include <openenclave/enclave.h>
+// Includes for mbedtls shipped with oe.
+// Also add the following libraries to your linker command line:
+// -loeenclave -lmbedcrypto -lmbedtls -lmbedx509
+#include <mbedtls/config.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/rsa.h>
+#include <mbedtls/sha256.h>
+#include "log.h"
+
+#define PUBLIC_KEY_SIZE 512
+
+class Crypto
+{
+  private:
+    mbedtls_ctr_drbg_context m_ctr_drbg_contex;
+    mbedtls_entropy_context m_entropy_context;
+    mbedtls_pk_context m_pk_context;
+    uint8_t m_public_key[512];
+    bool m_initialized;
+
+    // Public key of another enclave.
+    uint8_t m_other_enclave_pubkey[PUBLIC_KEY_SIZE];
+
+  public:
+    Crypto();
+    ~Crypto();
+
+    /**
+     * Get this enclave's own public key
+     */
+    void retrieve_public_key(uint8_t pem_public_key[512]);
+
+    /**
+     * Encrypt encrypts the given data using the given public key.
+     * Used to encrypt data using the public key of another enclave.
+     */
+    bool Encrypt(
+        const uint8_t* pem_public_key,
+        const uint8_t* data,
+        size_t size,
+        uint8_t* encrypted_data,
+        size_t* encrypted_data_size);
+
+    /**
+     * decrypt decrypts the given data using current enclave's private key.
+     * Used to receive encrypted data from another enclave.
+     */
+    bool decrypt(
+        const uint8_t* encrypted_data,
+        size_t encrypted_data_size,
+        uint8_t* data,
+        size_t* data_size);
+
+    /**
+     * get_rsa_modulus_from_pem returns the RSA modulus in big endian format
+     * from the public key PEM data. This is needed to verify the MRSIGNER
+     * of the other enclave, which ensures that the other enclave has been
+     * signed by the right key. MRSIGNER is the SHA256 hash of the modulus
+     * in little endian.
+     */
+    bool get_rsa_modulus_from_pem(
+        const char* pem_data,
+        size_t pem_size,
+        uint8_t** modulus,
+        size_t* modulus_size);
+
+    // Public key of another enclave.
+    uint8_t* get_the_other_enclave_public_key()
+    {
+        return m_other_enclave_pubkey;
+    }
+
+    /**
+     * Compute the sha256 hash of given data.
+     */
+    int Sha256(const uint8_t* data, size_t data_size, uint8_t sha256[32]);
+
+  private:
+    /**
+     * Crypto demonstrates use of mbedtls within the enclave to generate keys
+     * and perform encryption. In this sample, each enclave instance generates
+     * an ephemeral 2048-bit RSA key pair and shares the public key with the
+     * other instance. The other enclave instance then replies with data
+     * encrypted to the provided public key.
+     */
+
+    /** init_mbedtls initializes the crypto module.
+     */
+    bool init_mbedtls(void);
+
+    void cleanup_mbedtls(void);
+};
+
+#endif // OE_SAMPLES_ATTESTATION_ENC_CRYPTO_H

--- a/samples/tls_between_enclaves/server/enc/ecalls.cpp
+++ b/samples/tls_between_enclaves/server/enc/ecalls.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <string.h>
+#include <sys/socket.h>
+#include "../../common/tls_server_enc_signing_pubkey.h"
+#include "tls_server_t.h"
+
+typedef struct _enclave_config_data
+{
+    uint8_t* enclave_secret_data;
+    const char* other_enclave_pubkey_pem;
+    size_t other_enclave_pubkey_pem_size;
+} enclave_config_data_t;
+
+// For this purpose of this example: demonstrating how to do remote attestation
+// g_enclave_secret_data is hardcoded as part of the enclave. In this sample,
+// the secret data is hard coded as part of the enclave binary. In a real world
+// enclave implementation, secrets are never hard coded in the enclave binary
+// since the enclave binary itself is not encrypted. Instead, secrets are
+// acquired via provisioning from a service (such as a cloud server) after
+// successful attestation.
+// The g_enclave_secret_data holds the secret data specific to the holding
+// enclave, it's only visible inside this secured enclave. Arbitrary enclave
+// specific secret data exchanged by the enclaves. In this sample, the first
+// enclave sends its g_enclave_secret_data (encrypted) to the second enclave.
+// The second enclave decrypts the received data and adds it to its own
+// g_enclave_secret_data, and sends it back to the other enclave.
+#define ENCLAVE_SECRET_DATA_SIZE 16
+
+uint8_t g_enclave_secret_data[ENCLAVE_SECRET_DATA_SIZE] =
+    {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
+enclave_config_data_t config_data = {g_enclave_secret_data,
+                                     OTHER_ENCLAVE_SIGNING_PUBLIC_KEY,
+                                     sizeof(OTHER_ENCLAVE_SIGNING_PUBLIC_KEY)};
+
+// Declare a static dispatcher object for enabling
+// for better organizing enclave-wise global variables
+// static ecall_dispatcher dispatcher("Enclave1", &config_data);
+const char* enclave_name = "Enclave1";

--- a/samples/tls_between_enclaves/server/enc/enc.conf
+++ b/samples/tls_between_enclaves/server/enc/enc.conf
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Enclave settings:
+Debug=1
+NumHeapPages=1024
+NumStackPages=1024
+NumTCS=2
+ProductID=1
+SecurityVersion=1

--- a/samples/tls_between_enclaves/server/enc/identity_verifier.cpp
+++ b/samples/tls_between_enclaves/server/enc/identity_verifier.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <stdlib.h>
+#include <string>
+#include "../../common/tls_client_enc_signing_pubkey.h"
+#include "../../common/utility.h"
+
+oe_result_t enclave_identity_verifier_callback(
+    oe_identity_t* identity,
+    void* arg)
+{
+    oe_result_t result = OE_VERIFY_FAILED;
+    bool bret = false;
+
+    printf("Server:enclave_identity_verifier_callback is called with enclave "
+           "identity information:\n");
+
+    // the enclave's security version
+    printf("identity->security_version = %d\n", identity->security_version);
+
+    // the unique ID for the enclave, for SGX enclaves, this is the MRENCLAVE
+    // value
+    printf("identity->unique_id(MRENCLAVE) :\n");
+    for (int i = 0; i < OE_UNIQUE_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->unique_id[i]);
+
+    // Check enclave's signer id
+    // for SGX enclaves, this is the MRSIGNER value
+    printf("\nidentity->signer_id(MRSIGNER) :\n");
+    for (int i = 0; i < OE_SIGNER_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->signer_id[i]);
+
+    if (!verify_mrsigner(
+            (char*)OTHER_ENCLAVE_SIGNING_PUBLIC_KEY,
+            sizeof(OTHER_ENCLAVE_SIGNING_PUBLIC_KEY),
+            identity->signer_id,
+            sizeof(identity->signer_id)))
+    {
+        printf("failed:mrsigner not equal!\n");
+        goto exit;
+    }
+    printf("mrsigner id validation passed.\n");
+
+    // The Product ID for the enclave,  for SGX enclaves, this is the ISVPRODID
+    // value
+    printf("\nidentity->product_id :\n");
+    for (int i = 0; i < OE_PRODUCT_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->product_id[i]);
+
+    result = OE_OK;
+
+exit:
+
+    return result;
+}

--- a/samples/tls_between_enclaves/server/enc/log.h
+++ b/samples/tls_between_enclaves/server/enc/log.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef OE_SAMPLES_ATTESTATION_ENC_LOG_H
+#define OE_SAMPLES_ATTESTATION_ENC_LOG_H
+
+#include <stdio.h>
+
+#define TRACE_ENCLAVE(fmt, ...) \
+                                \
+    printf("Enclave: ***%s(%d): " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#endif // OE_SAMPLES_ATTESTATION_ENC_LOG_H

--- a/samples/tls_between_enclaves/server/enc/server.cpp
+++ b/samples/tls_between_enclaves/server/enc/server.cpp
@@ -1,0 +1,365 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <mbedtls/certs.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/debug.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/error.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/platform.h>
+#include <mbedtls/rsa.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/ssl_cache.h>
+#include <mbedtls/x509.h>
+#include <openenclave/enclave.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include "../../common/utility.h"
+
+extern "C"
+{
+    int setup_tls_server_and_run(char* server_port);
+};
+
+// mbedtls debug levels
+// 0 No debug, 1 Error, 2 State change, 3 Informational, 4 Verbose
+#define DEBUG_LEVEL 1
+#define SERVER_IP "0.0.0.0"
+#define MAX_ERROR_BUFF_SIZE 256
+char error_buf[MAX_ERROR_BUFF_SIZE];
+unsigned char buf[1024];
+
+static void your_debug(
+    void* ctx,
+    int level,
+    const char* file,
+    int line,
+    const char* str)
+{
+    ((void)level);
+
+    mbedtls_fprintf((FILE*)ctx, "%s:%04d: %s", file, line, str);
+    fflush((FILE*)ctx);
+}
+
+int configure_server_ssl(
+    mbedtls_ssl_context* ssl,
+    mbedtls_ssl_config* conf,
+    mbedtls_ssl_cache_context* cache,
+    mbedtls_ctr_drbg_context* ctr_drbg,
+    mbedtls_x509_crt* server_cert,
+    mbedtls_pk_context* pkey)
+{
+    int ret = 1;
+    oe_result_t result = OE_FAILURE;
+
+    printf("Generating the certificate\n");
+    result = generate_tls_certificate(server_cert, pkey);
+    if (result != OE_OK)
+    {
+        printf("failed with %s\n", oe_result_str(result));
+        ret = 1;
+        goto exit;
+    }
+
+    printf("\nSetting up the TLS configuration....\n");
+    if ((ret = mbedtls_ssl_config_defaults(
+             conf,
+             MBEDTLS_SSL_IS_SERVER,
+             MBEDTLS_SSL_TRANSPORT_STREAM,
+             MBEDTLS_SSL_PRESET_DEFAULT)) != 0)
+    {
+        printf(
+            "failed\n  ! mbedtls_ssl_config_defaults returned failed %d\n",
+            ret);
+        goto exit;
+    }
+
+    mbedtls_ssl_conf_rng(conf, mbedtls_ctr_drbg_random, ctr_drbg);
+    mbedtls_ssl_conf_dbg(conf, your_debug, stdout);
+    mbedtls_ssl_conf_session_cache(
+        conf, cache, mbedtls_ssl_cache_get, mbedtls_ssl_cache_set);
+
+    // need to set authmode mode to OPTIONAL for requesting client certificate
+    mbedtls_ssl_conf_authmode(conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+    mbedtls_ssl_conf_verify(conf, cert_verify_callback, NULL);
+    mbedtls_ssl_conf_ca_chain(conf, server_cert->next, NULL);
+
+    if ((ret = mbedtls_ssl_conf_own_cert(conf, server_cert, pkey)) != 0)
+    {
+        printf("failed\n  ! mbedtls_ssl_conf_own_cert returned %d\n", ret);
+        goto exit;
+    }
+
+    if ((ret = mbedtls_ssl_setup(ssl, conf)) != 0)
+    {
+        printf("failed\n  ! mbedtls_ssl_setup returned %d\n\n", ret);
+        goto exit;
+    }
+    ret = 0;
+exit:
+    fflush(stdout);
+    return ret;
+}
+
+// This routine was created to demonstrate a simple communication scenario
+// between a TLS client and an TLS server. In a real TLS server app, you
+// definitely will have to do more that just receiving a single message
+// from a client.
+int handle_communication_until_done(
+    mbedtls_ssl_context* ssl,
+    mbedtls_net_context* listen_fd,
+    mbedtls_net_context* client_fd)
+{
+    int ret = 0;
+    int len = 0;
+
+waiting_for_connection_request:
+
+    if (ret != 0)
+    {
+        mbedtls_strerror(ret, error_buf, MAX_ERROR_BUFF_SIZE);
+        printf("Last error was: %d - %s\n", ret, error_buf);
+    }
+
+    // reset ssl setup and client_fd to prepare for the new TLS connection
+    mbedtls_net_free(client_fd);
+    mbedtls_ssl_session_reset(ssl);
+
+    printf("Waiting for a client connection request...\n");
+    if ((ret = mbedtls_net_accept(listen_fd, client_fd, NULL, 0, NULL)) != 0)
+    {
+        char errbuf[512];
+        mbedtls_strerror(ret, errbuf, sizeof(errbuf));
+        printf(" failed\n  ! mbedtls_net_accept returned %d\n\n", ret);
+        printf("%s\n", errbuf);
+        goto done;
+    }
+    printf(
+        "mbedtls_net_accept returned successfully.(listen_fd = %d) (client_fd "
+        "= %d) \n",
+        listen_fd->fd,
+        client_fd->fd);
+
+    // set up bio callbacks
+    mbedtls_ssl_set_bio(
+        ssl, client_fd, mbedtls_net_send, mbedtls_net_recv, NULL);
+
+    printf("Performing the SSL/TLS handshake...\n");
+    while ((ret = mbedtls_ssl_handshake(ssl)) != 0)
+    {
+        if (ret != MBEDTLS_ERR_SSL_WANT_READ &&
+            ret != MBEDTLS_ERR_SSL_WANT_WRITE)
+        {
+            printf(" failed\n  ! mbedtls_ssl_handshake returned -0x%x\n", -ret);
+            goto done;
+        }
+    }
+
+    printf("mbedtls_ssl_handshake done successfully\n");
+
+    // read client's request
+    printf("<---- Read from client:\n");
+    do
+    {
+        len = sizeof(buf) - 1;
+        memset(buf, 0, sizeof(buf));
+        ret = mbedtls_ssl_read(ssl, buf, len);
+
+        if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
+            ret == MBEDTLS_ERR_SSL_WANT_WRITE)
+            continue;
+
+        if (ret <= 0)
+        {
+            switch (ret)
+            {
+                case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY:
+                    printf("connection was closed gracefully\n");
+                    break;
+
+                case MBEDTLS_ERR_NET_CONN_RESET:
+                    printf("connection was reset by peer\n");
+                    break;
+
+                default:
+                    printf("mbedtls_ssl_read returned -0x%x\n", -ret);
+                    break;
+            }
+            break;
+        }
+
+        len = ret;
+        printf(" %d bytes received from client:\n[%s]\n", len, (char*)buf);
+
+#ifdef ADD_TEST_CHECKING
+        if ((len != CLIENT_PAYLOAD_SIZE) ||
+            (memcmp(PAYLOAD_FROM_CLIENT, buf, len) != 0))
+        {
+            printf(
+                "ERROR: expected reading %d bytes but only got %d bytes\n",
+                (int)CLIENT_PAYLOAD_SIZE,
+                len);
+            ret = MBEDTLS_EXIT_FAILURE;
+            goto done;
+        }
+        printf("Verified: the contents of client payload were expected\n\n");
+#endif
+        if (ret > 0)
+            break;
+    } while (1);
+
+    // Write a response back to the client
+    printf("-----> Write to client:\n");
+    len = snprintf((char*)buf, sizeof(buf) - 1, PAYLOAD_FROM_SERVER);
+
+    while ((ret = mbedtls_ssl_write(ssl, buf, len)) <= 0)
+    {
+        if (ret == MBEDTLS_ERR_NET_CONN_RESET)
+        {
+            printf(" failed\n  ! peer closed the connection\n\n");
+            goto waiting_for_connection_request;
+        }
+        if (ret != MBEDTLS_ERR_SSL_WANT_READ &&
+            ret != MBEDTLS_ERR_SSL_WANT_WRITE)
+        {
+            printf(" failed\n  ! mbedtls_ssl_write returned %d\n\n", ret);
+            goto done;
+        }
+    }
+
+    len = ret;
+    printf(" %d bytes written to client\n\n", len);
+    printf("Closing the connection...\n");
+    while ((ret = mbedtls_ssl_close_notify(ssl)) < 0)
+    {
+        if (ret != MBEDTLS_ERR_SSL_WANT_READ &&
+            ret != MBEDTLS_ERR_SSL_WANT_WRITE)
+        {
+            printf("failed! mbedtls_ssl_close_notify returned %d\n\n", ret);
+            goto waiting_for_connection_request;
+        }
+    }
+
+    ret = 0;
+    // comment out the following line if you want the server in a loop
+    // goto waiting_for_connection_request;
+
+done:
+    return ret;
+}
+
+int setup_tls_server_and_run(char* server_port)
+{
+    int ret = 0;
+    oe_result_t result = OE_FAILURE;
+    mbedtls_entropy_context entropy;
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_config conf;
+    mbedtls_x509_crt server_cert;
+    mbedtls_pk_context pkey;
+    mbedtls_ssl_cache_context cache;
+    mbedtls_net_context listen_fd, client_fd;
+    const char* pers = "tls_server";
+
+    // init mbedtls objects
+    mbedtls_net_init(&listen_fd);
+    mbedtls_net_init(&client_fd);
+    mbedtls_ssl_init(&ssl);
+    mbedtls_ssl_config_init(&conf);
+    mbedtls_ssl_cache_init(&cache);
+    mbedtls_x509_crt_init(&server_cert);
+    mbedtls_pk_init(&pkey);
+    mbedtls_entropy_init(&entropy);
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    mbedtls_debug_set_threshold(DEBUG_LEVEL);
+
+    // explicitly load socket and host resolver features
+    if ((result = oe_load_module_host_resolver()) != OE_OK)
+    {
+        printf(
+            "oe_load_module_host_resolver failed with %s\n",
+            oe_result_str(result));
+        goto exit;
+    }
+    if ((result = oe_load_module_host_socket_interface()) != OE_OK)
+    {
+        printf(
+            "oe_load_module_host_socket_interface failed with %s\n",
+            oe_result_str(result));
+        goto exit;
+    }
+
+    // set up server port
+    printf(
+        "Setup the listening TCP socket on SERVER_IP= [%s] server_port = "
+        "[%s]\n",
+        SERVER_IP,
+        server_port);
+    if ((ret = mbedtls_net_bind(
+             &listen_fd, SERVER_IP, server_port, MBEDTLS_NET_PROTO_TCP)) != 0)
+    {
+        printf(" failed\n  ! mbedtls_net_bind returned %d\n", ret);
+        goto exit;
+    }
+
+    printf("mbedtls_net_bind succeeded (listen_fd = %d)\n", listen_fd.fd);
+
+    if ((ret = mbedtls_ctr_drbg_seed(
+             &ctr_drbg,
+             mbedtls_entropy_func,
+             &entropy,
+             (const unsigned char*)pers,
+             strlen(pers))) != 0)
+    {
+        printf(" failed\n  ! mbedtls_ctr_drbg_seed returned %d\n", ret);
+        goto exit;
+    }
+
+    // configure server tls settings
+    ret = configure_server_ssl(
+        &ssl, &conf, &cache, &ctr_drbg, &server_cert, &pkey);
+    if (ret != 0)
+    {
+        printf(" failed\n  ! mbedtls_net_connect returned %d\n", ret);
+        goto exit;
+    }
+
+    // handle communicate and server communication
+    ret = handle_communication_until_done(&ssl, &listen_fd, &client_fd);
+    if (ret != 0)
+    {
+        printf("server communication error %d\n", ret);
+        goto exit;
+    }
+
+exit:
+
+    if (ret != 0)
+    {
+        mbedtls_strerror(ret, error_buf, MAX_ERROR_BUFF_SIZE);
+        printf("Last error was: %d - %s\n\n", ret, error_buf);
+    }
+
+    // free resource
+    mbedtls_net_free(&client_fd);
+    mbedtls_net_free(&listen_fd);
+    mbedtls_x509_crt_free(&server_cert);
+    mbedtls_pk_free(&pkey);
+    mbedtls_ssl_free(&ssl);
+    mbedtls_ssl_config_free(&conf);
+    mbedtls_ssl_cache_free(&cache);
+    mbedtls_ctr_drbg_free(&ctr_drbg);
+    mbedtls_entropy_free(&entropy);
+    return (ret);
+}

--- a/samples/tls_between_enclaves/server/enc/verifier_server.cpp
+++ b/samples/tls_between_enclaves/server/enc/verifier_server.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/enclave.h>
+#include <stdlib.h>
+#include <string>
+#include "../../common/tls_client_enc_pubkey.h"
+#include "../../common/utility.h"
+
+oe_result_t enclave_identity_verifier_callback(
+    oe_identity_t* identity,
+    void* arg)
+{
+    oe_result_t result = OE_VERIFY_FAILED;
+    bool bret = false;
+
+    printf("Server:enclave_identity_verifier_callback is called with enclave "
+           "identity information:\n");
+
+    // the enclave's security version
+    printf("identity->security_version = %d\n", identity->security_version);
+
+    // the unique ID for the enclave, for SGX enclaves, this is the MRENCLAVE
+    // value
+    printf("identity->unique_id(MRENCLAVE) :\n");
+    for (int i = 0; i < OE_UNIQUE_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->unique_id[i]);
+
+    // Check enclave's signer id
+    // for SGX enclaves, this is the MRSIGNER value
+    printf("\nidentity->signer_id(MRSIGNER) :\n");
+    for (int i = 0; i < OE_SIGNER_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->signer_id[i]);
+
+    if (!verify_mrsigner(
+            (char*)OTHER_ENCLAVE_PUBLIC_KEY,
+            sizeof(OTHER_ENCLAVE_PUBLIC_KEY),
+            identity->signer_id,
+            sizeof(identity->signer_id)))
+    {
+        printf("failed:mrsigner not equal!\n");
+        goto exit;
+    }
+    printf("mrsigner id validation passed.\n");
+
+    // The Product ID for the enclave,  for SGX enclaves, this is the ISVPRODID
+    // value
+    printf("\nidentity->product_id :\n");
+    for (int i = 0; i < OE_PRODUCT_ID_SIZE; i++)
+        printf("0x%0x ", (uint8_t)identity->product_id[i]);
+
+    result = OE_OK;
+
+exit:
+
+    return result;
+}

--- a/samples/tls_between_enclaves/server/host/CMakeLists.txt
+++ b/samples/tls_between_enclaves/server/host/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+add_custom_command(OUTPUT tls_server_u.h tls_server_u.c tls_server_args.h
+  DEPENDS ${CMAKE_SOURCE_DIR}/server/tls_server.edl
+  COMMAND openenclave::oeedger8r --untrusted ${CMAKE_SOURCE_DIR}/server/tls_server.edl)
+
+add_executable(tls_server_host host.cpp ${CMAKE_CURRENT_BINARY_DIR}/tls_server_u.c)
+
+target_include_directories(tls_server_host PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(tls_server_host openenclave::oehostapp)

--- a/samples/tls_between_enclaves/server/host/Makefile
+++ b/samples/tls_between_enclaves/server/host/Makefile
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Detect C and C++ compiler options
+# if not gcc and g++, default to clang-7
+C_COMPILER=$(notdir $(CC))
+ifeq ($(C_COMPILER), gcc)
+        CXX_COMPILER=$(notdir $(CXX))
+        USE_GCC = true
+endif
+
+ifeq ($(USE_GCC),)
+        CC = clang-7
+        CXX = clang++-7
+        C_COMPILER=clang
+        CXX_COMPILER=clang++
+endif
+
+CFLAGS=$(shell pkg-config oehost-$(C_COMPILER) --cflags)
+CXXFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --cflags)
+LDFLAGS=$(shell pkg-config oehost-$(CXX_COMPILER) --libs)
+
+all: build
+
+build:
+	@ echo "Compilers used: $(CC), $(CXX)"
+	oeedger8r ../tls_server.edl --untrusted
+	$(CC) -c $(CFLAGS) $(CINCLUDES) tls_server_u.c
+	$(CXX) -c $(CXXFLAGS) $(INCLUDES) host.cpp
+	$(CXX) -o tls_server_host host.o tls_server_u.o $(LDFLAGS)
+
+clean:
+	rm -f tls_server_host *.o tls_server_u.*  tls_server_args.h

--- a/samples/tls_between_enclaves/server/host/host.cpp
+++ b/samples/tls_between_enclaves/server/host/host.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <openenclave/host.h>
+#include <stdio.h>
+#include "tls_server_u.h"
+
+oe_enclave_t* create_enclave(const char* enclave_path)
+{
+    oe_enclave_t* enclave = NULL;
+
+    printf("Host: Enclave library %s\n", enclave_path);
+    oe_result_t result = oe_create_tls_server_enclave(
+        enclave_path,
+        OE_ENCLAVE_TYPE_SGX,
+        OE_ENCLAVE_FLAG_DEBUG,
+        NULL,
+        0,
+        &enclave);
+
+    if (result != OE_OK)
+    {
+        printf(
+            "Host: oe_create_remoteattestation_enclave failed. %s",
+            oe_result_str(result));
+    }
+    else
+    {
+        printf("Host: Enclave successfully created.\n");
+    }
+    return enclave;
+}
+
+void terminate_enclave(oe_enclave_t* enclave)
+{
+    oe_terminate_enclave(enclave);
+    printf("Host: Enclave successfully terminated.\n");
+}
+
+int main(int argc, const char* argv[])
+{
+    oe_enclave_t* enclave = NULL;
+    oe_result_t result = OE_OK;
+    int ret = 1;
+    char* server_port = NULL;
+
+    /* Check argument count */
+    if (argc != 3)
+    {
+    print_usage:
+        printf("Usage: %s TLS_SERVER_ENCLAVE_PATH -port:<port>\n", argv[0]);
+        return 1;
+    }
+
+    // read port parameter
+    {
+        char* option = (char*)"-port:";
+        int param_len = 0;
+        param_len = strlen(option);
+        if (strncmp(argv[2], option, param_len) == 0)
+        {
+            server_port = (char*)(argv[2] + param_len);
+        }
+        else
+        {
+            fprintf(stderr, "Unknown option %s\n", argv[2]);
+            goto print_usage;
+        }
+    }
+    printf("server port = %s\n", server_port);
+
+    printf("Host: Creating an tls client enclave\n");
+    enclave = create_enclave(argv[1]);
+    if (enclave == NULL)
+    {
+        goto exit;
+    }
+
+    printf("Host: calling setup_tls_server_and_run\n");
+    ret = setup_tls_server_and_run(enclave, &ret, server_port);
+    if (ret != 0)
+    {
+        printf("Host: setup_tls_server_and_run failed\n");
+        goto exit;
+    }
+
+exit:
+
+    printf("Host: Terminating enclaves\n");
+    if (enclave)
+        terminate_enclave(enclave);
+
+    printf("Host:  %s \n", (ret == 0) ? "succeeded" : "failed");
+    return ret;
+}

--- a/samples/tls_between_enclaves/server/tls_server.edl
+++ b/samples/tls_between_enclaves/server/tls_server.edl
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+enclave {
+   trusted {
+        public int setup_tls_server_and_run([in, string] char* port);
+
+    };
+};


### PR DESCRIPTION
This is a preview of attested TLS sample. 

To simplify this sample,  it does not include how to provision a secret into an enclave, it embeds a private key (with warning) instead , which is not a secure practice in product code.

// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
// Note: an enclave is not supposed to embed any secrets in an enclave
// image itself, such as the TLS private key below.
// In this sample, we focus on showing how to use oe_verify_attestation_cert
// and oe_generate_attestation_cert APIs to establish an attested TLS channel
// . In the real production app, you want to have a clean enclave without
// and secret to start with and once an enclave is running, provision
// secrets into it after the enclave passese attestation challenges from
// the secret owner.
// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

It's still TBD to decide whether this sample should eventually get into master branch or just check into 
 https://github.com/openenclave/openenclave-extra-samples

For now, I am interested in getting feedback on the rest of the sample
