### PR TITLE
Re-enable the crypto tests on Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,8 @@ if (UNIX OR ADD_WINDOWS_ENCLAVE_TESTS OR USE_CLANGW)
         endif()
         add_subdirectory(backtrace)
         add_subdirectory(bigmalloc)
+        add_subdirectory(crypto)
+        add_subdirectory(crypto_crls_cert_chains)
         add_subdirectory(debug-mode)
         add_subdirectory(echo)
         add_subdirectory(enclaveparam)
@@ -85,8 +87,6 @@ if (OE_SGX AND UNIX)
    # ecall_ocall enclave size cannot be handled by Windows ninja CI
    add_subdirectory(ecall_ocall)
    add_subdirectory(libunwind)
-   add_subdirectory(crypto)
-   add_subdirectory(crypto_crls_cert_chains)
 
    # Attestation supported only on Linux
    add_subdirectory(qeidentity)


### PR DESCRIPTION
This change reverts PR https://github.com/microsoft/openenclave/pull/1926 where these tests were temporarily disabled.

The regression was fixed by reverting Git to `2.19.1` in order to have OpenSSL `1.0.2`.

Fixes https://github.com/microsoft/openenclave/issues/1927