### PR TITLE
Address more bug bash issues in VS extension

### DIFF
--- a/new_platforms/nuget/build/native/openenclave.targets
+++ b/new_platforms/nuget/build/native/openenclave.targets
@@ -339,7 +339,7 @@
 
             <!-- Master branch -->
             <AdditionalOptions Condition="$(OEIsSgx) == True And $(OEIsLinux) == True And $(OEIsMaster) == True">-nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id</AdditionalOptions>
-            <LibraryDependencies Condition="$(OEIsMaster) == True">oeenclave;mbedx509;mbedcrypto;oelibcxx;oelibc;oecore;%(LibraryDependencies)</LibraryDependencies>
+	    <AdditionalOptions Condition="$(OEIsMaster) == True">%(AdditionalOptions) -loeenclave /opt/openenclave/lib/openenclave/enclave/libmbedx509.a /opt/openenclave/lib/openenclave/enclave/libmbedcrypto.a -loelibcxx -loelibc -loecore</AdditionalOptions>
         </Link>
     </ItemDefinitionGroup>
 

--- a/new_platforms/nuget/build/native/openenclave.targets
+++ b/new_platforms/nuget/build/native/openenclave.targets
@@ -339,7 +339,7 @@
 
             <!-- Master branch -->
             <AdditionalOptions Condition="$(OEIsSgx) == True And $(OEIsLinux) == True And $(OEIsMaster) == True">-nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id</AdditionalOptions>
-	    <AdditionalOptions Condition="$(OEIsMaster) == True">%(AdditionalOptions) -loeenclave /opt/openenclave/lib/openenclave/enclave/libmbedx509.a /opt/openenclave/lib/openenclave/enclave/libmbedcrypto.a -loelibcxx -loelibc -loecore</AdditionalOptions>
+            <AdditionalOptions Condition="$(OEIsMaster) == True">%(AdditionalOptions) -loeenclave /opt/openenclave/lib/openenclave/enclave/libmbedx509.a /opt/openenclave/lib/openenclave/enclave/libmbedcrypto.a -loelibcxx -loelibc -loecore</AdditionalOptions>
         </Link>
     </ItemDefinitionGroup>
 

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/ecalls.c
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/ecalls.c
@@ -1,9 +1,11 @@
 #include <openenclave/enclave.h>
+#include <stdio.h>
 #include "$projectname$_t.h"
 
 int ecall_DoWorkInEnclave(void)
 {
     /* Implement your ECALL here. */
+    printf("Hello from within ecall_DoWorkInEnclave\n");
     oe_result_t result = ocall_DoWorkInHost();
     return (result != OE_OK);
 }

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/ecalls.c
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/ecalls.c
@@ -1,9 +1,11 @@
 #include <openenclave/enclave.h>
+#include <stdio.h>
 #include "$projectname$_t.h"
 
 int ecall_DoWorkInEnclave(void)
 {
     /* Implement your ECALL here. */
+    printf("Hello from within ecall_DoWorkInEnclave\n");
     oe_result_t result = ocall_DoWorkInHost();
     return (result != OE_OK);
 }

--- a/new_platforms/vsextension/ProjectWizard/source.extension.vsixmanifest
+++ b/new_platforms/vsextension/ProjectWizard/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="OpenEnclaveVisualStudioExtension-1" Version="0.5" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="OpenEnclaveVisualStudioExtension-1" Version="0.6" Language="en-US" Publisher="Microsoft" />
         <DisplayName>Open Enclave Wizard - Preview</DisplayName>
         <Description xml:space="preserve">Support for developing and debugging Trusted Execution Environment enclaves that can run on both SGX and TrustZone, and using them from your own applications.</Description>
         <MoreInfo>https://github.com/Microsoft/openenclave/blob/feature.new_platforms/new_platforms/docs/visualstudio_dev.md</MoreInfo>


### PR DESCRIPTION
- Work around mbedtls library path issue in VS Linux feature, by temporarily hard coding paths to mbedtls libraries for OE
- Add printf to generated sample ecall implementation, to reinforce that it's easy to port host code into an enclave
- Bump VSIX version to 0.6