### PR TITLE
Fix regression in tests/crypto

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,8 @@ if (UNIX OR ADD_WINDOWS_ENCLAVE_TESTS OR USE_CLANGW)
             add_subdirectory(thread_local_no_tdata)
         endif()
         add_subdirectory(bigmalloc)
+        add_subdirectory(crypto)
+        add_subdirectory(crypto_crls_cert_chains)
         add_subdirectory(debug-mode)
         add_subdirectory(echo)
         add_subdirectory(enclaveparam)
@@ -85,8 +87,6 @@ if (OE_SGX AND UNIX)
    # ecall_ocall enclave size cannot be handled by Windows ninja CI
    add_subdirectory(ecall_ocall)
    add_subdirectory(libunwind)
-   add_subdirectory(crypto)
-   add_subdirectory(crypto_crls_cert_chains)
 
    # Attestation supported only on Linux
    add_subdirectory(qeidentity)

--- a/tests/crypto/ec_tests.c
+++ b/tests/crypto/ec_tests.c
@@ -914,19 +914,32 @@ void TestEC()
             "../data/root.ec.cert.pem",
             _CHAIN,
             OE_COUNTOF(_CHAIN)) == OE_OK);
-    OE_TEST(read_key("../data/root.ec.key.pem", _PRIVATE_KEY) == OE_OK);
-    OE_TEST(read_key("../data/root.ec.public.key.pem", _PUBLIC_KEY) == OE_OK);
+    OE_TEST(
+        read_pem_key(
+            "../data/root.ec.key.pem",
+            _PRIVATE_KEY,
+            sizeof(_PRIVATE_KEY),
+            NULL) == OE_OK);
+    OE_TEST(
+        read_pem_key(
+            "../data/root.ec.public.key.pem",
+            _PUBLIC_KEY,
+            sizeof(_PUBLIC_KEY),
+            NULL) == OE_OK);
     OE_TEST(
         read_sign("../data/test_ec_signature", _SIGNATURE, &sign_size) ==
         OE_OK);
     OE_TEST(
         read_pem_key(
-            "../data/root.ec.key.pem", private_key_pem, &private_key_size) ==
-        OE_OK);
+            "../data/root.ec.key.pem",
+            (char*)private_key_pem,
+            sizeof(private_key_pem),
+            &private_key_size) == OE_OK);
     OE_TEST(
         read_pem_key(
             "../data/root.ec.public.key.pem",
-            public_key_pem,
+            (char*)public_key_pem,
+            sizeof(public_key_pem),
             &public_key_size) == OE_OK);
     OE_TEST(
         read_coordinates(

--- a/tests/crypto/read_file.c
+++ b/tests/crypto/read_file.c
@@ -262,7 +262,7 @@ oe_result_t read_sign(char* filename, uint8_t* sign, size_t* sign_size)
     return OE_OK;
 }
 
-static oe_result_t _load_file_without_crls(
+oe_result_t read_pem_key(
     const char* filename,
     char* data,
     size_t data_size,
@@ -312,15 +312,6 @@ done:
         fclose(stream);
 
     return result;
-}
-
-oe_result_t read_pem_key(
-    const char* filename,
-    char* key,
-    size_t key_size,
-    size_t* key_size_out)
-{
-    return _load_file_without_crls(filename, key, key_size, key_size_out);
 }
 
 oe_result_t read_coordinates(

--- a/tests/crypto/read_file.c
+++ b/tests/crypto/read_file.c
@@ -262,41 +262,65 @@ oe_result_t read_sign(char* filename, uint8_t* sign, size_t* sign_size)
     return OE_OK;
 }
 
-oe_result_t read_key(char* filename, char* key)
+static oe_result_t _load_file_without_crls(
+    const char* filename,
+    char* data,
+    size_t data_size,
+    size_t* data_size_out)
 {
-    size_t len_key;
-    FILE* kfp = fopen(filename, "r");
-    if (kfp != NULL)
-    {
-        len_key = fread(key, sizeof(char), max_key_size, kfp);
-    }
-    else
-    {
-        return OE_FAILURE;
-    }
-    key[len_key] = '\0';
+    oe_result_t result = OE_UNEXPECTED;
+    size_t size = 0;
+    FILE* stream = NULL;
+    int c;
 
-    fclose(kfp);
-    return OE_OK;
+    if (!filename || !data)
+    {
+        result = OE_INVALID_PARAMETER;
+        goto done;
+    }
+
+    /* Open file in binary mode. */
+    if (!(stream = fopen(filename, "rb")))
+    {
+        result = OE_FAILURE;
+        goto done;
+    }
+
+    /* Read character-by-character, removing any <CR> characters. */
+    while ((c = fgetc(stream)) != EOF && size < data_size)
+    {
+        if (c != '\r')
+            data[size++] = (char)c;
+    }
+
+    if (size == data_size)
+    {
+        result = OE_BUFFER_TOO_SMALL;
+        goto done;
+    }
+
+    data[size] = '\0';
+
+    if (data_size_out)
+        *data_size_out = size;
+
+    result = OE_OK;
+
+done:
+
+    if (stream)
+        fclose(stream);
+
+    return result;
 }
 
-oe_result_t read_pem_key(char* filename, uint8_t* key, size_t* key_size)
+oe_result_t read_pem_key(
+    const char* filename,
+    char* key,
+    size_t key_size,
+    size_t* key_size_out)
 {
-    size_t len_key;
-    FILE* kfp = fopen(filename, "r");
-    if (kfp != NULL)
-    {
-        len_key = fread(key, sizeof(char), max_key_size, kfp);
-    }
-    else
-    {
-        return OE_FAILURE;
-    }
-    key[len_key] = '\0';
-    *key_size = len_key;
-
-    fclose(kfp);
-    return OE_OK;
+    return _load_file_without_crls(filename, key, key_size, key_size_out);
 }
 
 oe_result_t read_coordinates(

--- a/tests/crypto/readfile.h
+++ b/tests/crypto/readfile.h
@@ -53,9 +53,9 @@ oe_result_t read_sign(char* filename, uint8_t* sign, size_t* sign_size);
 
 oe_result_t read_pem_key(
     const char* filename,
-    char* key,
-    size_t key_size,
-    size_t* key_size_out);
+    char* data,
+    size_t data_size,
+    size_t* data_size_out);
 
 oe_result_t read_coordinates(
     char* filename,

--- a/tests/crypto/readfile.h
+++ b/tests/crypto/readfile.h
@@ -51,9 +51,11 @@ oe_result_t read_mixed_chain(
 
 oe_result_t read_sign(char* filename, uint8_t* sign, size_t* sign_size);
 
-oe_result_t read_key(char* filename, char* key);
-
-oe_result_t read_pem_key(char* filename, uint8_t* key, size_t* key_size);
+oe_result_t read_pem_key(
+    const char* filename,
+    char* key,
+    size_t key_size,
+    size_t* key_size_out);
 
 oe_result_t read_coordinates(
     char* filename,

--- a/tests/crypto/rsa_tests.c
+++ b/tests/crypto/rsa_tests.c
@@ -483,8 +483,16 @@ void TestRSA(void)
             "../data/leaf_modulus.hex",
             _CERT1_RSA_MODULUS,
             &rsa_modulus_size) == OE_OK);
-    OE_TEST(read_key("../data/leaf.key.pem", _PRIVATE_KEY) == OE_OK);
-    OE_TEST(read_key("../data/leaf.public.key.pem", _PUBLIC_KEY) == OE_OK);
+    OE_TEST(
+        read_pem_key(
+            "../data/leaf.key.pem", _PRIVATE_KEY, sizeof(_PRIVATE_KEY), NULL) ==
+        OE_OK);
+    OE_TEST(
+        read_pem_key(
+            "../data/leaf.public.key.pem",
+            _PUBLIC_KEY,
+            sizeof(_PUBLIC_KEY),
+            NULL) == OE_OK);
     OE_TEST(
         read_sign("../data/test_rsa_signature", _SIGNATURE, &sign_size) ==
         OE_OK);


### PR DESCRIPTION
This fixes a regression in **tests/crypto**. The new **openssl** command generates PEM certificates with **CRLF** line endings on Windows. This change modifies **read_pem_key()** so that it discards **CR** characters when reading certificates.