### PR TITLE
Fix Linux $enclaveguid$ bug in Visual Studio Extension

### DIFF
--- a/new_platforms/vsextension/ItemTemplates/oehost/host.vstemplate
+++ b/new_platforms/vsextension/ItemTemplates/oehost/host.vstemplate
@@ -17,7 +17,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="openenclave" version="0.2.0-CI-20190607-222616" />
+      <package id="openenclave" version="0.2.0-CI-20190617-205644" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/MyEnclave.vcxproj
@@ -272,12 +272,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\openenclave.0.2.0-CI-20190607-222616\build\native\openenclave.targets" Condition="Exists('..\packages\openenclave.0.2.0-CI-20190607-222616\build\native\openenclave.targets')" />
+    <Import Project="..\packages\openenclave.0.2.0-CI-20190617-205644\build\native\openenclave.targets" Condition="Exists('..\packages\openenclave.0.2.0-CI-20190617-205644\build\native\openenclave.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\openenclave.0.2.0-CI-20190607-222616\build\native\openenclave.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\openenclave.0.2.0-CI-20190607-222616\build\native\openenclave.targets'))" />
+    <Error Condition="!Exists('..\packages\openenclave.0.2.0-CI-20190617-205644\build\native\openenclave.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\openenclave.0.2.0-CI-20190617-205644\build\native\openenclave.targets'))" />
   </Target>
 </Project>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/enclave.vstemplate
@@ -31,7 +31,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="openenclave" version="0.2.0-CI-20190607-222616" />
+      <package id="openenclave" version="0.2.0-CI-20190617-205644" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/packages.config
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-linux/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="openenclave" version="0.2.0-CI-20190607-222616" targetFramework="native" />
+  <package id="openenclave" version="0.2.0-CI-20190617-205644" targetFramework="native" />
 </packages>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/enclave.vstemplate
@@ -35,7 +35,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="OpenEnclaveVisualStudioExtension-1">
-      <package id="openenclave" version="0.2.0-CI-20190607-222616" />
+      <package id="openenclave" version="0.2.0-CI-20190617-205644" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/sub.mk
+++ b/new_platforms/vsextension/ProjectTemplates/oeenclave-windows/sub.mk
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-OE_SDK_PATH=../../packages/openenclave.0.2.0-CI-20190607-222616
+OE_SDK_PATH=../../packages/openenclave.0.2.0-CI-20190617-205644
 OE_SDK_INC_PATH=$(OE_SDK_PATH)/build/native/include
 OEEDGER8R=$(OE_SDK_PATH)/tools/oeedger8r
 

--- a/new_platforms/vsextension/ProjectWizard/ImportEnclaveCommand.cs
+++ b/new_platforms/vsextension/ProjectWizard/ImportEnclaveCommand.cs
@@ -361,7 +361,7 @@ namespace OpenEnclaveSDK
                     // Add nuget package to project.
                     // See https://stackoverflow.com/questions/41803738/how-to-programmatically-install-a-nuget-package/41895490#41895490
                     // and more particularly https://docs.microsoft.com/en-us/nuget/visual-studio-extensibility/nuget-api-in-visual-studio
-                    var packageVersions = new Dictionary<string, string>() { { "openenclave", "0.2.0-CI-20190607-222616" } };
+                    var packageVersions = new Dictionary<string, string>() { { "openenclave", "0.2.0-CI-20190617-205644" } };
                     var componentModel = (IComponentModel)(await this.ServiceProvider.GetServiceAsync(typeof(SComponentModel)));
                     var packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
                     packageInstaller.InstallPackagesFromVSExtensionRepository(

--- a/new_platforms/vsextension/ProjectWizard/VS Extension.csproj
+++ b/new_platforms/vsextension/ProjectWizard/VS Extension.csproj
@@ -155,7 +155,7 @@
       <ResourceName>Menus.ctmenu</ResourceName>
       <SubType>Designer</SubType>
     </VSCTCompile>
-    <Content Include="Packages\openenclave.0.2.0-CI-20190607-222616.nupkg">
+    <Content Include="Packages\openenclave.0.2.0-CI-20190617-205644.nupkg">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <None Include="source.extension.vsixmanifest">

--- a/new_platforms/vsextension/ProjectWizard/WizardImplementation.cs
+++ b/new_platforms/vsextension/ProjectWizard/WizardImplementation.cs
@@ -133,7 +133,7 @@ namespace OpenEnclaveSDK
                 // User picked a specific board for which we have binaries in the nuget package.
                 string solutionDirectory;
                 replacementsDictionary.TryGetValue("$solutiondirectory$", out solutionDirectory);
-                oeFolder = Path.Combine(solutionDirectory, "packages\\openenclave.0.2.0-CI-20190607-222616\\lib\\native\\gcc6\\optee\\v3.3.0\\" + board);
+                oeFolder = Path.Combine(solutionDirectory, "packages\\openenclave.0.2.0-CI-20190617-205644\\lib\\native\\gcc6\\optee\\v3.3.0\\" + board);
             }
             else
             {
@@ -214,13 +214,16 @@ namespace OpenEnclaveSDK
                 // Try to get enclave guid from the enclave project.
                 string enclaveguid = "FILL THIS IN";
                 string makFileName = Path.Combine(EdlLocation, "optee", "linux_gcc.mak");
-                foreach (string line in File.ReadLines(makFileName))
+                if (File.Exists(makFileName))
                 {
-                    int index = line.IndexOf("BINARY=");
-                    if (index >= 0)
+                    foreach (string line in File.ReadLines(makFileName))
                     {
-                        enclaveguid = line.Substring(index + 7).Trim();
-                        break;
+                        int index = line.IndexOf("BINARY=");
+                        if (index >= 0)
+                        {
+                            enclaveguid = line.Substring(index + 7).Trim();
+                            break;
+                        }
                     }
                 }
                 replacementsDictionary.Add("$enclaveguid$", enclaveguid);
@@ -229,7 +232,6 @@ namespace OpenEnclaveSDK
             }
             catch (Exception)
             {
-
             }
             return false;
         }

--- a/new_platforms/vsextension/ProjectWizard/source.extension.vsixmanifest
+++ b/new_platforms/vsextension/ProjectWizard/source.extension.vsixmanifest
@@ -16,7 +16,7 @@
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveWindowsProject.zip" />
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\Built\OEEnclaveLinuxProject.zip" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
-        <Asset Type="openenclave.0.2.0-CI-20190607-222616.nupkg" d:Source="File" Path="Packages\openenclave.0.2.0-CI-20190607-222616.nupkg" d:VsixSubPath="Packages" />
+        <Asset Type="openenclave.0.2.0-CI-20190617-205644.nupkg" d:Source="File" Path="Packages\openenclave.0.2.0-CI-20190617-205644.nupkg" d:VsixSubPath="Packages" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="ItemTemplates\Built\OEHostItem.zip" />
     </Assets>


### PR DESCRIPTION
Linux optee files were temporarily removed but the extension didn't
account for them being missing and left $enclaveguid$ in the source.
This change checks for their presence and correctly replaces with "FILL
THIS IN" when not present.

Also reference latest nuget package fixes

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>